### PR TITLE
FIX: check ends_at in migration to event date

### DIFF
--- a/db/post_migrate/20201111005205_move_data_to_event_dates.rb
+++ b/db/post_migrate/20201111005205_move_data_to_event_dates.rb
@@ -12,6 +12,7 @@ class MoveDataToEventDates < ActiveRecord::Migration[6.0]
       next if !post
       extracted_event = DiscoursePostEvent::EventParser.extract_events(post).first
       next if !extracted_event
+      next if !event.original_ends_at
 
       finished_at = (event.original_ends_at < Time.current) && event.original_ends_at
       event_will_start_sent_at = event.original_starts_at - 1.hours


### PR DESCRIPTION
Don't create event date when original_ends_at doesn't exist.

This mean that event markdown is not correct

It was throwing error: undefined method `<' for nil:NilClass>