### PR TITLE
FIX: slider input needs z-index for Chrome

### DIFF
--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -272,6 +272,7 @@ a.holiday {
   position: relative;
   box-sizing: border-box;
   background-color: transparent;
+  z-index: 1;
   &::before {
     background: var(--tertiary);
     content: "";


### PR DESCRIPTION
This works in Chrome and Safari; Firefox is still broken for some reason, I'll follow up on that in a separate PR 

Before:
![Screen Shot 2021-07-29 at 9 31 32 PM](https://user-images.githubusercontent.com/1681963/127586353-27abff9e-79cd-45c1-9d61-c199f63072b2.png)

After:
![Screen Shot 2021-07-29 at 9 31 26 PM](https://user-images.githubusercontent.com/1681963/127586354-b87bc518-6bc6-44bb-a59f-787a290db005.png)

