### PR TITLE
DEV: Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/discourse/controllers/discourse-post-event-invitees.js.es6
+++ b/assets/javascripts/discourse/controllers/discourse-post-event-invitees.js.es6
@@ -1,7 +1,8 @@
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import Controller from "@ember/controller";
-import { debounce } from "@ember/runloop";
 import { action } from "@ember/object";
+import discourseDebounce from "discourse-common/lib/debounce";
+import { debounce } from "@ember/runloop";
 
 export default Controller.extend(ModalFunctionality, {
   invitees: null,
@@ -14,7 +15,10 @@ export default Controller.extend(ModalFunctionality, {
 
   @action
   onFilterChanged(filter) {
-    debounce(this, this._fetchInvitees, filter, 250);
+    // TODO: Use discouseDebounce after the 2.7 release.
+    const debounceFunc = discourseDebounce || debounce;
+
+    debounceFunc(this, this._fetchInvitees, filter, 250);
   },
 
   @action


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.