### PR TITLE
FIX: Make region visible to current user too

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -319,7 +319,7 @@ after_initialize do
   )
 
   allow_staff_user_custom_field(DiscourseCalendar::HOLIDAY_CUSTOM_FIELD)
-  allow_staff_user_custom_field(DiscourseCalendar::REGION_CUSTOM_FIELD)
+  DiscoursePluginRegistry.serialized_current_user_fields << DiscourseCalendar::REGION_CUSTOM_FIELD
   register_editable_user_custom_field(DiscourseCalendar::REGION_CUSTOM_FIELD)
 
   on(:site_setting_changed) do |name, old_value, new_value|

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -12,7 +12,7 @@ describe UserSerializer do
     user.upsert_custom_fields(DiscourseCalendar::REGION_CUSTOM_FIELD => "uk")
   end
 
-  context "as user" do
+  context "as another user" do
     fab!(:guardian) { Fabricate(:user).guardian }
 
     it "does not return user region" do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UserSerializer do
+  fab!(:user) { Fabricate(:user) }
+
+  subject { described_class.new(user, scope: guardian).as_json }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    user.upsert_custom_fields(DiscourseCalendar::REGION_CUSTOM_FIELD => "uk")
+  end
+
+  context "as user" do
+    fab!(:guardian) { Fabricate(:user).guardian }
+
+    it "does not return user region" do
+      expect(subject[:user][:custom_fields]).to be_blank
+    end
+  end
+
+  context "as current user" do
+    fab!(:guardian) { user.guardian }
+
+    it "returns user region" do
+      expect(subject[:user][:custom_fields]).to eq(DiscourseCalendar::REGION_CUSTOM_FIELD => "uk")
+    end
+  end
+
+  context "as staff" do
+    fab!(:guardian) { Fabricate(:admin).guardian }
+
+    it "returns user region" do
+      expect(subject[:user][:custom_fields]).to eq(DiscourseCalendar::REGION_CUSTOM_FIELD => "uk")
+    end
+  end
+end


### PR DESCRIPTION
The 'holidays-region' custom field used to be visible only to staff
members, but editable by the current user. This meant that the user
could edit the value, but could not see the value after it was set.
This caused the input field from their user preferences page to be
always blank for regular users.