### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/jobs/scheduled/check_next_regional_holidays.rb
+++ b/jobs/scheduled/check_next_regional_holidays.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ::DiscourseCalendar::CheckNextRegionalHolidays < Jobs::Scheduled
+  class ::DiscourseCalendar::CheckNextRegionalHolidays < ::Jobs::Scheduled
     every 10.minutes
 
     def execute(args)

--- a/jobs/scheduled/ensure_consistency.rb
+++ b/jobs/scheduled/ensure_consistency.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ::DiscourseCalendar::EnsureConsistency < Jobs::Scheduled
+  class ::DiscourseCalendar::EnsureConsistency < ::Jobs::Scheduled
     every 12.hours
 
     PLUGIN_NAME ||= "calendar"

--- a/jobs/scheduled/ensure_expired_event_destruction.rb
+++ b/jobs/scheduled/ensure_expired_event_destruction.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ::DiscourseCalendar::EnsuredExpiredEventDestruction < Jobs::Scheduled
+  class ::DiscourseCalendar::EnsuredExpiredEventDestruction < ::Jobs::Scheduled
     every 10.minutes
 
     def execute(args)

--- a/jobs/scheduled/update_holiday_usernames.rb
+++ b/jobs/scheduled/update_holiday_usernames.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ::DiscourseCalendar::UpdateHolidayUsernames < Jobs::Scheduled
+  class ::DiscourseCalendar::UpdateHolidayUsernames < ::Jobs::Scheduled
     every 10.minutes
 
     PLUGIN_NAME ||= "calendar".freeze


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff, Jobs::Base and Jobs::Scheduled without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364