### PR TITLE
Prevent table overflow

### DIFF
--- a/assets/stylesheets/desktop/discourse-calendar.scss
+++ b/assets/stylesheets/desktop/discourse-calendar.scss
@@ -1,4 +1,7 @@
 .calendar {
+  table {
+    width: 100%;
+  }
   .fc-list-item-add-to-calendar {
     float: right;
     margin-right: 5px;


### PR DESCRIPTION
When you zoom in on a browser (safari only) it would manipulate the width of the tables causing the browser to read the table as 'overflown' which would trigger the `expand table` option. Ensure that the table keeps a width of 100% to prevent this from happening. No adverse reactions found in testing new change.