### PR TITLE
DEV: Add Lundi Gras to Louisiana calendar

### DIFF
--- a/vendor/holidays/definitions/us.yaml
+++ b/vendor/holidays/definitions/us.yaml
@@ -77,6 +77,10 @@ months:
     regions: [us_la]
     function: easter(year)
     function_modifier: -47
+  - name: Lundi Gras # most businesses closed in southern louisiana
+    regions: [us_la]
+    function: easter(year)
+    function_modifier: -48
   - name: Good Friday # informal in general
     regions: [us]
     function: easter(year)


### PR DESCRIPTION
Since most businesses are closed for Lundi Gras in South Louisiana, I am adding it to the Discourse Calendar plugin for the `us_la` region.