### PR TITLE
FIX: event serializer start and end date

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -65,12 +65,12 @@ module DiscoursePostEvent
 
     def starts_at
       event_dates.pending.order(:starts_at).last&.starts_at ||
-        event_dates.order(:starts_at).last&.starts_at
+        event_dates.order(:updated_at, :id).last&.starts_at
     end
 
     def ends_at
       event_dates.pending.order(:starts_at).last&.ends_at ||
-        event_dates.order(:starts_at).last&.ends_at
+        event_dates.order(:updated_at, :id).last&.ends_at
     end
 
     validates :original_starts_at, presence: true

--- a/spec/models/discourse_post_event/event_spec.rb
+++ b/spec/models/discourse_post_event/event_spec.rb
@@ -23,8 +23,8 @@ describe DiscoursePostEvent::Event do
     let(:second_post) { Fabricate(:post, topic: topic) }
     let!(:starts_at) { '2020-04-24 14:15:00' }
     let!(:ends_at) { '2020-04-24 16:15:00' }
-    let!(:alt_starts_at) { '2020-04-25 17:15:25' }
-    let!(:alt_ends_at) { '2020-04-25 19:15:25' }
+    let!(:alt_starts_at) { '2020-04-24 14:14:25' }
+    let!(:alt_ends_at) { '2020-04-24 19:15:25' }
 
     describe '#after_commit[:create, :update]' do
       context 'a post event has been created' do
@@ -84,6 +84,10 @@ describe DiscoursePostEvent::Event do
 
             expect(first_event_date.finished_at).not_to be nil
             expect(second_event_date.starts_at).to eq_time(DateTime.parse(alt_starts_at))
+
+            second_event_date.update_columns(finished_at: Time.current)
+            expect(post_event.starts_at).to eq_time(DateTime.parse(alt_starts_at))
+            expect(post_event.ends_at).to eq_time(DateTime.parse(alt_ends_at))
           end
         end
 


### PR DESCRIPTION
When all events are finished (not pending) serializer is not sorting correctly and not taking the lastly updated event_date. That is causing an issue that even though the database is updated correctly, it is not reflected in UI