### PR TITLE
FIX: Two week recurring events not working

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -348,6 +348,8 @@ module DiscoursePostEvent
         recurrence = "FREQ=MONTHLY;BYDAY=#{count}#{weekday.upcase[0, 2]}"
       when 'every_weekday'
         recurrence = 'FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR'
+      when 'every_two_weeks'
+        recurrence = "FREQ=WEEKLY;INTERVAL=2;"
       else
         byday = original_starts_at.strftime('%A').upcase[0, 2]
         recurrence = "FREQ=WEEKLY;BYDAY=#{byday}"

--- a/assets/javascripts/discourse/controllers/discourse-post-event-builder.js.es6
+++ b/assets/javascripts/discourse/controllers/discourse-post-event-builder.js.es6
@@ -43,6 +43,12 @@ export default Controller.extend(ModalFunctionality, {
           "discourse_post_event.builder_modal.recurrence.every_week"
         ),
       },
+      {
+        id: "every_two_weeks",
+        name: I18n.t(
+          "discourse_post_event.builder_modal.recurrence.every_two_weeks"
+        ),
+      },
     ]);
   },
 

--- a/lib/discourse_post_event/rrule_generator.rb
+++ b/lib/discourse_post_event/rrule_generator.rb
@@ -3,7 +3,7 @@
 require 'rrule'
 
 class RRuleGenerator
-  def self.generate(base_rrule, starts_at)
+  def self.generate(base_rrule, starts_at, interval = nil)
     rrule = generate_hash(base_rrule)
     rrule = set_mandatory_options(rrule, starts_at)
 
@@ -28,7 +28,7 @@ class RRuleGenerator
   def self.set_mandatory_options(rrule, time)
     rrule['BYHOUR'] = time.strftime('%H')
     rrule['BYMINUTE'] = time.strftime('%M')
-    rrule['INTERVAL'] = 1
+    rrule['INTERVAL'] ||= 1
     rrule['WKST'] = 'MO' # considers Monday as the first day of the week
     rrule
   end

--- a/spec/acceptance/recurrence_spec.rb
+++ b/spec/acceptance/recurrence_spec.rb
@@ -42,6 +42,18 @@ describe 'discourse_post_event_recurrence' do
     end
   end
 
+  context 'every_two_weeks' do
+    before do
+      post_event_1.update!(recurrence: 'every_two_weeks')
+    end
+
+    it 'sets in two weeks at the same weekday' do
+      post_event_1.set_next_date
+
+      expect(post_event_1.starts_at).to eq_time(Time.zone.parse('2020-09-24 19:00'))
+    end
+  end
+
   context 'every_day' do
     before do
       post_event_1.update!(recurrence: 'every_day')


### PR DESCRIPTION
- Update `discourse_post_event` with a recurring case of `'every_two_weeks'`, with corresponding test. 
- Update `rrule_generator` to allow you to pass a custom recurring interval

Two week recurring events now work as expected.