### PR TITLE
FEATURE: Show all events in past (add deleted_at in discourse_calendar_post_event_dates) + add show_past_event in settings

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -115,7 +115,8 @@ module DiscoursePostEvent
     end
 
     def filtered_events_params
-      params.permit(:post_id)
+      # Http params permited
+      params.permit(:post_id, :after, :before, :deleted)
     end
   end
 end

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -36,7 +36,7 @@ module DiscoursePostEvent
       return if !starts_at_changed && !ends_at_changed
 
       # One of date changed => Must delete the event_date and create new event_date on this event
-      event_dates.update_all(delete_at: Time.current)
+      event_dates.update_all(deleted_at: Time.current)
       set_next_date
     end
 

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -32,9 +32,11 @@ module DiscoursePostEvent
       starts_at_changed = saved_change_to_original_starts_at
       ends_at_changed = saved_change_to_original_ends_at
 
+      # No one of date changed => Must keep the event
       return if !starts_at_changed && !ends_at_changed
 
-      event_dates.update_all(finished_at: Time.current)
+      # One of date changed => Must delete the event_date and create new event_date on this event
+      event_dates.update_all(delete_at: Time.current)
       set_next_date
     end
 

--- a/app/models/discourse_post_event/event_date.rb
+++ b/app/models/discourse_post_event/event_date.rb
@@ -5,9 +5,9 @@ module DiscoursePostEvent
     self.table_name = 'discourse_calendar_post_event_dates'
     belongs_to :event
 
-    scope :pending, -> { where('delete_at IS NULL AND finished_at IS NULL') }
-    scope :expired, -> { where('delete_at IS NULL AND ends_at IS NOT NULL AND ends_at < ?', Time.now) }
-    scope :not_expired, -> { where('delete_at IS NULL AND (ends_at IS NULL OR ends_at > ?)', Time.now) }
+    scope :pending, -> { where('deleted_at IS NULL AND finished_at IS NULL') }
+    scope :expired, -> { where('deleted_at IS NULL AND ends_at IS NOT NULL AND ends_at < ?', Time.now) }
+    scope :not_expired, -> { where('deleted_at IS NULL AND (ends_at IS NULL OR ends_at > ?)', Time.now) }
 
     after_commit :upsert_topic_custom_field, on: %i[create]
     def upsert_topic_custom_field
@@ -60,6 +60,7 @@ end
 #  event_id                 :integer
 #  starts_at                :datetime
 #  ends_at                  :datetime
+#  deleted_at                :datetime
 #  reminder_counter         :integer          default(0)
 #  event_will_start_sent_at :datetime
 #  event_started_sent_at    :datetime

--- a/app/models/discourse_post_event/event_date.rb
+++ b/app/models/discourse_post_event/event_date.rb
@@ -5,9 +5,9 @@ module DiscoursePostEvent
     self.table_name = 'discourse_calendar_post_event_dates'
     belongs_to :event
 
-    scope :pending, -> { where(finished_at: nil) }
-    scope :expired, -> { where('ends_at IS NOT NULL AND ends_at < ?', Time.now) }
-    scope :not_expired, -> { where('ends_at IS NULL OR ends_at > ?', Time.now) }
+    scope :pending, -> { where('delete_at IS NULL AND finished_at IS NULL') }
+    scope :expired, -> { where('delete_at IS NULL AND ends_at IS NOT NULL AND ends_at < ?', Time.now) }
+    scope :not_expired, -> { where('delete_at IS NULL AND (ends_at IS NULL OR ends_at > ?)', Time.now) }
 
     after_commit :upsert_topic_custom_field, on: %i[create]
     def upsert_topic_custom_field

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,9 @@ discourse_calendar:
   calendar_enabled:
     default: false
     client: true
+  show_past_events:
+    default: false
+    client: true
   holiday_calendar_topic_id:
     default: ""
     client: true

--- a/db/migrate/20211211094100_add_date_delete_to_post_event_dates.rb
+++ b/db/migrate/20211211094100_add_date_delete_to_post_event_dates.rb
@@ -2,11 +2,11 @@
 
 class AddDateDeleteToPostEventDates < ActiveRecord::Migration[6.0]
   def up
