### PR TITLE
FIX: Cannot compare nil with less than or equal to

### DIFF
--- a/app/models/discourse_post_event/event_date.rb
+++ b/app/models/discourse_post_event/event_date.rb
@@ -46,6 +46,7 @@ module DiscoursePostEvent
     end
 
     def ended?
+      return false if ends_at.nil?
       ends_at <= Time.current
     end
   end

--- a/spec/models/discourse_post_event/event_date_spec.rb
+++ b/spec/models/discourse_post_event/event_date_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../fabricators/event_fabricator'
+
+describe DiscoursePostEvent::EventDate do
+  let(:user) { Fabricate(:user, admin: true) }
+  let(:topic) { Fabricate(:topic, user: user) }
+  let!(:first_post) { Fabricate(:post, topic: topic) }
+  let(:second_post) { Fabricate(:post, topic: topic) }
+  let!(:starts_at) { '2020-04-24 14:15:00' }
+  let!(:ends_at) { '2020-04-24 16:15:00' }
+  let!(:alt_starts_at) { '2020-04-25 17:15:25' }
+  let!(:alt_ends_at) { '2020-04-25 19:15:25' }
+  let!(:post_event) { Fabricate(:event, post: first_post, original_starts_at: starts_at) }
+  let!(:event_date) { Fabricate(:event_date, event: post_event) }
+
+  before do
+    freeze_time DateTime.parse('2020-04-24 14:10')
+    Jobs.run_immediately!
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+  end
+
+  describe 'Event Date Ended?' do
+
+    it 'returns false if no end time has been specified' do
+      expect(event_date.ended?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This commit is to fix this error:

`Job exception: undefined method `<=' for nil:NilClass`

That occurs from the finish method in the monitor_events_dates scheduled
job.

```
app/models/discourse_post_event/event_date.rb:49:in `ended?'
jobs/scheduled/monitor_event_dates.rb:35:in `finish'
jobs/scheduled/monitor_event_dates.rb:11:in `block in execute'
```

This method checks to see if the event has finished and if it has it
will mark it as finished in the database. Some events though don't have
an end date and so this job will throw the above error.

Added a spec file for the event_date model to test for this specific
case.
