### PR TITLE
FIX: error breaking other users preference profiles

### DIFF
--- a/assets/javascripts/connectors/user-custom-preferences/user-timezone.js.es6
+++ b/assets/javascripts/connectors/user-custom-preferences/user-timezone.js.es6
@@ -2,9 +2,9 @@ export default {
   setupComponent(args, component) {
     const { currentUser } = component;
     const user = args.model;
-    const userOptionsTimezoneEnabled = currentUser.user_option.hasOwnProperty(
-      "timezone"
-    );
+    const userOptionsTimezoneEnabled = user.user_option
+      ? user.user_option.hasOwnProperty("timezone")
+      : false;
 
     let instructions;
 


### PR DESCRIPTION
If calendar is enabled on a site, the user -> preferences -> profile view breaks. This fixes that.

![Screenshot from 2020-01-22 12-12-18](https://user-images.githubusercontent.com/16214023/72921696-5fd8bf00-3d11-11ea-9a8f-aca775b833f2.png)