-    add_column :discourse_calendar_post_event_dates, :delete_at, :datetime
-    add_index :discourse_calendar_post_event_dates, :delete_at
+    add_column :discourse_calendar_post_event_dates, :deleted_at, :datetime
+    add_index :discourse_calendar_post_event_dates, :deleted_at
   end
 
   def down
-    remove_column :discourse_calendar_post_event_dates, :delete_at
+    remove_column :discourse_calendar_post_event_dates, :deleted_at
   end
 end

--- a/db/migrate/20211211094100_add_date_delete_to_post_event_dates.rb
+++ b/db/migrate/20211211094100_add_date_delete_to_post_event_dates.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddDateDeleteToPostEventDates < ActiveRecord::Migration[6.0]
+  def up
+    add_column :discourse_calendar_post_event_dates, :delete_at, :datetime
+    add_index :discourse_calendar_post_event_dates, :delete_at
+  end
+
+  def down
+    remove_column :discourse_calendar_post_event_dates, :delete_at
+  end
+end

--- a/db/migrate/20211211224500_update_date_delete_from_finish_at.rb
+++ b/db/migrate/20211211224500_update_date_delete_from_finish_at.rb
@@ -2,8 +2,8 @@
 
 class UpdateDateDeleteFromFinishAt < ActiveRecord::Migration[6.0]
   def up
-    execute "update discourse_calendar_post_event_dates SET delete_at = now() WHERE finished_at is not NULL;
-UPDATE discourse_calendar_post_event_dates SET delete_at = NULL
+    execute "update discourse_calendar_post_event_dates SET deleted_at = now() WHERE finished_at is not NULL;
+UPDATE discourse_calendar_post_event_dates SET deleted_at = NULL
 FROM  (
 	SELECT DISTINCT ON (event_id)
 		   id

--- a/db/migrate/20211211224500_update_date_delete_from_finish_at.rb
+++ b/db/migrate/20211211224500_update_date_delete_from_finish_at.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UpdateDateDeleteFromFinishAt < ActiveRecord::Migration[6.0]
+  def up
+    execute "update discourse_calendar_post_event_dates SET delete_at = now() WHERE finished_at is not NULL;
+UPDATE discourse_calendar_post_event_dates SET delete_at = NULL
+FROM  (
+	SELECT DISTINCT ON (event_id)
+		   id
+	FROM  discourse_calendar_post_event_dates
+	where finished_at is not null
+	ORDER  BY event_id, updated_at DESC
+) AS sq
+WHERE  discourse_calendar_post_event_dates.id=sq.id;"
+  end
+end

--- a/lib/discourse_post_event/event_finder.rb
+++ b/lib/discourse_post_event/event_finder.rb
@@ -21,7 +21,11 @@ module DiscoursePostEvent
           .where("dcped.finished_at IS NOT NULL AND (dcped.ends_at IS NOT NULL AND dcped.ends_at < ?)", Time.now)
           .where("discourse_post_event_events.id NOT IN (SELECT DISTINCT event_id FROM discourse_calendar_post_event_dates WHERE event_id = discourse_post_event_events.id AND finished_at IS NULL)")
       else
-        events = events.where("dcped.finished_at IS NULL AND (dcped.ends_at IS NULL OR dcped.ends_at > ?)", Time.now)
+        if SiteSetting.show_past_events
+          events = events.where("dcped.delete_at IS NULL")
+        else
+          events = events.where("dcped.delete_at IS NULL AND ((dcped.ends_at IS NOT NULL AND dcped.ends_at > ?) OR (dcped.ends_at IS NULL AND dcped.starts_at > ?))", Time.now,  Time.now)
+        end
       end
 
       if params[:post_id]


### PR DESCRIPTION
### Add delete_at in discourse_calendar_post_event_dates and show all events in past + add show_past_event in plugin settings
commit 1d27f67fc68820f4ffb21e82761f71763eff0c79
 - Add delete_at to separate concept of finish_at
 - Add  show_past_event in admin plugin
![image](https://user-images.githubusercontent.com/5228655/146450381-df48901b-4cf4-468b-ab73-df299949a599.png)
![image](https://user-images.githubusercontent.com/5228655/146623373-5842d349-9717-46a5-9ac1-6e9801d55a01.png)

 - I make migration sql queries.
 - translation of admin option is missing