### PR TITLE
FEATURE: Add timezone picker and options

### DIFF
--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -313,6 +313,10 @@ function initializeDiscourseCalendar(api) {
     let defaultTimezone = null;
     if ($timezonePicker.length) {
       defaultTimezone = $timezonePicker.attr("data-default-timezone");
+      const isValidDefaultTimezone = !!moment.tz.zone(defaultTimezone);
+      if (!isValidDefaultTimezone) {
+        defaultTimezone = null;
+      }
     }
     const currentUserTimezone = currentUser ? currentUser.timezone : null;
     return defaultTimezone || currentUserTimezone || moment.tz.guess();

--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -46,8 +46,8 @@ function initializeDiscourseCalendar(api) {
   function render($calendar, post) {
     $calendar = $calendar.empty();
 
-    const timeZone = _getTimeZone($calendar, api.getCurrentUser());
-    const calendar = _buildCalendar($calendar, timeZone);
+    const timezone = _getTimeZone($calendar, api.getCurrentUser());
+    const calendar = _buildCalendar($calendar, timezone);
     const isStatic = $calendar.attr("data-calendar-type") === "static";
 
     if (isStatic) {
@@ -59,7 +59,7 @@ function initializeDiscourseCalendar(api) {
       _setDynamicCalendarOptions(calendar, $calendar);
     }
 
-    _setupTimezonePicker(calendar, timeZone);
+    _setupTimezonePicker(calendar, timezone);
   }
 
   function attachCalendar($elem, helper) {
@@ -75,7 +75,7 @@ function initializeDiscourseCalendar(api) {
   }
 
   function _buildCalendar($calendar, timeZone) {
-    let $calendarTitle = $(
+    let $calendarTitle = document.querySelector(
       ".discourse-calendar-header > .discourse-calendar-title"
     );
     const defaultView = escapeExpression(
@@ -83,7 +83,7 @@ function initializeDiscourseCalendar(api) {
     );
 
     return new window.FullCalendar.Calendar($calendar[0], {
-      timeZone: timeZone,
+      timeZone,
       timeZoneImpl: "moment-timezone",
       nextDayThreshold: "06:00:00",
       displayEventEnd: true,
@@ -108,9 +108,7 @@ function initializeDiscourseCalendar(api) {
         center: "title",
         right: "month,basicWeek,listNextYear"
       },
-      datesRender: info => {
-        $calendarTitle.text(info.view.title);
-      }
+      datesRender: info => ($calendarTitle.innerText = info.view.title)
     });
   }
 
@@ -315,25 +313,28 @@ function initializeDiscourseCalendar(api) {
       defaultTimezone = null;
     }
 
-    const currentUserTimezone = currentUser ? currentUser.timezone : null;
-    return defaultTimezone || currentUserTimezone || moment.tz.guess();
+    return (
+      defaultTimezone ||
+      (currentUser && currentUser.timezone) ||
+      moment.tz.guess()
+    );
   }
 
-  function _setupTimezonePicker(calendar, timeZone) {
+  function _setupTimezonePicker(calendar, timezone) {
     let $timezonePicker = $(".discourse-calendar-timezone-picker");
 
     if ($timezonePicker.length) {
-      $timezonePicker.on("change", function(e) {
-        calendar.setOption("timeZone", $(this).val());
+      $timezonePicker.on("change", function(event) {
+        calendar.setOption("timeZone", event.target.value);
       });
 
       moment.tz.names().forEach(timezone => {
         $timezonePicker.append(new Option(timezone, timezone));
       });
 
-      $timezonePicker.val(timeZone);
+      $timezonePicker.val(timezone);
     } else {
-      $(".discourse-calendar-timezone-wrap").text(`${timeZone}`);
+      $(".discourse-calendar-timezone-wrap").text(timezone);
     }
   }
 }

--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -46,7 +46,7 @@ function initializeDiscourseCalendar(api) {
   function render($calendar, post) {
     $calendar = $calendar.empty();
 
-    const timeZone = _getTimeZone(api.getCurrentUser());
+    const timeZone = _getTimeZone($calendar, api.getCurrentUser());
     const calendar = _buildCalendar($calendar, timeZone);
     const isStatic = $calendar.attr("data-calendar-type") === "static";
 
@@ -308,16 +308,13 @@ function initializeDiscourseCalendar(api) {
     });
   }
 
-  function _getTimeZone(currentUser) {
-    let $timezonePicker = $(".discourse-calendar-timezone-picker");
-    let defaultTimezone = null;
-    if ($timezonePicker.length) {
-      defaultTimezone = $timezonePicker.attr("data-default-timezone");
-      const isValidDefaultTimezone = !!moment.tz.zone(defaultTimezone);
-      if (!isValidDefaultTimezone) {
-        defaultTimezone = null;
-      }
+  function _getTimeZone($calendar, currentUser) {
+    let defaultTimezone = $calendar.attr("data-calendar-default-timezone");
+    const isValidDefaultTimezone = !!moment.tz.zone(defaultTimezone);
+    if (!isValidDefaultTimezone) {
+      defaultTimezone = null;
     }
+
     const currentUserTimezone = currentUser ? currentUser.timezone : null;
     return defaultTimezone || currentUserTimezone || moment.tz.guess();
   }
@@ -335,6 +332,8 @@ function initializeDiscourseCalendar(api) {
       });
 
       $timezonePicker.val(timeZone);
+    } else {
+      $(".discourse-calendar-timezone-wrap").text(`${timeZone}`);
     }
   }
 }

--- a/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
@@ -13,9 +13,14 @@ const calendarRule = {
     titleH2Token.attrs = [["class", "discourse-calendar-title"]];
     state.push("h2_close", "h2", -1);
 
+    let timezoneWrapToken = state.push("span_open", "span", 1);
+    timezoneWrapToken.attrs = [
+      ["class", "discourse-calendar-timezone-wrap"]
+    ]
     if (info.attrs.tzpicker === "true") {
       _renderTimezonePicker(state, info);
     }
+    state.push("span_close", "span", -1);
 
     state.push("div_close", "div", -1);
     // end div.discourse-calendar-header
@@ -25,7 +30,8 @@ const calendarRule = {
     mainCalendarDivToken.attrs = [
       ["class", "calendar"],
       ["data-calendar-type", info.attrs.type || "dynamic"],
-      ["data-calendar-default-view", info.attrs.defaultView || "month"]
+      ["data-calendar-default-view", info.attrs.defaultView || "month"],
+      ["data-calendar-default-timezone", info.attrs.tzdefault]
     ];
 
     if (info.attrs.weekends) {
@@ -52,8 +58,7 @@ const calendarRule = {
 function _renderTimezonePicker(state, info) {
   let timezoneSelectToken = state.push("select_open", "select", 1);
   timezoneSelectToken.attrs = [
-    ["class", "discourse-calendar-timezone-picker"],
-    ["data-default-timezone", info.attrs.tzdefault]
+    ["class", "discourse-calendar-timezone-picker"]
   ];
 
   state.push("select_close", "select", -1);
@@ -65,11 +70,12 @@ export function setup(helper) {
     "div.discourse-calendar-header",
     "div.discourse-calendar-wrap",
     "select.discourse-calendar-timezone-picker",
-    "select[data-default-timezone]",
+    "span.discourse-calendar-timezone-wrap",
     "h2.discourse-calendar-title",
     "option",
     "div[data-calendar-type]",
     "div[data-calendar-default-view]",
+    "div[data-calendar-default-timezone]",
     "div[data-weekends]",
     "div[data-hidden-days]"
   ]);

--- a/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
@@ -2,11 +2,10 @@ const calendarRule = {
   tag: "calendar",
 
   before: function(state, info) {
-    let wrapperDivToken = state.push("div_open", "div", 1);
+    let wrapperDivToken = state.push("div_calendar_wrap", "div", 1);
     wrapperDivToken.attrs = [["class", "discourse-calendar-wrap"]];
 
-    // div.discourse-calendar-header
-    let headerDivToken = state.push("div_open", "div", 1);
+    let headerDivToken = state.push("div_calendar_header", "div", 1);
     headerDivToken.attrs = [["class", "discourse-calendar-header"]];
 
     let titleH2Token = state.push("h2_open", "h2", 1);
@@ -17,21 +16,19 @@ const calendarRule = {
     timezoneWrapToken.attrs = [
       ["class", "discourse-calendar-timezone-wrap"]
     ]
-    if (info.attrs.tzpicker === "true") {
+    if (info.attrs.tzPicker === "true") {
       _renderTimezonePicker(state, info);
     }
     state.push("span_close", "span", -1);
 
-    state.push("div_close", "div", -1);
-    // end div.discourse-calendar-header
+    state.push("div_calendar_header", "div", -1);
 
-    // div.calendar
-    let mainCalendarDivToken = state.push("div_open", "div", 1);
+    let mainCalendarDivToken = state.push("div_calendar", "div", 1);
     mainCalendarDivToken.attrs = [
       ["class", "calendar"],
       ["data-calendar-type", info.attrs.type || "dynamic"],
       ["data-calendar-default-view", info.attrs.defaultView || "month"],
-      ["data-calendar-default-timezone", info.attrs.tzdefault]
+      ["data-calendar-default-timezone", info.attrs.defaultTimezone]
     ];
 
     if (info.attrs.weekends) {
@@ -47,11 +44,8 @@ const calendarRule = {
   },
 
   after: function(state) {
-    state.push("div_close", "div", -1);
-    // end div.calendar
-
-    state.push("div_close", "div", -1);
-    // end div.discourse-calendar-wrap
+    state.push("div_calendar", "div", -1);
+    state.push("div_calendar_wrap", "div", -1);
   }
 };
 
@@ -72,7 +66,6 @@ export function setup(helper) {
     "select.discourse-calendar-timezone-picker",
     "span.discourse-calendar-timezone-wrap",
     "h2.discourse-calendar-title",
-    "option",
     "div[data-calendar-type]",
     "div[data-calendar-default-view]",
     "div[data-calendar-default-timezone]",

--- a/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
@@ -1,28 +1,73 @@
 const calendarRule = {
   tag: "calendar",
 
-  wrap(token, info) {
-    token.attrs = [
+  before: function(state, info) {
+    let wrapperDivToken = state.push("div_open", "div", 1);
+    wrapperDivToken.attrs = [["class", "discourse-calendar-wrap"]];
+
+    // div.discourse-calendar-header
+    let headerDivToken = state.push("div_open", "div", 1);
+    headerDivToken.attrs = [["class", "discourse-calendar-header"]];
+
+    let titleH2Token = state.push("h2_open", "h2", 1);
+    titleH2Token.attrs = [["class", "discourse-calendar-title"]];
+    state.push("h2_close", "h2", -1);
+
+    if (info.attrs.tzpicker === "true") {
+      _renderTimezonePicker(state, info);
+    }
+
+    state.push("div_close", "div", -1);
+    // end div.discourse-calendar-header
+
+    // div.calendar
+    let mainCalendarDivToken = state.push("div_open", "div", 1);
+    mainCalendarDivToken.attrs = [
       ["class", "calendar"],
       ["data-calendar-type", info.attrs.type || "dynamic"],
       ["data-calendar-default-view", info.attrs.defaultView || "month"]
     ];
 
     if (info.attrs.weekends) {
-      token.attrs.push(["data-weekends", info.attrs.weekends]);
+      mainCalendarDivToken.attrs.push(["data-weekends", info.attrs.weekends]);
     }
 
     if (info.attrs.hiddenDays) {
-      token.attrs.push(["data-hidden-days", info.attrs.hiddenDays]);
+      mainCalendarDivToken.attrs.push([
+        "data-hidden-days",
+        info.attrs.hiddenDays
+      ]);
     }
+  },
 
-    return true;
+  after: function(state) {
+    state.push("div_close", "div", -1);
+    // end div.calendar
+
+    state.push("div_close", "div", -1);
+    // end div.discourse-calendar-wrap
   }
 };
+
+function _renderTimezonePicker(state, info) {
+  let timezoneSelectToken = state.push("select_open", "select", 1);
+  timezoneSelectToken.attrs = [
+    ["class", "discourse-calendar-timezone-picker"],
+    ["data-default-timezone", info.attrs.tzdefault]
+  ];
+
+  state.push("select_close", "select", -1);
+}
 
 export function setup(helper) {
   helper.whiteList([
     "div.calendar",
+    "div.discourse-calendar-header",
+    "div.discourse-calendar-wrap",
+    "select.discourse-calendar-timezone-picker",
+    "select[data-default-timezone]",
+    "h2.discourse-calendar-title",
+    "option",
     "div[data-calendar-type]",
     "div[data-calendar-default-view]",
     "div[data-weekends]",

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -1,5 +1,6 @@
 .calendar {
   height: 690px; // Must be fixed to prevent height change on load
+  padding: 0 10px;
 
   &.fc-unthemed {
     tbody,
@@ -33,6 +34,10 @@
 
     .fc-widget-header span {
       padding: 3px 3px 3px 0.5em;
+    }
+
+    .fc-center {
+      visibility: hidden;
     }
 
     .fc-button {
@@ -105,4 +110,32 @@ a.holiday {
 
 .combo-box.user-timezone {
   min-width: 15em;
+}
+
+.discourse-calendar-header {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  padding: 0.5em;
+  border-bottom: 1px solid $primary-low;
+  background: $primary-very-low;
+
+  .discourse-calendar-timezone-picker {
+    margin-bottom: 0;
+  }
+
+  .discourse-calendar-title {
+    margin-top: 10px;
+  }
+  
+  .title {
+    font-weight: 700;
+    text-transform: capitalize;
+  }
+}
+
+.discourse-calendar-wrap {
+  border: 1px solid $primary-low;
 }

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -1,6 +1,6 @@
 .calendar {
-  height: 690px; // Must be fixed to prevent height change on load
-  padding: 0 10px;
+  height: 645px; // Must be fixed to prevent height change on load
+  padding: 0 0.5em;
 
   &.fc-unthemed {
     tbody,
@@ -37,7 +37,7 @@
     }
 
     .fc-center {
-      visibility: hidden;
+      display: none;
     }
 
     .fc-button {
@@ -127,7 +127,7 @@ a.holiday {
   }
 
   .discourse-calendar-title {
-    margin-top: 10px;
+    margin-top: 0.5em;
   }
   
   .title {


### PR DESCRIPTION
Added these options for the markdown block, which utilise fullcalendar's inbuilt timezone functionality:

* `defaultTimezone` - Provide a default timezone to display the calendar dates in. If this is null we fall back to the current user timezone, and if that is null (or the current user is null) we fall back to moment.tz.guess(). This value is validated.
* `tzPicker` - If set to true, show a dropdown list allowing the user to pick the timezone the calendar displays in. The selected value is based on the rules described in tzdefault. If this is not turned on we show the text of the timezone in the header. The options for the picker come from moment.tz.names() and are rendered into the select at runtime, so we are not storing huge amounts of <option> HTML elements in the DB for no real reason.

I also hid the fullcalendar title because the title is now up in the header of the calendar.

With the picker enabled:

![image](https://user-images.githubusercontent.com/920448/71223444-c0926780-231f-11ea-9782-d27655141352.png)

Without the picker enabled:

![image](https://user-images.githubusercontent.com/920448/71224669-cc7f2900-2321-11ea-8a73-c74ab1f9bf63.png)
