### PR TITLE
FIX: small region preferences select

### DIFF
--- a/assets/javascripts/templates/connectors/user-custom-preferences/region.hbs
+++ b/assets/javascripts/templates/connectors/user-custom-preferences/region.hbs
@@ -4,7 +4,6 @@
     {{region-input
       value=model.custom_fields.holidays-region
       onChange=(action "onChange")
-      class="input-xxlarge"
     }}
   </div>
   {{d-button icon="globe" label="discourse_calendar.region.use_current_region" action=(action "useCurrentRegion") }}

--- a/assets/stylesheets/common/user-preferences.scss
+++ b/assets/stylesheets/common/user-preferences.scss
@@ -1,0 +1,5 @@
+.user-preferences {
+  .region details {
+    min-width: 175px;
+  }
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -31,6 +31,7 @@ register_asset 'stylesheets/mobile/discourse-calendar.scss', :mobile
 register_asset 'stylesheets/mobile/discourse-post-event.scss', :mobile
 register_asset 'stylesheets/desktop/discourse-calendar.scss', :desktop
 register_asset 'stylesheets/colors.scss', :color_definitions
+register_asset 'stylesheets/common/user-preferences.scss'
 register_svg_icon 'fas fa-calendar-day'
 register_svg_icon 'fas fa-clock'
 register_svg_icon 'fas fa-file-csv'


### PR DESCRIPTION
Reduce size of user region preferences

Before
<img width="597" alt="Screen Shot 2021-10-05 at 11 53 42 am" src="https://user-images.githubusercontent.com/72780/135944315-24b0731a-bf91-463a-bcaf-3ac231707ee6.png">

After
<img width="382" alt="Screen Shot 2021-10-05 at 11 52 53 am" src="https://user-images.githubusercontent.com/72780/135944324-257fb8e3-7f8b-4c92-a315-f961707e51b4.png">
