### PR TITLE
FIX: find_each does not respect ordering clauses

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -395,7 +395,7 @@ after_initialize do
     grouped = {}
     standalones = []
 
-    CalendarEvent.where(topic_id: object.topic_id).order(:start_date, :end_date).find_each do |event|
+    CalendarEvent.where(topic_id: object.topic_id).order(:start_date, :end_date).each do |event|
       if event.post_id
         standalones << {
           type: :standalone,


### PR DESCRIPTION
`find_each` gets the rows in batches, ordered by the primary key, so
ordering clauses are ignored. If it is not OK to fetch them all from
postgres, then it is also not OK to send them all to the client at once.