### PR TITLE
Add upcoming Saudi holidays (Eid Al Fitr)

### DIFF
--- a/vendor/holidays/definitions/sa.yaml
+++ b/vendor/holidays/definitions/sa.yaml
@@ -2,6 +2,22 @@
 
 ---
 months:
+  5:
+  - name: Festival of Breaking the Fast
+    regions: [sa]
+    mday: 2
+    year_ranges:
+      limited: [2022]
+  - name: Second Day of the Festival of Breaking the Fast
+    regions: [sa]
+    mday: 3
+    year_ranges:
+      limited: [2022]
+  - name: Third Day of the Festival of Breaking the Fast
+    regions: [sa]
+    mday: 4
+    year_ranges:
+      limited: [2022]
   7:
   - name: Day of Arafah
     regions: [sa]

--- a/vendor/holidays/lib/generated_definitions/sa.rb
+++ b/vendor/holidays/lib/generated_definitions/sa.rb
@@ -12,7 +12,10 @@ module Holidays
 
     def self.holidays_by_month
       {
-                7 => [{:mday => 19, :year_ranges => { :limited => [2021] },:name => "Day of Arafah", :regions => [:sa]},
+                5 => [{:mday => 2, :year_ranges => { :limited => [2022] },:name => "Festival of Breaking the Fast", :regions => [:sa]},
+            {:mday => 3, :year_ranges => { :limited => [2022] },:name => "Second Day of the Festival of Breaking the Fast", :regions => [:sa]},
+            {:mday => 4, :year_ranges => { :limited => [2022] },:name => "Third Day of the Festival of Breaking the Fast", :regions => [:sa]}],
+      7 => [{:mday => 19, :year_ranges => { :limited => [2021] },:name => "Day of Arafah", :regions => [:sa]},
             {:mday => 20, :year_ranges => { :limited => [2021] },:name => "Day 1 of Eid Al Adha", :regions => [:sa]},
             {:mday => 21, :year_ranges => { :limited => [2021] },:name => "Day 2 of Eid Al Adha", :regions => [:sa]},
             {:mday => 22, :year_ranges => { :limited => [2021] },:name => "Day 3 of Eid Al Adha", :regions => [:sa]}],


### PR DESCRIPTION
The 2nd of May to the 4th of May of 2022 is a public holiday in Saudi Arabia as per https://holidayapi.com/countries/sa/2022.