### PR TITLE
FIX: Remove unused RRuleGenerator param

### DIFF
--- a/lib/discourse_post_event/rrule_generator.rb
+++ b/lib/discourse_post_event/rrule_generator.rb
@@ -3,7 +3,7 @@
 require 'rrule'
 
 class RRuleGenerator
-  def self.generate(base_rrule, starts_at, interval = nil)
+  def self.generate(base_rrule, starts_at)
     rrule = generate_hash(base_rrule)
     rrule = set_mandatory_options(rrule, starts_at)
 


### PR DESCRIPTION
Per @ZogStriP's [comment](https://github.com/discourse/discourse-calendar/pull/180#discussion_r729895168), remove the unused param of `interval`