### PR TITLE
FEATURE: Improve timezone logic for all-day events

### DIFF
--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -79,7 +79,7 @@ function initializeDiscourseCalendar(api) {
     return new window.FullCalendar.Calendar($calendar[0], {
       timeZone: moment.tz.guess(),
       timeZoneImpl: "moment-timezone",
-      nextDayThreshold: "23:59:59",
+      nextDayThreshold: "06:00:00",
       displayEventEnd: true,
       height: 650,
       firstDay: 1,

--- a/jobs/scheduled/check_next_regional_holidays.rb
+++ b/jobs/scheduled/check_next_regional_holidays.rb
@@ -46,6 +46,7 @@ module Jobs
       business_days = 1..5
       load_until = 6.months.from_now
       today = Date.today
+      holiday_hour = ::DiscourseCalendar::BEGINNING_OF_DAY_HOUR
 
       users_in_region.keys.sort.each do |region|
         holidays = Holidays.between(today, load_until, [region]).filter do |h|
@@ -55,7 +56,8 @@ module Jobs
         holidays.each do |next_holiday|
           users_in_region[region].each do |user_id|
             date = if tz = user_timezones[user_id]
-              next_holiday[:date].in_time_zone(tz).iso8601
+              datetime = next_holiday[:date].in_time_zone(tz).change(hour: holiday_hour)
+              datetime.iso8601
             else
               next_holiday[:date].to_s
             end

--- a/lib/event_updater.rb
+++ b/lib/event_updater.rb
@@ -13,11 +13,11 @@ module DiscourseCalendar
       end
 
       from = self.convert_to_date_time(dates[0])
-      from = from.beginning_of_day unless dates[0]['time']
+      from = from.change(hour: DiscourseCalendar::BEGINNING_OF_DAY_HOUR) unless dates[0]['time']
 
       if dates.count == 2
         to = self.convert_to_date_time(dates[1])
-        to = to.end_of_day unless dates[1]['time']
+        to = to.change(hour: DiscourseCalendar::END_OF_DAY_HOUR) unless dates[1]['time']
       end
 
       html = post.cooked

--- a/plugin.rb
+++ b/plugin.rb
@@ -50,6 +50,9 @@ after_initialize do
 
     USER_OPTIONS_TIMEZONE_ENABLED = UserOption.column_names.include?('timezone')
 
+    BEGINNING_OF_DAY_HOUR = 6
+    END_OF_DAY_HOUR = 18
+
     def self.users_on_holiday
       PluginStore.get(PLUGIN_NAME, USERS_ON_HOLIDAY_KEY)
     end

--- a/spec/jobs/check_next_regional_holidays_spec.rb
+++ b/spec/jobs/check_next_regional_holidays_spec.rb
@@ -70,7 +70,7 @@ describe DiscourseCalendar::CheckNextRegionalHolidays do
       @op.reload
 
       expect(@op.calendar_holidays[0]).to eq(
-        ["fr", "Assomption", "2019-08-15T00:00:00+02:00", frenchy.username]
+        ["fr", "Assomption", "2019-08-15T06:00:00+02:00", frenchy.username]
       )
     end
   end
@@ -94,7 +94,7 @@ describe DiscourseCalendar::CheckNextRegionalHolidays do
       @op.reload
 
       expect(@op.calendar_holidays[0]).to eq(
-        ["fr", "Assomption", "2019-08-15T00:00:00+02:00", frenchy.username]
+        ["fr", "Assomption", "2019-08-15T06:00:00+02:00", frenchy.username]
       )
     end
   end

--- a/spec/lib/dynamic_calendar_spec.rb
+++ b/spec/lib/dynamic_calendar_spec.rb
@@ -21,7 +21,7 @@ describe "Dynamic calendar" do
 
     op.reload
     expect(op.calendar_details[p.post_number.to_s]).to eq([
-      "Rome", "2018-06-05T00:00:00+02:00", nil, p.user.username, nil
+      "Rome", "2018-06-05T06:00:00+02:00", nil, p.user.username, nil
     ])
   end
 
@@ -39,7 +39,7 @@ describe "Dynamic calendar" do
 
     op.reload
     expect(op.calendar_details[p.post_number.to_s]).to eq([
-      "Rome", "2018-06-05T00:00:00+02:00", "2018-06-08T23:59:59+02:00", p.user.username, nil
+      "Rome", "2018-06-05T06:00:00+02:00", "2018-06-08T18:00:00+02:00", p.user.username, nil
     ])
   end
 

--- a/spec/lib/event_updater_spec.rb
+++ b/spec/lib/event_updater_spec.rb
@@ -53,8 +53,8 @@ describe DiscourseCalendar::EventUpdater do
     op.reload
 
     _, from, to = op.calendar_details[post.post_number.to_s]
-    expect(from).to eq("2018-06-05T00:00:00Z")
-    expect(to).to eq("2018-06-11T23:59:59Z")
+    expect(from).to eq("2018-06-05T06:00:00Z")
+    expect(to).to eq("2018-06-11T18:00:00Z")
   end
 
   it "will work with timezone" do
@@ -67,7 +67,7 @@ describe DiscourseCalendar::EventUpdater do
     op.reload
 
     _, from, to = op.calendar_details[post.post_number.to_s]
-    expect(from).to eq("2018-06-05T00:00:00+02:00")
+    expect(from).to eq("2018-06-05T06:00:00+02:00")
     expect(to).to eq("2018-06-11T13:45:33-07:00")
   end
 


### PR DESCRIPTION
- Render all-day events from 6am to 6pm local time, so that they appear more logically for users in other timezones
- Set the `nextDayThreshold` to 6am, so that multi-day events in slightly more easterly timezones display the end date correctly

As an example, imagine @ZogStriP has entered an event from 23rd - 27th December, and Christmas is on the 25th. I am in GMT, and Regis is GMT+1. To me, his events look like this, which is very confusing:

<img width="743" alt="Screenshot 2019-12-16 at 12 50 50" src="https://user-images.githubusercontent.com/6270921/70908347-e3144000-2002-11ea-84b4-7d495e8560bf.png">

Following this PR, they will look like this:

<img width="758" alt="Screenshot 2019-12-16 at 12 51 28" src="https://user-images.githubusercontent.com/6270921/70908431-0b03a380-2003-11ea-81a7-bbcedf439eff.png">

6am-6pm are not necessarily the working hours of everyone, but I think they are a better approximation than 12am - 12pm.