### PR TITLE
FIX: Handle multiple holidays in the same day

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -411,16 +411,21 @@ after_initialize do
 
         grouped[identifier] ||= {
           type: :grouped,
-          name: event.description,
           from: event.start_date,
+          name: [],
           usernames: []
         }
 
+        grouped[identifier][:name] << event.description
         grouped[identifier][:usernames] << event.username
       end
     end
 
-    grouped.each { |_, v| v[:usernames].sort! }
+    grouped.each do |_, v|
+      v[:name] = v[:name].sort.join(", ")
+      v[:usernames].sort!
+      v[:usernames].uniq!
+    end
 
     standalones + grouped.values
   end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -27,4 +27,24 @@ describe PostSerializer do
     expect(json[:post][:group_timezones]["admins"].count).to eq(1)
     expect(json[:post][:group_timezones]["trust_level_0"].count).to eq(2)
   end
+
+  it "groups calendar events correctly" do
+    user = Fabricate(:user)
+    user.upsert_custom_fields(::DiscourseCalendar::REGION_CUSTOM_FIELD => 'ar')
+
+    post = create_post(raw: "[calendar]\n[/calendar]")
+    SiteSetting.holiday_calendar_topic_id = post.topic.id
+
+    freeze_time Date.new(2021, 4, 1)
+    ::DiscourseCalendar::CreateHolidayEvents.new.execute({})
+
+    json = PostSerializer.new(post.reload, scope: Guardian.new).as_json
+    expect(json[:post][:calendar_details].map { |x| x[:name] }).to contain_exactly(
+      "Día del Veterano y de los Caídos en la Guerra de Malvinas, Viernes Santo",
+      "Día de la Revolución de Mayo",
+      "Feriado puente turístico",
+      "Día de la Independencia"
+    )
+    expect(json[:post][:calendar_details].map { |x| x[:usernames] }).to all (contain_exactly(user.username))
+  end
 end


### PR DESCRIPTION
If a user had two holidays in the same day, the calendar would show
only one of them, but the username would be shown twice. This ensures
the calendar shows both holidays and the username only once.