### PR TITLE
FIX: correctly destroys standalone calendar events

### DIFF
--- a/jobs/scheduled/destroy_past_events.rb
+++ b/jobs/scheduled/destroy_past_events.rb
@@ -29,9 +29,10 @@ module Jobs
 
         end_date = event.end_date ? event.end_date : event.start_date + 24.hours
         next if end_date + delay.hour > Time.zone.now
-        next if event.post.blank?
 
         expired_event_ids << event.id
+
+        next if event.post.blank?
 
         # Delete the post and all replies that do not represent other events
         event.post.replies.each do |reply|

--- a/spec/jobs/scheduled/destroy_past_events_spec.rb
+++ b/spec/jobs/scheduled/destroy_past_events_spec.rb
@@ -48,6 +48,15 @@ describe DiscourseCalendar::DestroyPastEvents do
     expect(Post.find_by(id: post.id)).not_to eq(nil)
   end
 
+  it "will destroy expired standalone events" do
+    topic = Fabricate(:topic)
+    event = CalendarEvent.create!(topic: calendar_post.topic, start_date: 10.years.ago)
+
+    subject.execute(nil)
+
+    expect(CalendarEvent.find_by(id: event.id)).to eq(nil)
+  end
+
   it "will not destroy recurring events" do
     freeze_time Time.strptime("2018-06-03 09:21:00 UTC", "%Y-%m-%d %H:%M:%S %Z")
 


### PR DESCRIPTION
Standalone events are mostly created for holidays where we create a calendar event not associated to any post of of the topic, before this change, the loop was exited before collecting the ID of the calendar event to be destroyed.