### PR TITLE
FIX: randomly failing export CSV spec

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -520,7 +520,7 @@ after_initialize do
 
         guardian.ensure_can_act_on_discourse_post_event!(event)
 
-        event.invitees.each do |invitee|
+        event.invitees.order(:created_at).each do |invitee|
           yield [
             invitee.user.username,
             DiscoursePostEvent::Invitee.statuses[invitee.status],

--- a/spec/jobs/export_post_event_report_csv_spec.rb
+++ b/spec/jobs/export_post_event_report_csv_spec.rb
@@ -23,10 +23,8 @@ describe Jobs::ExportCsvFile do
       context 'the event exists' do
         context 'the event has invitees' do
           before do
-            post_event.create_invitees([
-              { user_id: user_1.id, status: nil },
-              { user_id: user_2.id, status: 2 }
-            ])
+            post_event.create_invitees([{ user_id: user_1.id, status: nil }])
+            post_event.create_invitees([{ user_id: user_2.id, status: 2 }])
           end
 
           context 'the user requesting the upload is admin' do


### PR DESCRIPTION
The test is failing because of an incorrect order. I added an order by `created_by`.

Also, I needed to split create_invitess because it is using the same date for `created_at`

```ruby
def create_invitees(attrs)
  timestamp = Time.now
  attrs.map! do |attr|
    {
      post_id: self.id, created_at: timestamp, updated_at: timestamp
    }.merge(attr)
  end

  self.invitees.insert_all!(attrs)
end
```