### PR TITLE
FIX: Stop include_group_timezones? N1 query

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -271,7 +271,7 @@ after_initialize do
   end
 
   add_to_serializer(:post, :include_group_timezones?) do
-    object.has_group_timezones?
+    post_custom_fields[DiscourseCalendar::HAS_GROUP_TIMEZONES_CUSTOM_FIELD] || false
   end
 
   add_to_serializer(:site, :users_on_holiday) { DiscourseCalendar.users_on_holiday }


### PR DESCRIPTION
Using custom_fields instead of post_custom_fields triggers a query for the custom field on every post in the topic. Change the include_group_timezones to use post_custom_fields instead which queries every post for the topic on topic view load.