### PR TITLE
FIX: Freezed time used in update_holiday_usernames_spec.rb should be UTC

### DIFF
--- a/spec/jobs/update_holiday_usernames_spec.rb
+++ b/spec/jobs/update_holiday_usernames_spec.rb
@@ -17,12 +17,12 @@ describe DiscourseCalendar::UpdateHolidayUsernames do
     post = create_post(raw: raw, topic: @op.topic)
     CookedPostProcessor.new(post).post_process
 
-    freeze_time Time.new(2018, 6, 5, 18, 40)
+    freeze_time Time.utc(2018, 6, 5, 18, 40)
     DiscourseCalendar::UpdateHolidayUsernames.new.execute(nil)
 
     expect(DiscourseCalendar.users_on_holiday).to eq([post.user.username])
 
-    freeze_time Time.new(2018, 6, 7, 18, 40)
+    freeze_time Time.utc(2018, 6, 7, 18, 40)
     DiscourseCalendar::UpdateHolidayUsernames.new.execute(nil)
 
     expect(DiscourseCalendar.users_on_holiday).to eq([])


### PR DESCRIPTION
I was curious why this spec was failing on my local machine.

The reason for that was `from_date` of the post which in this spec was `2018-06-05 10:20:00 UTC`

Because I am in Australia timezone, `freeze_time Time.new(2018, 6, 5, 18, 40)` was giving me `2018-06-05 08:40:00 UTC` which was before `from_date`. 

I think that bug was introduced here: https://github.com/discourse/discourse-calendar/commit/b1fe4456d083be89188bcd57d3f4247a971637f5#diff-b1651fed94990b46f84a76daf7330e2dL17
