### PR TITLE
FIX: group event timezone for fullDay setting

### DIFF
--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -479,10 +479,14 @@ function initializeDiscourseCalendar(api) {
     const formattedGroupedEvents = {};
     groupedEvents.forEach((groupedEvent) => {
       const minDate = fullDay
-        ? moment(groupedEvent.from).format("YYYY-MM-DD")
+        ? moment
+            .tz(groupedEvent.from, groupedEvent.timezone)
+            .format("YYYY-MM-DD")
         : moment(groupedEvent.from).utc().startOf("day").toISOString();
       const maxDate = fullDay
-        ? moment(groupedEvent.to || groupedEvent.from).format("YYYY-MM-DD")
+        ? moment
+            .tz(groupedEvent.to || groupedEvent.from, groupedEvent.timezone)
+            .format("YYYY-MM-DD")
         : moment(groupedEvent.to || groupedEvent.from)
             .utc()
             .endOf("day")

--- a/plugin.rb
+++ b/plugin.rb
@@ -407,11 +407,22 @@ after_initialize do
       else
         identifier = "#{event.region.split("_").first}-#{event.start_date.strftime("%j")}"
 
+        timezone = begin
+                     ActiveSupport::TimeZone.country_zones(event.region).last.tzinfo.identifier
+                   rescue TZInfo::InvalidCountryCode
+                     begin
+                       ActiveSupport::TimeZone.country_zones(Holidays::PARENT_REGION_LOOKUP[event.region.to_sym]).last.tzinfo.identifier
+                     rescue TZInfo::InvalidCountryCode
+                       ActiveSupport::TimeZone.country_zones(Holidays::PARENT_REGION_LOOKUP[event.region.to_sym].to_s.split("_").first).last.tzinfo.identifier
+                     end
+                   end
+
         grouped[identifier] ||= {
           type: :grouped,
           from: event.start_date,
           name: [],
-          usernames: []
+          usernames: [],
+          timezone: timezone
         }
 
         grouped[identifier][:name] << event.description


### PR DESCRIPTION
When full Day setting is enabled, we need to know even timezone to correctly calculate event day.

Frontend is hard to test as it is browser behavior. Sensor tab is allowing to jump between different timezones.

<img width="1350" alt="Screen Shot 2022-04-21 at 10 27 11 am" src="https://user-images.githubusercontent.com/72780/164357181-d1b8d52d-8640-4250-ad29-1ffd39e93039.png">
