### PR TITLE
FEATURE: Show category/sub-category events on calendar category header (add eventsFromCategory parameter in categorySetting of admin plugin settings)

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -115,7 +115,7 @@ module DiscoursePostEvent
     end
 
     def filtered_events_params
-      params.permit(:post_id)
+      params.permit(:post_id, :category_id, :include_subcategories)
     end
   end
 end

--- a/app/serializers/discourse_post_event/event_serializer.rb
+++ b/app/serializers/discourse_post_event/event_serializer.rb
@@ -71,7 +71,8 @@ module DiscoursePostEvent
         url: object.post.url,
         topic: {
           id: object.post.topic.id,
-          title: object.post.topic.title
+          title: object.post.topic.title,
+          category_id: object.post.topic.category_id
         }
       }
     end


### PR DESCRIPTION
### Add eventsFromCategory feature from categorySetting
Commit : f786cc159421966dc2c8e67e4e5604e228d9c159
 This add parameter to 'categorySetting' in /admin/site_settings/category/all_results?filter=plugin%3Adiscourse-calendar
 example : categoryId=4;eventsFromCategory=4
This parameter add a calendar to the top of the 'categoryId' page, and fetch all events in the 'eventsFromCategory' category and sub category

![image](https://user-images.githubusercontent.com/5228655/146450017-6ed241a0-c520-427f-97e3-d933abeedd95.png)
![image](https://user-images.githubusercontent.com/5228655/146450131-37a0014e-464e-468f-b990-4618c4d4db05.png)
Events is in topics of the category and sub-caegory.
(In future, maybe the option 'eventsFromCategory' can take an array of categoryID, and an option to not use sub-categories)
