### PR TITLE
FIX: Error when users_on_holiday is undefined

### DIFF
--- a/assets/javascripts/connectors/after-user-name/holiday-flair.js.es6
+++ b/assets/javascripts/connectors/after-user-name/holiday-flair.js.es6
@@ -6,6 +6,7 @@ export default {
   shouldRender(args, context) {
     return (
       context.siteSettings.calendar_enabled &&
+      context.site.users_on_holiday &&
       context.site.users_on_holiday.includes(args.user.username)
     );
   },


### PR DESCRIPTION
I was getting this error from calendar 

![Screenshot from 2020-07-08 15-58-23](https://user-images.githubusercontent.com/16214023/86969895-1d2a6800-c134-11ea-97c2-362306239a58.png)
