### PR TITLE
HACK: Drop readonly tables when running tests

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -34,6 +34,21 @@ register_svg_icon 'fas fa-star'
 register_svg_icon 'fas fa-file-upload'
 
 after_initialize do
+
+  # TODO: Put this code inside a migration.
+  # lib/db_helper_spec.rb fails without this because these tables are read-only
+  # See: https://github.com/discourse/discourse-calendar/commit/c17bbf57d15920101319b0be40f0bc0fbf17802a
+  if Rails.env.test?
+    connection = ActiveRecord::Base.connection
+    if connection.table_exists?(:discourse_calendar_post_events)
+      Migration::TableDropper.execute_drop(:discourse_calendar_post_events)
+    end
+
+    if connection.table_exists?(:discourse_calendar_invitees)
+      Migration::TableDropper.execute_drop(:discourse_calendar_invitees)
+    end
+  end
+
   module ::DiscourseCalendar
     PLUGIN_NAME ||= 'discourse-calendar'
 


### PR DESCRIPTION
 To reproduce:
  - Clone this repo.
  - ` bundle exec rake db:drop db:create db:migrate LOAD_PLUGINS=1 RAILS_ENV=test`
  - `LOAD_PLUGINS=1 bundle exec rspec /Users/romeer/projects/discourse/spec/lib/db_helper_spec.rb`

Fails with this error:

```
Failure/Error:
        rows = DB.exec(<<~SQL, from: from, to: to, like: like)
          UPDATE \"#{table}\"
             SET #{set}
           WHERE #{where}
        SQL

PG::RaiseException:
  ERROR:  Discourse: discourse_calendar_post_events is read only
  CONTEXT:  PL/pgSQL function discourse_functions.raise_discourse_calendar_post_events_readonly() line 3 at RAISE
# (eval):24:in `exec'
# (eval):24:in `async_exec'
```

