### PR TITLE
FEATURE: add events calendar on the category page

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -101,7 +101,7 @@ module DiscoursePostEvent
     private
 
     def filtered_events_params
-      params.permit(:post_id)
+      params.permit(:post_id, :category_id)
     end
   end
 end

--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -41,19 +41,23 @@ function initializeDiscourseCalendar(api) {
   }
 
   api.onPageChange((url) => {
-    const $calendarContainer = $(`${selector}.category-calendar`);
-    if ($calendarContainer.length) {
-      $calendarContainer.hide();
+    const categoryCalendarNode = document.querySelector(
+      `${selector}.category-calendar`
+    );
+    if (categoryCalendarNode) {
+      categoryCalendarNode.innerHTML = "";
     }
 
-    const calendarNode = document.getElementById("upcoming-events-calendar");
-    if (calendarNode) {
-      calendarNode.innerHTML = "";
+    const categoryEventNode = document.getElementById(
+      "upcoming-events-calendar"
+    );
+    if (categoryEventNode) {
+      categoryEventNode.innerHTML = "";
     }
 
     const browsedCategory = Category.findBySlugPathWithID(url);
     if (browsedCategory) {
-      if (!$calendarContainer.length) {
+      if (!categoryCalendarNode) {
         return;
       }
 
@@ -78,12 +82,10 @@ function initializeDiscourseCalendar(api) {
       );
 
       if (categorySetting && categorySetting.postId) {
-        $calendarContainer.show();
         const postId = categorySetting.postId;
-        const $spinner = $(
-          '<div class="calendar"><div class="spinner medium"></div></div>'
-        );
-        $calendarContainer.html($spinner);
+        categoryCalendarNode.innerHTML =
+          '<div class="calendar"><div class="spinner medium"></div></div>';
+
         loadFullCalendar().then(() => {
           const options = [`postId=${postId}`];
 
@@ -102,14 +104,13 @@ function initializeDiscourseCalendar(api) {
           Promise.all([cookRaw, loadPost]).then((results) => {
             const cooked = results[0];
             const post = results[1];
-            const $cooked = $(cooked.string);
-            $calendarContainer.html($cooked);
-            render($(".calendar", $cooked), post);
+            categoryCalendarNode.innerHTML = cooked.string;
+            render($(".calendar"), post);
           });
         });
       } else {
         // category events calendar
-        if (!calendarNode) {
+        if (!categoryEventNode) {
           return;
         }
 
@@ -120,7 +121,10 @@ function initializeDiscourseCalendar(api) {
 
         if (foundCategory) {
           loadFullCalendar().then(() => {
-            let calendar = new window.FullCalendar.Calendar(calendarNode, {});
+            let calendar = new window.FullCalendar.Calendar(
+              categoryEventNode,
+              {}
+            );
             const loadEvents = ajax(
               `/discourse-post-event/events.json?category_id=${browsedCategory.id}`
             );

--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -114,7 +114,9 @@ function initializeDiscourseCalendar(api) {
           return;
         }
 
-        const eventSettings = siteSettings.events_calendar_category.split("|");
+        const eventSettings = siteSettings.events_calendar_categories.split(
+          "|"
+        );
         const foundCategory = eventSettings.find(
           (k) => k === browsedCategory.id.toString()
         );

--- a/assets/javascripts/templates/connectors/discovery-list-container-top/category-events.hbs
+++ b/assets/javascripts/templates/connectors/discovery-list-container-top/category-events.hbs
@@ -1,0 +1,1 @@
+<div id="upcoming-events-calendar"></div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -45,7 +45,7 @@ en:
     working_day_start_hour: "Start time of the working day hours."
     working_day_end_hour: "End time of the working day hours."
     close_to_working_day_hours_extension: "Set extension time in working day hours to highlight the timezones."
-    events_calendar_category: "Display an events calendar at the top of a category."
+    events_calendar_categories: "Display an events calendar at the top of a category."
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -45,6 +45,7 @@ en:
     working_day_start_hour: "Start time of the working day hours."
     working_day_end_hour: "End time of the working day hours."
     close_to_working_day_hours_extension: "Set extension time in working day hours to highlight the timezones."
+    events_calendar_category: "Display an events calendar at the top of a category."
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -72,3 +72,7 @@ discourse_post_event:
     list_type: simple
     client: true
     default: ""
+  events_calendar_category:
+    type: category_list
+    client: true
+    default: ""

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -72,7 +72,7 @@ discourse_post_event:
     list_type: simple
     client: true
     default: ""
-  events_calendar_category:
+  events_calendar_categories:
     type: category_list
     client: true
     default: ""

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -207,6 +207,21 @@ module DiscoursePostEvent
             end
           end
         end
+
+        context 'when filtering by category' do
+          it 'can filter the event by category' do
+            category = Fabricate(:category)
+            topic = Fabricate(:topic, category: category)
+            event_2 = Fabricate(:event, post: Fabricate(:post, post_number: 1, topic: topic))
+
+            get "/discourse-post-event/events.json?category_id=#{category.id}"
+
+            expect(response.status).to eq(200)
+            events = response.parsed_body["events"]
+            expect(events.length).to eq(1)
+            expect(events[0]["id"]).to eq(event_2.id)
+          end
+        end
       end
     end
   end

--- a/test/javascripts/acceptance/category-events-calendar-test.js
+++ b/test/javascripts/acceptance/category-events-calendar-test.js
@@ -1,0 +1,87 @@
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+
+acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
+  needs.user();
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    events_calendar_categories: "1",
+    calendar_categories: "",
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/discourse-post-event/events.json", () => {
+      return helper.response({
+        events: [
+          {
+            id: 67501,
+            creator: {
+              id: 1500588,
+              username: "foobar",
+              name: null,
+              avatar_template:
+                "/user_avatar/localhost/foobar/{size}/1913_2.png",
+              assign_icon: "user-plus",
+              assign_path: "/u/foobar/activity/assigned",
+            },
+            sample_invitees: [],
+            watching_invitee: null,
+            starts_at: "2022-04-25T15:14:00.000Z",
+            ends_at: "2022-04-30T16:14:00.000Z",
+            timezone: "Asia/Calcutta",
+            stats: {
+              going: 0,
+              interested: 0,
+              not_going: 0,
+              invited: 0,
+            },
+            status: "public",
+            raw_invitees: ["trust_level_0"],
+            post: {
+              id: 67501,
+              post_number: 1,
+              url: "/t/this-is-an-event/18449/1",
+              topic: {
+                id: 18449,
+                title: "This is an event",
+              },
+            },
+            name: "Awesome Event",
+            can_act_on_discourse_post_event: true,
+            can_update_attendance: true,
+            is_expired: false,
+            is_ongoing: false,
+            should_display_invitees: false,
+            url: null,
+            custom_fields: {},
+            is_public: true,
+            is_private: false,
+            is_standalone: false,
+            reminders: [],
+            recurrence: null,
+          },
+        ],
+      });
+    });
+  });
+
+  test("shows event calendar on category page", async (assert) => {
+    await visit("/c/bug/1");
+
+    assert.ok(
+      exists("#upcoming-events-calendar"),
+      "Events calendar div exists."
+    );
+    assert.strictEqual(
+      query(".fc-event-container .fc-content .fc-title").innerText,
+      "Awesome Event",
+      "Calendar has event name."
+    );
+  });
+});


### PR DESCRIPTION
This commit adds a new site setting `events calendar category` for events calendar that is separate and independent from `calendar categories`. If a category is present in both `events calendar category` and `calendar categories` then priority is given to `calendar categories`.

<img width="754" alt="Screen Shot 2022-04-08 at 09 46 42" src="https://user-images.githubusercontent.com/5732281/162699330-a8dc9023-6157-4d39-b1bf-a21f60fdc808.png">

<img width="572" alt="Screen Shot 2022-04-08 at 09 56 28" src="https://user-images.githubusercontent.com/5732281/162699341-e8f494c8-ee91-49e6-a330-14b684f8405e.png">
