### PR TITLE
FIX: Show holiday name only once

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -422,9 +422,9 @@ after_initialize do
     end
 
     grouped.each do |_, v|
-      v[:name] = v[:name].sort.join(", ")
-      v[:usernames].sort!
-      v[:usernames].uniq!
+      v[:name].sort!.uniq!
+      v[:name] = v[:name].join(", ")
+      v[:usernames].sort!.uniq!
     end
 
     standalones + grouped.values

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -32,6 +32,9 @@ describe PostSerializer do
     user = Fabricate(:user)
     user.upsert_custom_fields(::DiscourseCalendar::REGION_CUSTOM_FIELD => 'ar')
 
+    user2 = Fabricate(:user)
+    user2.upsert_custom_fields(::DiscourseCalendar::REGION_CUSTOM_FIELD => 'ar')
+
     post = create_post(raw: "[calendar]\n[/calendar]")
     SiteSetting.holiday_calendar_topic_id = post.topic.id
 
@@ -45,6 +48,6 @@ describe PostSerializer do
       "Feriado puente turístico",
       "Día de la Independencia"
     )
-    expect(json[:post][:calendar_details].map { |x| x[:usernames] }).to all (contain_exactly(user.username))
+    expect(json[:post][:calendar_details].map { |x| x[:usernames] }).to all (contain_exactly(user.username, user2.username))
   end
 end


### PR DESCRIPTION
It used to handle the case when the same user has multiple holidays in
the same day by joining all holiday names in a single string. This was
a problem when another user was in the same region and had the same
holidays, because each holiday name was duplicated.