### PR TITLE
Meeting location and google calendar link

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -89,6 +89,7 @@ module DiscoursePostEvent
         .permit(
           :id,
           :name,
+          :meetingLocation,
           :starts_at,
           :ends_at,
           :status,

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -163,6 +163,7 @@ module DiscoursePostEvent
 
         params = {
           name: event_params[:name],
+          meetingLocation: event_params[:"meeting-location"],
           starts_at: event_params[:start] || event.starts_at,
           ends_at: event_params[:end],
           status: event_params[:status].present? ? Event.statuses[event_params[:status].to_sym] : event.status,

--- a/app/serializers/discourse_post_event/event_serializer.rb
+++ b/app/serializers/discourse_post_event/event_serializer.rb
@@ -17,6 +17,7 @@ module DiscoursePostEvent
     attributes :can_update_attendance
     attributes :is_expired
     attributes :should_display_invitees
+    attributes :meetingLocation
 
     def can_act_on_discourse_post_event
       scope.can_act_on_discourse_post_event?(object)

--- a/assets/javascripts/discourse/controllers/discourse-post-event-builder.js.es6
+++ b/assets/javascripts/discourse/controllers/discourse-post-event-builder.js.es6
@@ -146,6 +146,10 @@ export default Controller.extend(ModalFunctionality, {
       eventParams.status = this.model.eventModel.status;
     }
 
+    if (this.model.eventModel.meetingLocation) {
+      eventParams.meetingLocation = this.model.eventModel.meetingLocation;
+    }
+
     if (this.model.eventModel.name) {
       eventParams.name = this.model.eventModel.name;
     }

--- a/assets/javascripts/discourse/models/discourse-post-event-event.js.es6
+++ b/assets/javascripts/discourse/models/discourse-post-event-event.js.es6
@@ -3,7 +3,7 @@ import RestModel from "discourse/models/rest";
 const ATTRIBUTES = {
   id: {},
   name: {},
-  meetingLocation: {},
+  meetingLocation: { },
   starts_at: {},
   ends_at: {},
   raw_invitees: {},
@@ -43,6 +43,7 @@ const Event = RestModel.extend({
       const attribute = ATTRIBUTES[key];
       if (attribute.transform) {
         props[key] = attribute.transform(props[key]);
+        console.log(key, props[key]);
       }
     });
   },

--- a/assets/javascripts/discourse/models/discourse-post-event-event.js.es6
+++ b/assets/javascripts/discourse/models/discourse-post-event-event.js.es6
@@ -43,7 +43,6 @@ const Event = RestModel.extend({
       const attribute = ATTRIBUTES[key];
       if (attribute.transform) {
         props[key] = attribute.transform(props[key]);
-        console.log(key, props[key]);
       }
     });
   },

--- a/assets/javascripts/discourse/models/discourse-post-event-event.js.es6
+++ b/assets/javascripts/discourse/models/discourse-post-event-event.js.es6
@@ -3,6 +3,7 @@ import RestModel from "discourse/models/rest";
 const ATTRIBUTES = {
   id: {},
   name: {},
+  meetingLocation: {},
   starts_at: {},
   ends_at: {},
   raw_invitees: {},

--- a/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
+++ b/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
@@ -19,6 +19,13 @@
         }}
       {{/event-field}}
 
+      {{#event-field class="meeting-location" label="discourse_post_event.builder_modal.meetingLocation"}}
+        {{input
+          value=(readonly model.eventModel.meetingLocation)
+          input=(action (mut model.eventModel.meetingLocation) value="target.value")
+        }}
+      {{/event-field}}
+
       {{#event-field label="discourse_post_event.builder_modal.status.label"}}
         <label class="radio-label">
           {{radio-button

--- a/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
@@ -138,7 +138,7 @@ export default createWidget("discourse-post-event", {
       startsAtMonth: moment(eventModel.starts_at).format("MMM"),
       startsAtDay: moment(eventModel.starts_at).format("D"),
       meetingLocation: mLocation,
-      gcal_url: gCalUrl,
+      gcalUrl: gCalUrl,
       eventName: eName,
       statusClass: `status ${eventModel.status}`,
       isPublicEvent: eventModel.status === "public",
@@ -182,7 +182,7 @@ export default createWidget("discourse-post-event", {
 
 
           <div class="meeting-location">
-            <div title="Add to google calendar" >{{d-icon 'calendar-alt'}} <a href={{transformed.gcal_url}} target="_blank">{{d-icon 'fab-google'}}</a></div>
+            <div title="Add to google calendar" >{{d-icon 'calendar-alt'}} <a href={{transformed.gcalUrl}} target="_blank">{{d-icon 'fab-google'}}</a></div>
             {{#if transformed.meetingLocation}}
             <div title="Join meeting" data-url=transformed.meetingLocation.url>{{d-icon 'map-marker-alt'}}
             {{#if transformed.meetingLocation.url}}

--- a/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
@@ -111,15 +111,17 @@ export default createWidget("discourse-post-event", {
       const ret = {
         location: value
       }
-      const uidx = value.indexOf('~');
-      if (value && uidx >= 0) {
-        ret.location = value.substr(0, uidx);
-        ret.url = value.substr(uidx + 1);
+      if (value) {
+        const uidx = value.indexOf('~');
+        if (uidx >= 0) {
+          ret.location = value.substr(0, uidx);
+          ret.url = value.substr(uidx + 1);
+        }
       }
       return ret;
     })(eventModel.meetingLocation);
     const gCalUrl = (() => {
-      const mUrl = mLocation.url ? (mLocation.url) : mLocation.location;
+      const mUrl = mLocation.location ? (mLocation.url ? (mLocation.url) : mLocation.location) : '';
       let dates = '';
       if (eventModel.starts_at) dates += eventModel.starts_at.replace(/-|:|\.000/g, '');
       if (eventModel.ends_at) dates += '%2F' + eventModel.ends_at.replace(/-|:|\.000/g, '');
@@ -178,13 +180,20 @@ export default createWidget("discourse-post-event", {
           </div>
         </div>
 
-        {{#if state.eventModel.meetingLocation}}
+
           <div class="meeting-location">
             <div title="Add to google calendar" >{{d-icon 'calendar-alt'}} <a href={{transformed.gcal_url}} target="_blank">{{d-icon 'fab-google'}}</a></div>
-            <div title="Join meeting">{{d-icon 'map-marker-alt'}} <a href={{transformed.meetingLocation.url}} target="_blank">{{{transformed.meetingLocation.location}}}</a></div><br/>
+            {{#if transformed.meetingLocation}}
+            <div title="Join meeting" data-url=transformed.meetingLocation.url>{{d-icon 'map-marker-alt'}}
+            {{#if transformed.meetingLocation.url}}
+            <a href={{transformed.meetingLocation.url}} target="_blank">{{transformed.meetingLocation.location}}</a>
+            {{else}}
+            {{transformed.meetingLocation.location}}
+            {{/if}}
+            </div>
+            {{/if}}
           </div>
           <hr />
-        {{/if}}
 
         {{attach
           widget="more-dropdown"

--- a/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
@@ -100,7 +100,17 @@ export default createWidget("discourse-post-event", {
 
   transform() {
     const eventModel = this.state.eventModel;
-
+    const mLocation = ((value) => {
+      const ret = {
+        location: value
+      }
+      const uidx = value.indexOf('~');
+      if (value && uidx >= 0) {
+        ret.location = value.substr(0, uidx);
+        ret.url = value.substr(uidx + 1);
+      }
+      return ret;
+    })(eventModel.meetingLocation);
     return {
       eventStatusLabel: I18n.t(
         `discourse_post_event.models.event.status.${eventModel.status}.title`
@@ -110,7 +120,7 @@ export default createWidget("discourse-post-event", {
       ),
       startsAtMonth: moment(eventModel.starts_at).format("MMM"),
       startsAtDay: moment(eventModel.starts_at).format("D"),
-      meetingLocation: eventModel.meetingLocation,
+      meetingLocation: mLocation,
       eventName: emojiUnescape(
         eventModel.name ||
           this._cleanTopicTitle(
@@ -187,7 +197,7 @@ export default createWidget("discourse-post-event", {
 
       {{#if state.eventModel.meetingLocation}}
         <section class="meeting-location">
-        Location: <a href={{transformed.meetingLocation}}>{{{transformed.meetingLocation}}}</a>
+        Location: <a href={{transformed.meetingLocation.url}}>{{{transformed.meetingLocation.location}}}</a>
         </section>
         <hr />
       {{/if}}

--- a/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
@@ -110,6 +110,7 @@ export default createWidget("discourse-post-event", {
       ),
       startsAtMonth: moment(eventModel.starts_at).format("MMM"),
       startsAtDay: moment(eventModel.starts_at).format("D"),
+      meetingLocation: eventModel.meetingLocation,
       eventName: emojiUnescape(
         eventModel.name ||
           this._cleanTopicTitle(
@@ -162,6 +163,7 @@ export default createWidget("discourse-post-event", {
           attrs=(hash
             canActOnEvent=this.transformed.canActOnEvent
             postEventId=state.eventModel.id
+            meetingLocation=state.eventModel.meetingLocation
             isExpired=state.eventModel.is_expired
             creatorUsername=state.eventModel.creator.username
             isPublicEvent=this.transformed.isPublicEvent
@@ -181,6 +183,14 @@ export default createWidget("discourse-post-event", {
       {{/if}}
 
       <hr />
+
+
+      {{#if state.eventModel.meetingLocation}}
+        <section class="meeting-location">
+        Location: <a href={{transformed.meetingLocation}}>{{{transformed.meetingLocation}}}</a>
+        </section>
+        <hr />
+      {{/if}}
 
       {{attach widget="discourse-post-event-dates"
         attrs=(hash

--- a/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-post-event.js.es6
@@ -183,8 +183,8 @@ export default createWidget("discourse-post-event", {
 
           <div class="meeting-location">
             <div title="Add to google calendar" >{{d-icon 'calendar-alt'}} <a href={{transformed.gcalUrl}} target="_blank">{{d-icon 'fab-google'}}</a></div>
-            {{#if transformed.meetingLocation}}
-            <div title="Join meeting" data-url=transformed.meetingLocation.url>{{d-icon 'map-marker-alt'}}
+            {{#if transformed.meetingLocation.location}}
+            <div data-url=transformed.meetingLocation.url>{{d-icon 'map-marker-alt'}}
             {{#if transformed.meetingLocation.url}}
             <a href={{transformed.meetingLocation.url}} target="_blank">{{transformed.meetingLocation.location}}</a>
             {{else}}

--- a/assets/javascripts/lib/discourse-markdown/discourse-post-event-block.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-post-event-block.js.es6
@@ -23,6 +23,10 @@ const rule = {
       token.attrs.push(["data-name", info.attrs.name]);
     }
 
+    if (info.attrs.meetingLocation) {
+      token.attrs.push(["data-meeting-location", info.attrs.meetingLocation]);
+    }
+
     if (info.attrs.allowedGroups) {
       token.attrs.push(["data-allowed-groups", info.attrs.allowedGroups]);
     }

--- a/assets/stylesheets/common/discourse-post-event-builder.scss
+++ b/assets/stylesheets/common/discourse-post-event-builder.scss
@@ -62,7 +62,7 @@
     margin: 1em 0;
     flex-direction: column;
 
-    &.name {
+    &.name, &.meeting-location {
       input {
         width: 100%;
       }

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -28,6 +28,9 @@
 
     .meeting-location {
       padding: 0.3em 1em;
+      display: inline-block;
+      margin-left: 20px;
+      margin-top: 20px;
     }
   }
 

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -25,6 +25,10 @@
         }
       }
     }
+
+    .meeting-location {
+      padding: 0.3em 1em;
+    }
   }
 
   &.is-loading {

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -29,8 +29,6 @@
     .meeting-location {
       padding: 0.3em 1em;
       display: inline-block;
-      margin-left: 20px;
-      margin-top: 20px;
     }
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -318,6 +318,7 @@ en:
         name:
           label: Event name
           placeholder: Optional, defaults to topic title
+        meetingLocation: Location
         invitees:
           label: Invited groups
         status:

--- a/db/migrate/20200721080458_add_meeting_location_to_calendar_events.rb
+++ b/db/migrate/20200721080458_add_meeting_location_to_calendar_events.rb
@@ -1,0 +1,5 @@
+class AddMeetingLocationToCalendarEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :calendar_events, :meetingLocation, :string
+  end
+end

--- a/db/migrate/20200721082530_add_meeting_location_to_discourse_post_event_event.rb
+++ b/db/migrate/20200721082530_add_meeting_location_to_discourse_post_event_event.rb
@@ -1,0 +1,5 @@
+class AddMeetingLocationToDiscoursePostEventEvent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :discourse_post_event_events, :meetingLocation, :string
+  end
+end

--- a/lib/discourse_post_event/event_parser.rb
+++ b/lib/discourse_post_event/event_parser.rb
@@ -4,6 +4,7 @@ VALID_OPTIONS = [
   :start,
   :end,
   :status,
+  :"meeting-location",
   :"allowed-groups",
   :name
 ]


### PR DESCRIPTION
- Option to add a location for an event, which could additionally have a link
- Display a link to quickly add event to google calendar
- Location gets added to link so it is saved in the google calendar event.

To create a link with location, the format is as follows:
Format: `<Link Text>~<Link url>`
Example: Zoom~https://zoom.us

For location with link, it appears like so:
![image](https://user-images.githubusercontent.com/44477386/88103807-e6167680-cb77-11ea-8857-96ad3a6703ca.png)

When using text-only location, it appears like so:
![image](https://user-images.githubusercontent.com/44477386/88103744-d1d27980-cb77-11ea-99ad-f55a11747da7.png)

Without a location, it appears like so:
![image](https://user-images.githubusercontent.com/44477386/88103977-270e8b00-cb78-11ea-986b-1fb980345e84.png)
