### PR TITLE
FIX: `.calendar` selector was too broad

### DIFF
--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -12,7 +12,7 @@
   display: table-caption;
 }
 
-.calendar {
+.discourse-calendar .calendar {
   height: 645px; // Must be fixed to prevent height change on load
   border: 0;
 

--- a/assets/stylesheets/desktop/discourse-calendar.scss
+++ b/assets/stylesheets/desktop/discourse-calendar.scss
@@ -1,4 +1,4 @@
-.calendar {
+.discourse-calendar .calendar {
   table {
     width: 100%;
   }


### PR DESCRIPTION
…and collided with other elements, e.g. a calendar emoji in chat message menu