### PR TITLE
REFACTOR: Fix Rails 6 scope deprecation warning

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -39,10 +39,10 @@ module DiscoursePostEvent
 
     scope :visible, -> { where(deleted_at: nil) }
     scope :not_expired, -> {
-      where('ends_at IS NOT NULL and ends_at > :now', now: Time.now)
-        .or(
-          Event.where('starts_at > :now and ends_at IS NULL', now: Time.now)
-        )
+      where(<<-SQL, now: Time.now)
+        (ends_at IS NOT NULL AND ends_at > :now) OR
+        (starts_at > :now AND ends_at IS NULL)
+      SQL
     }
 
     def is_expired?


### PR DESCRIPTION
```
DEPRECATION WARNING: Class level methods will no longer
inherit scoping from `not_expired` in Rails 6.1.
To continue using the scoped relation, pass it into
the block directly. To instead access the full set of models,
as Rails 6.1 will, use
`DiscoursePostEvent::Event.default_scoped`.
(called from block in <class:Event> at
/home/runner/work/discourse/discourse/plugins/discourse-calendar/app/models/discourse_post_event/event.rb:44)
```

It's not a solution mentioned in the deprecation warning, but it's simpler, shorter, has one level of indentation less, doesn't create extra ActiveRecord objects, and uses a single Time instance.