### PR TITLE
FIX: Expired/non-expired events logic

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -44,9 +44,12 @@ module DiscoursePostEvent
 
       event_dates.create!(
         starts_at: next_dates[:starts_at],
-        ends_at: next_dates[:ends_at],
-        finished_at: next_dates[:ends_at] && next_dates[:ends_at] < Time.current && next_dates[:ends_at]
-      )
+        ends_at: next_dates[:ends_at]
+      ) do |event_date|
+        if next_dates[:ends_at] && next_dates[:ends_at] < Time.current
+          event_date.finished_at = next_dates[:ends_at]
+        end
+      end
 
       publish_update!
       invitees.update_all(status: nil, notified: false)

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -45,7 +45,7 @@ module DiscoursePostEvent
       event_dates.create!(
         starts_at: next_dates[:starts_at],
         ends_at: next_dates[:ends_at],
-        finished_at: (next_dates[:starts_at] < Time.current) && next_dates[:starts_at]
+        finished_at: next_dates[:ends_at] && next_dates[:ends_at] < Time.current && next_dates[:ends_at]
       )
 
       publish_update!

--- a/spec/fabricators/event_fabricator.rb
+++ b/spec/fabricators/event_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:event, from: 'DiscoursePostEvent::Event') do
-  post { |attrs| attrs[:post] }
+  post { |attrs| attrs[:post] || Fabricate(:post) }
 
   id { |attrs| attrs[:post].id }
 

--- a/spec/lib/discourse_post_event/event_finder_spec.rb
+++ b/spec/lib/discourse_post_event/event_finder_spec.rb
@@ -89,29 +89,33 @@ describe DiscoursePostEvent::EventFinder do
     end
 
     context 'by expiration status' do
-      let(:post1) {
-        PostCreator.create!(
-          user,
-          title: 'We should buy a boat',
-          raw: 'The boat market is quite active lately.'
-        )
-      }
-      let(:post2) {
-        PostCreator.create!(
-          user,
-          title: 'We should buy another boat',
-          raw: 'The boat market is very active lately.'
-        )
-      }
-      let!(:event1) { Fabricate(:event, post: post1, original_starts_at: 2.hours.ago, original_ends_at: 1.hour.ago) }
-      let!(:event2) { Fabricate(:event, post: post2, original_starts_at: 1.hour.from_now, original_ends_at: 2.hours.from_now) }
+      let!(:old_event) { Fabricate(:event, name: 'old_event', original_starts_at: 2.hours.ago, original_ends_at: 1.hour.ago) }
+      let!(:future_event) { Fabricate(:event, name: 'future_event', original_starts_at: 1.hour.from_now, original_ends_at: 2.hours.from_now) }
+      let!(:current_event) { Fabricate(:event, name: 'current_event', original_starts_at: 5.minutes.ago, original_ends_at: 5.minutes.from_now) }
+      let!(:older_event) { Fabricate(:event, name: 'older_event', original_starts_at: 4.hours.ago, original_ends_at: 3.hour.ago) }
 
       it 'returns non-expired events when false' do
-        expect(subject.search(current_user, { expired: false })).to match_array([event2])
+        expect(subject.search(current_user, { expired: false })).to eq([current_event, future_event])
       end
 
       it 'returns expired events when true' do
-        expect(subject.search(current_user, { expired: true })).to match_array([event1])
+        expect(subject.search(current_user, { expired: true })).to eq([older_event, old_event])
+      end
+
+      context 'when a past event has been edited to be in the future' do
+        let!(:event_date) { Fabricate(:event_date, event: future_event, starts_at: 2.hours.ago, ends_at: 1.hour.ago, finished_at: 1.hour.ago) }
+
+        it 'returns correct non-expired events' do
+          expect(subject.search(current_user, { expired: false })).to eq([current_event, future_event])
+        end
+      end
+
+      context 'when a future event has been edited to be in the past' do
+        let!(:event_date) { Fabricate(:event_date, event: old_event, starts_at: 1.hour.from_now, ends_at: 2.hours.from_now, finished_at: 1.hour.ago) }
+
+        it 'returns correct expired events' do
+          expect(subject.search(current_user, { expired: true })).to eq([older_event, old_event])
+        end
       end
     end
   end

--- a/spec/lib/discourse_post_event/event_finder_spec.rb
+++ b/spec/lib/discourse_post_event/event_finder_spec.rb
@@ -94,26 +94,25 @@ describe DiscoursePostEvent::EventFinder do
       let!(:current_event) { Fabricate(:event, name: 'current_event', original_starts_at: 5.minutes.ago, original_ends_at: 5.minutes.from_now) }
       let!(:older_event) { Fabricate(:event, name: 'older_event', original_starts_at: 4.hours.ago, original_ends_at: 3.hour.ago) }
 
-      it 'returns non-expired events when false' do
+      it 'returns correct events' do
         expect(subject.search(current_user, { expired: false })).to eq([current_event, future_event])
-      end
-
-      it 'returns expired events when true' do
         expect(subject.search(current_user, { expired: true })).to eq([older_event, old_event])
       end
 
       context 'when a past event has been edited to be in the future' do
         let!(:event_date) { Fabricate(:event_date, event: future_event, starts_at: 2.hours.ago, ends_at: 1.hour.ago, finished_at: 1.hour.ago) }
 
-        it 'returns correct non-expired events' do
+        it 'returns correct events' do
           expect(subject.search(current_user, { expired: false })).to eq([current_event, future_event])
+          expect(subject.search(current_user, { expired: true })).to eq([older_event, old_event])
         end
       end
 
       context 'when a future event has been edited to be in the past' do
         let!(:event_date) { Fabricate(:event_date, event: old_event, starts_at: 1.hour.from_now, ends_at: 2.hours.from_now, finished_at: 1.hour.ago) }
 
-        it 'returns correct expired events' do
+        it 'returns correct events' do
+          expect(subject.search(current_user, { expired: false })).to eq([current_event, future_event])
           expect(subject.search(current_user, { expired: true })).to eq([older_event, old_event])
         end
       end


### PR DESCRIPTION
Previously, an edited event could be returned in both expired and non-expired event queries.