### PR TITLE
UX: Fix date field overlap

### DIFF
--- a/assets/stylesheets/common/discourse-post-event-builder.scss
+++ b/assets/stylesheets/common/discourse-post-event-builder.scss
@@ -54,6 +54,7 @@
       .d-date-input {
         box-sizing: border-box;
         flex: 0;
+        min-width: unset;
 
         .date-picker {
           width: 155px;
@@ -159,7 +160,6 @@
 
         input[type="radio"] {
           width: auto;
-          margin-right: 0.5em;
         }
 
         .message {


### PR DESCRIPTION
Before/After
<img width="280" alt="Screen Shot 2021-10-12 at 12 07 05" src="https://user-images.githubusercontent.com/66961/136937428-fb128a54-526f-4ca5-9103-36eeceec42ee.png"> <img width="280" alt="Screen Shot 2021-10-12 at 12 07 35" src="https://user-images.githubusercontent.com/66961/136937417-7aca0e30-b702-4275-957d-b1f7e7e9b1cb.png">

(and reduce a double margin on radio inputs 🤫)