### PR TITLE
Change height to min-height for group-timezone sizing

### DIFF
--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -215,17 +215,17 @@ $bg-in-working-hours: dark-light-choose(
 
   &[data-size="small"],
   &.small {
-    height: 175px;
+    max-height: 175px;
   }
 
   &[data-size="medium"],
   &.medium {
-    height: 300px;
+    max-height: 300px;
   }
 
   &[data-size="large"],
   &.large {
-    height: 600px;
+    max-height: 600px;
   }
 }
 


### PR DESCRIPTION
Right now, the larger sizes look really weird with only a few users in a group. This allows the group timezone component to look good with small # of users, but also max at the correct height.