### PR TITLE
UX: do not show scrollbar when there's no scrolling required

### DIFF
--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -34,7 +34,7 @@
     overflow: hidden;
 
     .fc-scroller {
-      height: 570px !important;
+      height: 575px !important;
       padding-bottom: 5px;
     }
 


### PR DESCRIPTION
This commit tries to avoid adding the scrollbar when the scrolling is not required.

Internal ticket t60974.