### PR TITLE
UX: Update event notification text and markup

### DIFF
--- a/assets/javascripts/discourse/widgets/event-invitation-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/event-invitation-notification-item.js.es6
@@ -13,8 +13,7 @@ createWidgetFrom(
     },
 
     text(notificationName, data) {
-      const username = formatUsername(data.display_username);
-
+      const username = `<span>${formatUsername(data.display_username)}</span>`;
       let description;
       if (data.topic_title) {
         description = `<span data-topic-id="${this.attrs.topic_id}">${data.topic_title}</span>`;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -272,7 +272,7 @@ en:
       group_availability: "%{group} availability"
     discourse_post_event:
       notifications:
-        invite_user_notification: "%{username} has invited you to %{description}"
+        invite_user_notification: "%{username} %{description}"
         invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to %{description}"
         before_event_reminder: "An event is about to start %{description}"
         after_event_reminder: "An event has ended %{description}"


### PR DESCRIPTION
Needed an extra span in there to match core styling (default text color username, blue link), also shortened text of the default event notification to match other core notification formatting

Before:
![Screen Shot 2021-04-23 at 11 31 09 PM](https://user-images.githubusercontent.com/1681963/115945926-fef7e380-a48b-11eb-9e2b-4bf6d21ec875.png)


After:
![Screen Shot 2021-04-23 at 11 03 32 PM](https://user-images.githubusercontent.com/1681963/115945942-1c2cb200-a48c-11eb-9dd2-5fb18f374aa3.png)

