### PR TITLE
FEATURE: fullDay calendar option

### DIFF
--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -34,6 +34,7 @@ class CalendarEvent < ActiveRecord::Base
 
     description = PrettyText.excerpt(html, 1000, strip_links: true, text_entities: true, keep_emoji_images: true)
     recurrence = dates[0]['recurring'].presence
+    timezone = dates[0]['timezone'].presence
 
     CalendarEvent.create!(
       topic_id: post.topic_id,
@@ -44,7 +45,8 @@ class CalendarEvent < ActiveRecord::Base
       description: description,
       start_date: from,
       end_date: to,
-      recurrence: recurrence
+      recurrence: recurrence,
+      timezone: timezone
     )
 
     post.publish_change_to_clients!(:calendar_change)
@@ -86,6 +88,7 @@ end
 #  region      :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  timezone    :string
 #
 # Indexes
 #

--- a/assets/javascripts/initializers/discourse-calendar.js.es6
+++ b/assets/javascripts/initializers/discourse-calendar.js.es6
@@ -137,12 +137,13 @@ function initializeDiscourseCalendar(api) {
     const timezone = _getTimeZone($calendar, api.getCurrentUser());
     const calendar = _buildCalendar($calendar, timezone);
     const isStatic = $calendar.attr("data-calendar-type") === "static";
+    const fullDay = $calendar.attr("data-calendar-full-day") === "true";
 
     if (isStatic) {
       calendar.render();
       _setStaticCalendarEvents(calendar, $calendar, post);
     } else {
-      _setDynamicCalendarEvents(calendar, $calendar, post, siteSettings);
+      _setDynamicCalendarEvents(calendar, post, siteSettings, fullDay);
       calendar.render();
       _setDynamicCalendarOptions(calendar, $calendar);
     }
@@ -434,10 +435,8 @@ function initializeDiscourseCalendar(api) {
     calendar.addEvent(event);
   }
 
-  function _setDynamicCalendarEvents(calendar, $calendar, post, siteSettings) {
+  function _setDynamicCalendarEvents(calendar, post, siteSettings, fullDay) {
     const groupedEvents = [];
-
-    const fullDay = $calendar.attr("data-calendar-full-day") === "true";
 
     (post.calendar_details || []).forEach((detail) => {
       switch (detail.type) {

--- a/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-calendar.js.es6
@@ -46,6 +46,13 @@ const calendarRule = {
       ]);
     }
 
+    if (info.attrs.fullDay) {
+      mainCalendarDivToken.attrs.push([
+        "data-calendar-full-day",
+        info.attrs.fullDay === "true",
+      ]);
+    }
+
     if (info.attrs.hiddenDays) {
       mainCalendarDivToken.attrs.push([
         "data-hidden-days",

--- a/db/migrate/20211216124303_add_timezone_to_calendar_events.rb
+++ b/db/migrate/20211216124303_add_timezone_to_calendar_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimezoneToCalendarEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :calendar_events, :timezone, :string
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -416,7 +416,8 @@ after_initialize do
           to: event.end_date,
           username: event.username,
           recurring: event.recurrence,
-          post_url: Post.url("-", event.topic_id, event.post_number)
+          post_url: Post.url("-", event.topic_id, event.post_number),
+          timezone: event.timezone
         }
       else
         identifier = "#{event.region.split("_").first}-#{event.start_date.strftime("%j")}"


### PR DESCRIPTION
Allow calendar to disrespect timezones and always display full day for standalone and group events.

Standalone events are saved in specific timezone: https://github.com/discourse/discourse-calendar/blob/main/app/models/calendar_event.rb#L62

However, we don't store information about timezone. It is essential to have that information to calculate date properly. Therefore, a new column was added.