### PR TITLE
FIX: clean up holidays from deactivated/suspended/silenced users

### DIFF
--- a/spec/jobs/scheduled/create_holiday_events_spec.rb
+++ b/spec/jobs/scheduled/create_holiday_events_spec.rb
@@ -69,6 +69,21 @@ describe DiscourseCalendar::CreateHolidayEvents do
     expect(CalendarEvent.pluck(:region, :description, :start_date, :username)).to eq([])
   end
 
+  it "cleans up holidays from deactivated/silenced/suspended users" do
+    frenchy
+    freeze_time Time.zone.local(2019, 8, 1)
+    subject.execute(nil)
+
+    expect(CalendarEvent.exists?(username: frenchy.username)).to eq(true)
+
+    frenchy.active = false
+    frenchy.save!
+
+    subject.execute(nil)
+
+    expect(CalendarEvent.exists?(username: frenchy.username)).to eq(false)
+  end
+
   context "when user_options.timezone column exists" do
     it "uses the user TZ when available" do
       frenchy.user_option.update!(timezone: "Europe/Paris")


### PR DESCRIPTION
Since we're generating holidays for the next 6 months, there might be some
leftovers whenever a user is deactivated/suspended/silenced.

PERF: only load timezones informations from concerned users.
We only care about the timezones of the users we will be generating holidays for.

DEV: rename `user_ids_and_timezones` to the clear-but-shorter `timezones` 