### PR TITLE
FEATURE: Re-use existing invite and reminders notifications.

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -187,7 +187,7 @@ module DiscoursePostEvent
           'discourse_post_event.notifications.invite_user_notification'
         end
 
-      user.notifications.create!(
+      attrs = {
         notification_type: Notification.types[:event_invitation] || Notification.types[:custom],
         topic_id: post.topic_id,
         post_number: post.post_number,
@@ -196,7 +196,11 @@ module DiscoursePostEvent
           display_username: post.user.username,
           message: message
         }.to_json
-      )
+      }
+
+      # TODO(Roman): Use #consolidate_or_create! after the 2.8 release.
+      method = Notification.respond_to?(:consolidate_or_create!) ? :consolidate_or_create! : :create!
+      user.notifications.public_send(method, attrs)
     end
 
     def ongoing?

--- a/jobs/regular/discourse_post_event/send_reminder.rb
+++ b/jobs/regular/discourse_post_event/send_reminder.rb
@@ -47,7 +47,7 @@ module Jobs
       end
 
       invitees.find_each do |invitee|
-        invitee.user.notifications.create!(
+        attrs = {
           notification_type: Notification.types[:event_reminder] || Notification.types[:custom],
           topic_id: event.post.topic_id,
           post_number: event.post.post_number,
@@ -56,7 +56,11 @@ module Jobs
             display_username: invitee.user.username,
             message: "discourse_post_event.notifications.#{prefix}_event_reminder"
           }.to_json
-        )
+        }
+
+        # TODO(Roman): Use #consolidate_or_create! after the 2.8 release.
+        method = Notification.respond_to?(:consolidate_or_create!) ? :consolidate_or_create! : :create!
+        invitee.user.notifications.public_send(method, attrs)
 
         PostAlerter.new(event.post).create_notification_alert(
           user: invitee.user,

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -10,7 +10,7 @@ task 'javascript:update_constants' => :environment do
   holiday_regions = Holidays.available_regions.map(&:to_s) - UNUSED_REGIONS
 
   time_zone_to_region = {}
-  data = JSON.parse(URI.open(TIMEZONES_DEFINITIONS).read)
+  data = JSON.parse(URI.parse(TIMEZONES_DEFINITIONS).open.read)
   data['zones'].each do |timezone, timezone_data|
     country_code = timezone_data['countries'].first.downcase
     if HOLIDAYS_COUNTRY_OVERRIDES.include?(country_code)

--- a/plugin.rb
+++ b/plugin.rb
@@ -616,4 +616,26 @@ after_initialize do
       end
     end
   end
+
+  # TODO(Roman): Remove #respond_to? after the 2.8 release.
+  if respond_to?(:register_notification_consolidation_plan)
+    query = ->(notifications, data) do
+      notifications
+        .where("data::json ->> 'topic_title' = ?", data[:topic_title].to_s)
+        .where("data::json ->> 'message' = ?", data[:message].to_s)
+    end
+
+    reminders_consolidation_plan = Notifications::DeletePreviousNotifications.new(
+      type: Notification.types[:event_reminder],
+      previous_query_blk: query
+    )
+
+    invitation_consolidation_plan = Notifications::DeletePreviousNotifications.new(
+      type: Notification.types[:event_invitation],
+      previous_query_blk: query
+    )
+
+    register_notification_consolidation_plan(reminders_consolidation_plan)
+    register_notification_consolidation_plan(invitation_consolidation_plan)
+  end
 end

--- a/spec/acceptance/recurrence_spec.rb
+++ b/spec/acceptance/recurrence_spec.rb
@@ -18,6 +18,17 @@ describe 'discourse_post_event_recurrence' do
     SiteSetting.discourse_post_event_enabled = true
   end
 
+  it 'delete previous notifications before creating a new one for invites' do
+    going_user = Fabricate(:user)
+    Invitee.create_attendance!(going_user.id, post_event_1.id, :going)
+    post_event_1.update!(recurrence: 'every_month')
+
+    post_event_1.set_next_date
+    post_event_1.set_next_date
+
+    expect(going_user.notifications.where(notification_type: Notification.types[:event_invitation]).count).to eq(1)
+  end
+
   context 'every_month' do
     before do
       post_event_1.update!(recurrence: 'every_month')


### PR DESCRIPTION
Delete previous notifications of recurring events before creating a new one.