### PR TITLE
FIX: do not hide upcoming events calendar when navigating away from page

### DIFF
--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -49,7 +49,7 @@ function initializeDiscourseCalendar(api) {
     }
 
     const categoryEventNode = document.getElementById(
-      "upcoming-events-calendar"
+      "category-events-calendar"
     );
     if (categoryEventNode) {
       categoryEventNode.innerHTML = "";

--- a/assets/javascripts/templates/connectors/discovery-list-container-top/category-events.hbs
+++ b/assets/javascripts/templates/connectors/discovery-list-container-top/category-events.hbs
@@ -1,1 +1,1 @@
-<div id="upcoming-events-calendar"></div>
+<div id="category-events-calendar"></div>

--- a/assets/stylesheets/common/upcoming-events-calendar.scss
+++ b/assets/stylesheets/common/upcoming-events-calendar.scss
@@ -1,4 +1,5 @@
-#upcoming-events-calendar {
+#upcoming-events-calendar,
+#category-events-calendar {
   &.fc-unthemed {
     tbody,
     thead,

--- a/test/javascripts/acceptance/category-events-calendar-test.js
+++ b/test/javascripts/acceptance/category-events-calendar-test.js
@@ -75,7 +75,7 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
     await visit("/c/bug/1");
 
     assert.ok(
-      exists("#upcoming-events-calendar"),
+      exists("#category-events-calendar"),
       "Events calendar div exists."
     );
     assert.strictEqual(


### PR DESCRIPTION
Previously the ID for standard upcoming events calendar and category
events calendar was same and on every page change we were hiding the
category events calendar. Due to this the upcoming events calendar were
getting hidden when navigating away from page but was not reloading on
visiting again. This commit changes the ID for category events calendar
so that we can have finer control over it.

Internal ticket t61598.