### PR TITLE
Extracting category id using regex

### DIFF
--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -65,10 +65,7 @@ function initializeDiscourseCalendar(api) {
           return data;
         });
 
-      const categorySetting = settings.findBy(
-        "categoryId",
-        browsedCategory
-      );
+      const categorySetting = settings.findBy("categoryId", browsedCategory);
 
       if (categorySetting && categorySetting.postId) {
         $calendarContainer.show();

--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -7,7 +7,6 @@ import loadScript from "discourse/lib/load-script";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { ajax } from "discourse/lib/ajax";
 import { showPopover, hidePopover } from "discourse/lib/d-popover";
-import Category from "discourse/models/category";
 
 // https://stackoverflow.com/a/16348977
 /* eslint-disable */

--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -48,7 +48,8 @@ function initializeDiscourseCalendar(api) {
     if (!$calendarContainer.length) return;
     $calendarContainer.hide();
 
-    const browsedCategory = Category.findBySlugPathWithID(url);
+    const matches = url.match(/(?:\/c\/[a-zA-Z\-]+\/)([0-9]+)/);
+    const browsedCategory = matches && matches[1];
     if (browsedCategory) {
       const settings = Discourse.SiteSettings.calendar_categories
         .split("|")
@@ -67,7 +68,7 @@ function initializeDiscourseCalendar(api) {
 
       const categorySetting = settings.findBy(
         "categoryId",
-        browsedCategory.id.toString()
+        browsedCategory
       );
 
       if (categorySetting && categorySetting.postId) {


### PR DESCRIPTION
Apply the calendar plugin on enabled categories with their default URL different from `/c/category-name/id`.