### PR TITLE
DEV: Use uppy mixins for CSV uploader

### DIFF
--- a/assets/javascripts/discourse/components/csv-uploader.js.es6
+++ b/assets/javascripts/discourse/components/csv-uploader.js.es6
@@ -1,15 +1,15 @@
 import Component from "@ember/component";
 import I18n from "I18n";
-import UploadMixin from "discourse/mixins/upload";
+import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import bootbox from "bootbox";
 import discourseComputed from "discourse-common/utils/decorators";
-import { on } from "@ember/object/evented";
 
-export default Component.extend(UploadMixin, {
+export default Component.extend(UppyUploadMixin, {
   type: "csv",
   tagName: "span",
   uploadUrl: null,
   i18nPrefix: null,
+  autoStartUploads: false,
 
   validateUploadedFilesOptions() {
     return { csvOnly: true };
@@ -20,30 +20,24 @@ export default Component.extend(UploadMixin, {
     return uploading ? I18n.t("uploading") : I18n.t(`${this.i18nPrefix}.text`);
   },
 
-  @discourseComputed("uploading")
-  uploadButtonDisabled(uploading) {
+  @discourseComputed("uploading", "processing")
+  uploadButtonDisabled(uploading, processing) {
     // https://github.com/emberjs/ember.js/issues/10976#issuecomment-132417731
-    return uploading ? true : null;
+    return uploading || processing ? true : null;
   },
 
   uploadDone() {
     bootbox.alert(I18n.t(`${this.i18nPrefix}.success`));
   },
 
-  uploadOptions() {
-    return { autoUpload: false };
-  },
-
-  _init: on("didInsertElement", function () {
-    const $upload = $(this.element);
-
-    $upload.on("fileuploadadd", (e, data) => {
+  _uppyReady() {
+    this._uppyInstance.on("file-added", () => {
       bootbox.confirm(
         I18n.t(`${this.i18nPrefix}.confirmation_message`),
         I18n.t("cancel"),
-        I18n.t("go_ahead"),
-        (result) => (result ? data.submit() : data.abort())
+        I18n.t(`${this.i18nPrefix}.confirm`),
+        (result) => (result ? this._startUpload() : this._reset())
       );
     });
-  }),
+  },
 });

--- a/assets/javascripts/discourse/templates/components/csv-uploader.hbs
+++ b/assets/javascripts/discourse/templates/components/csv-uploader.hbs
@@ -2,6 +2,6 @@
   {{d-icon "upload"}}&nbsp;{{uploadButtonText}}
   <input class="hidden-upload-field" disabled={{uploading}} type="file" accept=".csv">
 </label>
-{{#if uploading}}
+{{#if (or uploading processing)}}
   <span>{{i18n "upload_selector.uploading"}} {{uploadProgress}}%</span>
 {{/if}}

--- a/assets/javascripts/discourse/templates/modal/discourse-post-event-bulk-invite.hbs
+++ b/assets/javascripts/discourse/templates/modal/discourse-post-event-bulk-invite.hbs
@@ -62,6 +62,7 @@
       {{bulk-invite-sample-csv-file}}
 
       {{csv-uploader
+        id="discourse-post-event-csv-uploader"
         uploadUrl=(concat "/discourse-post-event/events/" model.eventModel.id "/csv-bulk-invite")
         i18nPrefix="discourse_post_event.bulk_invite_modal"
         uploading=uploading

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -334,6 +334,7 @@ en:
         title_participated: "List of users who participated"
         filter_placeholder: "Filter users"
       bulk_invite_modal:
+        confirm: "confirm"
         text: "Upload CSV file"
         title: "Bulk Invite"
         success: "File uploaded successfully, you will be notified via message when the process is complete."


### PR DESCRIPTION
This commit removes usage of the old upload mixin
and direct hooks into jQuery file upload, which we
are removing in core.

https://github.com/discourse/discourse/pull/15361 must
be merged before this.