### PR TITLE
UX: Make the event text colors more readable

### DIFF
--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -9,22 +9,11 @@ import { ajax } from "discourse/lib/ajax";
 import { hidePopover, showPopover } from "discourse/lib/d-popover";
 import Category from "discourse/models/category";
 import I18n from "I18n";
-
-// https://stackoverflow.com/a/16348977
-function stringToHexColor(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    // eslint-disable-next-line no-bitwise
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  let hex = "#";
-  for (let i = 0; i < 3; i++) {
-    // eslint-disable-next-line no-bitwise
-    let value = (hash >> (i * 8)) & 0xff;
-    hex += ("00" + value.toString(16)).slice(-2);
-  }
-  return hex;
-}
+import {
+  colorToHex,
+  contrastColor,
+  stringToColor,
+} from "discourse/plugins/discourse-calendar/lib/colors";
 
 function loadFullCalendar() {
   return loadScript(
@@ -379,8 +368,11 @@ function initializeDiscourseCalendar(api) {
       event.title = text[0];
       event.extendedProps.description = text.slice(1).join(" ");
     } else {
+      const color = stringToColor(detail.username);
+
       event.title = detail.username;
-      event.backgroundColor = stringToHexColor(detail.username);
+      event.backgroundColor = colorToHex(color);
+      event.textColor = colorToHex(contrastColor(color));
     }
 
     let popupText = detail.message.substr(0, 50);

--- a/assets/javascripts/lib/colors.js
+++ b/assets/javascripts/lib/colors.js
@@ -1,0 +1,34 @@
+// https://stackoverflow.com/a/16348977
+export function stringToColor(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    // eslint-disable-next-line no-bitwise
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  let color = [];
+  for (let i = 0; i < 3; i++) {
+    // eslint-disable-next-line no-bitwise
+    let value = (hash >> (i * 8)) & 0xff;
+    color.push(value);
+  }
+  return color;
+}
+
+export function colorToHex(color) {
+  let hex = "#";
+  for (let i = 0; i < 3; i++) {
+    hex += ("00" + Math.round(color[i]).toString(16)).slice(-2);
+  }
+  return hex;
+}
+
+export function contrastColor(color) {
+  const luminance = 0.2126 * color[0] + 0.7152 * color[1] + 0.0722 * color[2];
+  const multiplier = luminance >= 128 ? 0.25 : 4.0;
+
+  return [
+    Math.min(Math.max(multiplier * color[0], 0), 255),
+    Math.min(Math.max(multiplier * color[1], 0), 255),
+    Math.min(Math.max(multiplier * color[2], 0), 255),
+  ];
+}


### PR DESCRIPTION
It's not ideal, but at least should handle worst cases.

Before / After

<img width="326" alt="Screen Shot 2022-02-10 at 22 30 36" src="https://user-images.githubusercontent.com/66961/153504222-fd1f02d3-a092-4e06-9735-1fb8a4b133be.png"> <img width="326" alt="Screen Shot 2022-02-10 at 23 02 17" src="https://user-images.githubusercontent.com/66961/153504232-4dc9233b-42c9-4535-862e-f5f485337017.png">
