### PR TITLE
FIX: Firefox doesn't allow pseudos on inputs

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-group-timezones-time-traveler.js.es6
+++ b/assets/javascripts/discourse/widgets/discourse-group-timezones-time-traveler.js.es6
@@ -21,9 +21,11 @@ export default createWidget("discourse-group-timezones-time-traveler", {
     <span class="time">
       {{transformed.localTimeWithOffset}}
     </span>
-    {{attach
-      widget="discourse-group-timezones-slider"
-    }}
+    <span class="discourse-group-timezones-slider-wrapper">
+      {{attach
+        widget="discourse-group-timezones-slider"
+      }}
+    </span>
     {{attach
       widget="discourse-group-timezones-reset"
       attrs=(hash

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -259,31 +259,35 @@ a.holiday {
   display: none;
 }
 
-.group-timezones-slider {
-  width: 120px;
+.discourse-group-timezones-slider-wrapper {
+  // we need the wrapper because Firefox doesn't allow pseudo selectors on inputs
+  position: relative;
   margin: 0.25em 0;
   margin-right: 0.5em;
+  &::before {
+    display: block;
+    content: "";
+    position: absolute;
+    margin-top: -1px;
+    background: var(--tertiary);
+    height: 2px;
+    top: 50%;
+    width: 100%;
+    z-index: -1;
+  }
+}
+
+.group-timezones-slider {
+  display: flex;
+  width: 120px;
   padding: 0.25em;
   -webkit-appearance: none;
   -moz-appearance: none;
   cursor: pointer;
   font: inherit;
   outline: none;
-  position: relative;
   box-sizing: border-box;
   background-color: transparent;
-  z-index: 1;
-  &::before {
-    background: var(--tertiary);
-    content: "";
-    display: block;
-    height: 2px;
-    position: absolute;
-    top: 50%;
-    margin-top: -1px;
-    width: 100%;
-    z-index: -1;
-  }
 }
 
 .group-timezones-body {


### PR DESCRIPTION
Turns out Firefox doesn't allow psuedo selectors on range inputs (maybe all inputs), so the bar wasn't rendering at all. Adding a wrapper works fine on all browsers. 

Before:
![Screen Shot 2021-07-29 at 10 01 18 PM](https://user-images.githubusercontent.com/1681963/127588599-21795645-023f-46c4-b2ef-af465eedb87e.png)

After:
![Screen Shot 2021-07-29 at 10 00 59 PM](https://user-images.githubusercontent.com/1681963/127588610-b2eae8eb-9176-4448-9665-ff8340b124e2.png)
