### PR TITLE
FIX: Events ending at 12:00am are not automatically all-day

### DIFF
--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -222,7 +222,7 @@ function initializeDiscourseCalendar(api) {
     };
 
     if (to) {
-      if (hasTimeSpecified(to.dateTime)) {
+      if (hasTimeSpecified(to.dateTime) || hasTimeSpecified(from.dateTime)) {
         event.end = to.dateTime.toDate();
       } else {
         event.end = to.dateTime.add(1, "days").toDate();


### PR DESCRIPTION
Events that go from 11:00pm to 12:00am are showing as all-day. This fixes that.