### PR TITLE
FIX: csv-uploader has been removed from core

### DIFF
--- a/assets/javascripts/discourse/components/csv-uploader.js.es6
+++ b/assets/javascripts/discourse/components/csv-uploader.js.es6
@@ -1,0 +1,49 @@
+import Component from "@ember/component";
+import I18n from "I18n";
+import UploadMixin from "discourse/mixins/upload";
+import bootbox from "bootbox";
+import discourseComputed from "discourse-common/utils/decorators";
+import { on } from "@ember/object/evented";
+
+export default Component.extend(UploadMixin, {
+  type: "csv",
+  tagName: "span",
+  uploadUrl: null,
+  i18nPrefix: null,
+
+  validateUploadedFilesOptions() {
+    return { csvOnly: true };
+  },
+
+  @discourseComputed("uploading")
+  uploadButtonText(uploading) {
+    return uploading ? I18n.t("uploading") : I18n.t(`${this.i18nPrefix}.text`);
+  },
+
+  @discourseComputed("uploading")
+  uploadButtonDisabled(uploading) {
+    // https://github.com/emberjs/ember.js/issues/10976#issuecomment-132417731
+    return uploading ? true : null;
+  },
+
+  uploadDone() {
+    bootbox.alert(I18n.t(`${this.i18nPrefix}.success`));
+  },
+
+  uploadOptions() {
+    return { autoUpload: false };
+  },
+
+  _init: on("didInsertElement", function () {
+    const $upload = $(this.element);
+
+    $upload.on("fileuploadadd", (e, data) => {
+      bootbox.confirm(
+        I18n.t(`${this.i18nPrefix}.confirmation_message`),
+        I18n.t("cancel"),
+        I18n.t("go_ahead"),
+        (result) => (result ? data.submit() : data.abort())
+      );
+    });
+  }),
+});

--- a/assets/javascripts/discourse/templates/components/csv-uploader.hbs
+++ b/assets/javascripts/discourse/templates/components/csv-uploader.hbs
@@ -1,0 +1,7 @@
+<label class="btn" disabled={{uploadButtonDisabled}}>
+  {{d-icon "upload"}}&nbsp;{{uploadButtonText}}
+  <input class="hidden-upload-field" disabled={{uploading}} type="file" accept=".csv">
+</label>
+{{#if uploading}}
+  <span>{{i18n "upload_selector.uploading"}} {{uploadProgress}}%</span>
+{{/if}}

--- a/assets/javascripts/discourse/templates/modal/discourse-post-event-bulk-invite.hbs
+++ b/assets/javascripts/discourse/templates/modal/discourse-post-event-bulk-invite.hbs
@@ -62,7 +62,7 @@
       {{bulk-invite-sample-csv-file}}
 
       {{csv-uploader
-        uploadUrl=(concat "/discourse-post-event/events/" model.id "/csv-bulk-invite")
+        uploadUrl=(concat "/discourse-post-event/events/" model.eventModel.id "/csv-bulk-invite")
         i18nPrefix="discourse_post_event.bulk_invite_modal"
         uploading=uploading
         uploadDone=(action "uploadDone")


### PR DESCRIPTION
For now copy previous component into discourse-calendar plugin