### PR TITLE
FIX: enforces the value of recurrence

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -10,6 +10,8 @@ module DiscoursePostEvent
 
     has_many :event_dates, dependent: :destroy
 
+    before_validation :enforce_recurrence
+
     def self.attributes_protected_by_default
       super - %w[id]
     end
@@ -364,6 +366,22 @@ module DiscoursePostEvent
       next_ends_at = next_starts_at + difference.seconds
 
       { starts_at: next_starts_at, ends_at: next_ends_at }
+    end
+
+    private
+
+    def enforce_recurrence
+      valid_recurrences = %w[
+        every_month
+        every_week
+        every_two_weeks
+        every_day
+        every_weekday
+      ]
+
+      if self.recurrence.present? && !valid_recurrences.include?(self.recurrence)
+        self.recurrence = 'every_week'
+      end
     end
   end
 end

--- a/spec/models/discourse_post_event/event_spec.rb
+++ b/spec/models/discourse_post_event/event_spec.rb
@@ -387,4 +387,24 @@ describe DiscoursePostEvent::Event do
       expect(event_1.missing_users.pluck(:id)).to match_array([user_1.id, user_2.id])
     end
   end
+
+  context 'setting recurrence' do
+    fab!(:post_1) { Fabricate(:post) }
+    fab!(:event_1) { Fabricate(:event, post: post_1, recurrence: 'every_week') }
+
+    it 'forces the value of an invalid recurrence' do
+      event_1.update!(recurrence: 'foo')
+      expect(event_1.recurrence).to eq('every_week')
+    end
+
+    it 'doesn’t force the value of an empty recurrence' do
+      event_1.update!(recurrence: nil)
+      expect(event_1.recurrence).to eq(nil)
+    end
+
+    it 'doesn’t force the value of a valid recurrence' do
+      event_1.update!(recurrence: 'every_two_weeks')
+      expect(event_1.recurrence).to eq('every_two_weeks')
+    end
+  end
 end


### PR DESCRIPTION
Due to the fact we do this in :post_process_cooked it's easier to ensure no invalid value is set rather than showing some error in the UI as it will be too late.