### PR TITLE
FIX: reminder job is not erroring when a post is deleted

### DIFF
--- a/jobs/regular/discourse_post_event/send_reminder.rb
+++ b/jobs/regular/discourse_post_event/send_reminder.rb
@@ -9,6 +9,9 @@ module Jobs
       raise Discourse::InvalidParameters.new(:reminder) if args[:reminder].blank?
 
       event = DiscoursePostEvent::Event.includes(post: [:topic], invitees: [:user]).find(args[:event_id])
+
+      return unless event.post
+
       invitees = event.invitees.where(status: [
         DiscoursePostEvent::Invitee.statuses[:going],
         DiscoursePostEvent::Invitee.statuses[:interested]

--- a/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
+++ b/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
@@ -65,6 +65,18 @@ describe Jobs::DiscoursePostEventSendReminder do
       end
     end
 
+    context 'deleted post' do
+      let!(:event_1) { Fabricate(:event, post: post_1, reminders: reminders, original_starts_at: 3.hours.from_now) }
+
+      it 'is not erroring when post is already deleted' do
+        post_1.delete
+
+        expect {
+          subject.execute(event_id: event_1.id, reminder: reminders)
+        }.not_to raise_error
+      end
+    end
+
     context 'public event' do
       context 'event has not started' do
         let!(:event_1) { Fabricate(:event, post: post_1, reminders: reminders, original_starts_at: 3.hours.from_now) }


### PR DESCRIPTION
We should not error in reminder job when a post is already deleted.

In that case, we should simply skip and don't send any notifications.