### PR TITLE
FEATURE: Auto-trash direct replies for post with event that is trashed

### DIFF
--- a/jobs/scheduled/ensure_expired_event_destruction.rb
+++ b/jobs/scheduled/ensure_expired_event_destruction.rb
@@ -37,8 +37,6 @@ module Jobs
           next if (to_time + delay.hour) > Time.zone.now
 
           if post = pcf.post.topic.posts.find_by(post_number: post_number)
-            destroy_post(post)
-
             post.post_replies.each do |post_reply|
               # we do not want to destroy any direct replies with dates
               # (they will get destroyed automatically when their time comes)
@@ -46,6 +44,8 @@ module Jobs
               next if post_numbers_with_dates.include?(reply_post.post_number)
               destroy_post(reply_post)
             end
+
+            destroy_post(post)
           end
         end
       end

--- a/jobs/scheduled/ensure_expired_event_destruction.rb
+++ b/jobs/scheduled/ensure_expired_event_destruction.rb
@@ -42,8 +42,9 @@ module Jobs
             post.post_replies.each do |post_reply|
               # we do not want to destroy any direct replies with dates
               # (they will get destroyed automatically when their time comes)
-              next if post_numbers_with_dates.include?(post_reply.reply_id)
-              destroy_post(post_reply.post)
+              reply_post = post_reply.reply
+              next if post_numbers_with_dates.include?(reply_post.post_number)
+              destroy_post(reply_post)
             end
           end
         end

--- a/spec/jobs/ensure_expired_event_destruction_spec.rb
+++ b/spec/jobs/ensure_expired_event_destruction_spec.rb
@@ -31,6 +31,38 @@ describe DiscourseCalendar::EnsuredExpiredEventDestruction do
     expect(@op.calendar_details[@post.post_number.to_s]).to be_nil
   end
 
+  it "will correctly destroy the post" do
+    freeze_time Time.strptime("2018-06-06 13:21:00 UTC", "%Y-%m-%d %H:%M:%S %Z")
+    DiscourseCalendar::EnsuredExpiredEventDestruction.new.execute(nil)
+    expect(Post.find_by(id: @post.id)).to eq(nil)
+  end
+
+  context "when the post has direct replies" do
+    let!(:direct_reply_without_event) do
+      raw = 'Boy that sure sounds like fun, I wish I was going on vacation as well!'
+      reply = create_post(raw: raw, topic: @op.topic, reply_to_post_number: @post.post_number)
+      PostReply.create(post: @post, reply: reply)
+    end
+    let!(:direct_reply_with_event) do
+      raw = 'Rome [date="2018-06-07" time="10:20:00"] to [date="2018-06-08" time="11:20:00"]'
+      reply = create_post(raw: raw, topic: @op.topic, reply_to_post_number: @post.post_number)
+      PostReply.create(post: @post, reply: reply)
+    end
+
+    before do
+      freeze_time Time.strptime("2018-06-06 13:21:00 UTC", "%Y-%m-%d %H:%M:%S %Z")
+      DiscourseCalendar::EnsuredExpiredEventDestruction.new.execute(nil)
+    end
+
+    it "destroys replies without events (small talk)" do
+      expect(Post.find_by(id: direct_reply_without_event.id)).to eq(nil)
+    end
+
+    it "does not destroy replies with events" do
+      expect(Post.find_by(id: direct_reply_with_event.id)).to eq(nil)
+    end
+  end
+
   it "wont destroy recurring events" do
     freeze_time Time.strptime("2018-06-03 09:21:00 UTC", "%Y-%m-%d %H:%M:%S %Z")
 


### PR DESCRIPTION
* When the post with the event gets auto-trashed after the event has passed
* BUT do not trash posts that are direct replies IF they have their own events