### PR TITLE
FIX: Use Ember's debounce on stable.

### DIFF
--- a/assets/javascripts/discourse/controllers/discourse-post-event-invitees.js.es6
+++ b/assets/javascripts/discourse/controllers/discourse-post-event-invitees.js.es6
@@ -1,7 +1,6 @@
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
-import discourseDebounce from "discourse-common/lib/debounce";
 import { debounce } from "@ember/runloop";
 
 export default Controller.extend(ModalFunctionality, {
@@ -16,7 +15,11 @@ export default Controller.extend(ModalFunctionality, {
   @action
   onFilterChanged(filter) {
     // TODO: Use discouseDebounce after the 2.7 release.
-    const debounceFunc = discourseDebounce || debounce;
+    let debounceFunc = debounce;
+
+    try {
+      debounceFunc = require("discourse-common/lib/debounce").default;
+    } catch (_) {}
 
     debounceFunc(this, this._fetchInvitees, filter, 250);
   },


### PR DESCRIPTION
We need to wrap the new debounce function inside a try block to avoid throwing a "module not found" exception.