### PR TITLE
FIX: ensures client is sending UTC to backend

### DIFF
--- a/assets/javascripts/discourse/controllers/discourse-post-event-builder.js
+++ b/assets/javascripts/discourse/controllers/discourse-post-event-builder.js
@@ -120,15 +120,16 @@ export default Controller.extend(ModalFunctionality, {
   startsAt: computed("model.eventModel.starts_at", {
     get() {
       return this.model.eventModel.starts_at
-        ? moment(this.model.eventModel.starts_at)
-        : moment();
+        ? moment.utc(this.model.eventModel.starts_at)
+        : moment().utcOffset(0, true);
     },
   }),
 
   endsAt: computed("model.eventModel.ends_at", {
     get() {
       return (
-        this.model.eventModel.ends_at && moment(this.model.eventModel.ends_at)
+        this.model.eventModel.ends_at &&
+        moment.utc(this.model.eventModel.ends_at)
       );
     },
   }),
@@ -140,8 +141,8 @@ export default Controller.extend(ModalFunctionality, {
   @action
   onChangeDates(changes) {
     this.model.eventModel.setProperties({
-      starts_at: changes.from,
-      ends_at: changes.to,
+      starts_at: changes.from?.tz("utc", true),
+      ends_at: changes.to?.tz("utc", true),
     });
   },
 

--- a/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
+++ b/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
@@ -12,6 +12,14 @@
         onChange=(action "onChangeDates")
       }}
 
+      {{#event-field class="timezone" label="discourse_post_event.builder_modal.timezone.label"}}
+        {{timezone-input
+          value=model.eventModel.timezone
+          onChange=(action (mut model.eventModel.timezone))
+          none="discourse_post_event.builder_modal.timezone.remove_timezone"
+        }}
+      {{/event-field}}
+
       {{#event-field class="name" label="discourse_post_event.builder_modal.name.label"}}
         {{input
           value=(readonly model.eventModel.name)
@@ -25,15 +33,6 @@
           value=(readonly model.eventModel.url)
           placeholderKey="discourse_post_event.builder_modal.url.placeholder"
           input=(action (mut model.eventModel.url) value="target.value")
-        }}
-      {{/event-field}}
-
-      {{#event-field class="timezone" label="discourse_post_event.builder_modal.timezone.label"}}
-        {{timezone-input
-          value=model.eventModel.timezone
-          onChange=(action (mut model.eventModel.timezone))
-          class="input-xxlarge"
-          none="discourse_post_event.builder_modal.timezone.remove_timezone"
         }}
       {{/event-field}}
 

--- a/assets/javascripts/initializers/add-event-ui-builder.js
+++ b/assets/javascripts/initializers/add-event-ui-builder.js
@@ -39,6 +39,7 @@ function initializeEventBuilder(api) {
         );
         eventModel.set("status", "public");
         eventModel.set("custom_fields", {});
+        eventModel.set("timezone", moment.tz.guess());
 
         showModal("discourse-post-event-builder").setProperties({
           toolbarEvent: this.toolbarEvent,

--- a/assets/javascripts/lib/raw-event-helper.js
+++ b/assets/javascripts/lib/raw-event-helper.js
@@ -1,10 +1,18 @@
 export function buildParams(startsAt, endsAt, eventModel, siteSettings) {
   const params = {};
 
+  if (eventModel.timezone) {
+    params.timezone = eventModel.timezone;
+  }
+
   if (startsAt) {
-    params.start = moment(startsAt).utc().format("YYYY-MM-DD HH:mm");
+    params.start = moment(startsAt)
+      .tz(eventModel.timezone || "UTC", true)
+      .format("YYYY-MM-DD HH:mm");
   } else {
-    params.start = moment().utc().format("YYYY-MM-DD HH:mm");
+    params.start = moment()
+      .tz(eventModel.timezone || "UTC", true)
+      .format("YYYY-MM-DD HH:mm");
   }
 
   if (eventModel.status) {
@@ -19,16 +27,14 @@ export function buildParams(startsAt, endsAt, eventModel, siteSettings) {
     params.url = eventModel.url;
   }
 
-  if (eventModel.timezone) {
-    params.timezone = eventModel.timezone;
-  }
-
   if (eventModel.recurrence) {
     params.recurrence = eventModel.recurrence;
   }
 
   if (endsAt) {
-    params.end = moment(endsAt).utc().format("YYYY-MM-DD HH:mm");
+    params.end = moment(endsAt)
+      .tz(eventModel.timezone || "UTC", true)
+      .format("YYYY-MM-DD HH:mm");
   }
 
   if (eventModel.status === "private") {

--- a/assets/stylesheets/common/discourse-post-event-builder.scss
+++ b/assets/stylesheets/common/discourse-post-event-builder.scss
@@ -1,35 +1,3 @@
-.mobile-view {
-  .discourse-post-event-builder-modal {
-    .modal-inner-container {
-      .modal-body {
-        .d-date-time-input-range {
-          flex-direction: column;
-          width: 100%;
-          border: 0;
-
-          .d-date-time-input {
-            .d-date-input {
-              width: 100%;
-            }
-
-            .name {
-              font-size: $font-down-1;
-            }
-
-            &.from {
-              margin-right: 2.65em;
-            }
-
-            &.to {
-              margin-top: 0.5em;
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 .discourse-post-event-builder-modal {
   .modal-inner-container {
     width: 550px;
@@ -37,6 +5,10 @@
 
   .modal-body {
     min-height: 200px;
+
+    .timezone-input {
+      width: 100%;
+    }
 
     .d-date-time-input-range {
       margin-bottom: 2em;

--- a/assets/stylesheets/mobile/discourse-post-event-builder.scss
+++ b/assets/stylesheets/mobile/discourse-post-event-builder.scss
@@ -1,5 +1,37 @@
-.discourse-post-event-builder-modal {
-  .modal-inner-container {
-    width: 100%;
+.mobile-view {
+  .discourse-post-event-builder-modal {
+    .modal-inner-container {
+      width: 100%;
+
+      .modal-body {
+        .d-date-time-input-range {
+          flex-direction: column;
+          width: 100%;
+          border: 0;
+
+          .timezone-input {
+            width: 100%;
+          }
+
+          .d-date-time-input {
+            .d-date-input {
+              width: 100%;
+            }
+
+            .name {
+              font-size: $font-down-1;
+            }
+
+            &.from {
+              margin-right: 2.65em;
+            }
+
+            &.to {
+              margin-top: 0.5em;
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/spec/acceptance/post_spec.rb
+++ b/spec/acceptance/post_spec.rb
@@ -301,6 +301,13 @@ describe Post do
             expect(post.event.reminders).to eq('1.hours,-3.days')
           end
 
+          it 'works with timezone attribute' do
+            post = create_post_with_event(user).reload
+            expect(post.event.timezone).to eq(nil)
+            post = create_post_with_event(user, 'timezone="America/New_York"').reload
+            expect(post.event.timezone).to eq('America/New_York')
+          end
+
           context 'with custom fields' do
             before do
               SiteSetting.discourse_post_event_allowed_custom_fields = 'foo-bar|bar'


### PR DESCRIPTION
It's easier to store a date as UTC and the timezone it should be converted to on display. However, we got to be careful we are not doing any conversion on the frontend.

This commit also does minor UX tweaks to timezones.