### PR TITLE
FIX: prevents exception when accessing `post.local_dates`

### DIFF
--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -9,7 +9,7 @@ class CalendarEvent < ActiveRecord::Base
     CalendarEvent.where(post_id: post.id).destroy_all
 
     dates = post.local_dates
-    return if dates.size < 1 || dates.size > 2
+    return if !dates || dates.size < 1 || dates.size > 2
 
     first_post = post.topic&.first_post
     return if !first_post || !first_post.custom_fields[DiscourseCalendar::CALENDAR_CUSTOM_FIELD]


### PR DESCRIPTION
`post.local_dates` is coming from the core discourse plugin, which has the following implementation:

```
  add_to_class(:post, :local_dates) do
    custom_fields[DiscourseLocalDates::POST_CUSTOM_FIELD] || []
  end
```

Meaning we should always at least get an array, however, if the core local dates plugin is disabled, `add_to_class` will be called and the method added, however it will return nothing if the plugin is not enabled.

Source location correctly leads to the `add_to_class` block:

```
[9] pry(main)> Post.last.method(:local_dates).source_location
=> ["/discourse/lib/plugin/instance.rb", 260]
```