### PR TITLE
DEV: Change background job frequency from 10min to 1min

### DIFF
--- a/jobs/scheduled/monitor_event_dates.rb
+++ b/jobs/scheduled/monitor_event_dates.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class ::DiscourseCalendar::MonitorEventDates < ::Jobs::Scheduled
-    every 10.minutes
+    every 1.minute
 
     def execute(args)
       DiscoursePostEvent::EventDate.pending.find_each do |event_date|


### PR DESCRIPTION
We need to increase how often background jobs run so that event
reminders like a "5min before" reminder aren't significantly delayed
or sent out after an event has started.