### PR TITLE
DEV: Add API endpoints for holidays

### DIFF
--- a/app/controllers/admin/admin_discourse_calendar_controller.rb
+++ b/app/controllers/admin/admin_discourse_calendar_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Admin::DiscourseCalendar
+  class AdminDiscourseCalendarController < Admin::AdminController
+    before_action :ensure_calendar_enabled
+
+    def ensure_calendar_enabled
+      if !SiteSetting.calendar_enabled
+        raise Discourse::NotFound
+      end
+    end
+  end
+end

--- a/app/controllers/admin/discourse_calendar/admin_holiday_regions_controller.rb
+++ b/app/controllers/admin/discourse_calendar/admin_holiday_regions_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "holidays"
+
+module Admin::DiscourseCalendar
+  class AdminHolidayRegionsController < AdminDiscourseCalendarController
+    def index
+      render json: { holiday_regions: Holidays.available_regions }
+    end
+  end
+end

--- a/app/controllers/admin/discourse_calendar/admin_holidays_controller.rb
+++ b/app/controllers/admin/discourse_calendar/admin_holidays_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "holidays"
+
+module Admin::DiscourseCalendar
+  class AdminHolidaysController < AdminDiscourseCalendarController
+    def index
+      region_code = params[:region_code]
+
+      begin
+        holidays = Holidays.year_holidays([region_code], Time.current.beginning_of_year)
+      rescue Holidays::InvalidRegion
+        return render_json_error(I18n.t("system_messages.discourse_calendar_holiday_region_invalid"), 422)
+      end
+
+      render json: { region_code: region_code, holidays: holidays }
+    end
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,6 +10,7 @@ en:
       event_started:
         title: Event started
   system_messages:
+    discourse_calendar_holiday_region_invalid: "The holiday region you provided does not exist."
     discourse_post_event_bulk_invite_succeeded:
       title: "Event - Bulk Invite Succeeded"
       subject_template: "Bulk invite processed successfully"

--- a/plugin.rb
+++ b/plugin.rb
@@ -84,6 +84,19 @@ after_initialize do
     end
   end
 
+  # DISCOURSE CALENDAR
+
+  %w[
+    ../app/controllers/admin/admin_discourse_calendar_controller.rb
+    ../app/controllers/admin/discourse_calendar/admin_holiday_regions_controller.rb
+  ].each { |path| load File.expand_path(path, __FILE__) }
+
+  Discourse::Application.routes.append do
+    mount ::DiscourseCalendar::Engine, at: '/'
+
+    get '/admin/discourse-calendar/holiday-regions' => 'admin/discourse_calendar/admin_holiday_regions#index', constraints: StaffConstraint.new
+  end
+
   # DISCOURSE POST EVENT
 
   %w[

--- a/plugin.rb
+++ b/plugin.rb
@@ -89,12 +89,14 @@ after_initialize do
   %w[
     ../app/controllers/admin/admin_discourse_calendar_controller.rb
     ../app/controllers/admin/discourse_calendar/admin_holiday_regions_controller.rb
+    ../app/controllers/admin/discourse_calendar/admin_holidays_controller.rb
   ].each { |path| load File.expand_path(path, __FILE__) }
 
   Discourse::Application.routes.append do
     mount ::DiscourseCalendar::Engine, at: '/'
 
     get '/admin/discourse-calendar/holiday-regions' => 'admin/discourse_calendar/admin_holiday_regions#index', constraints: StaffConstraint.new
+    get '/admin/discourse-calendar/holiday-regions/:region_code/holidays' => 'admin/discourse_calendar/admin_holidays#index', constraints: StaffConstraint.new
   end
 
   # DISCOURSE POST EVENT

--- a/spec/requests/admin/admin_holiday_regions_controller_spec.rb
+++ b/spec/requests/admin/admin_holiday_regions_controller_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Admin::DiscourseCalendar
+  describe AdminHolidayRegionsController do
+    fab!(:admin) { Fabricate(:user, admin: true) }
+    fab!(:member) { Fabricate(:user) }
+
+    before do
+      SiteSetting.calendar_enabled = calendar_enabled
+    end
+
+    describe "#index" do
+      context "when the calendar plugin is enabled" do
+        let(:calendar_enabled) { true }
+
+        it "returns a list of holiday regions for an admin" do
+          sign_in(admin)
+          get "/admin/discourse-calendar/holiday-regions.json"
+
+          expect(response.parsed_body["holiday_regions"].count).to eq(262)
+          expect(response.parsed_body["holiday_regions"]).to eq(
+            %w(
+              ar at au au_nsw au_vic au_qld au_nt au_act au_sa au_wa au_tas
+              au_tas_south au_qld_cairns au_qld_brisbane au_tas_north
+              au_vic_melbourne be_fr be_nl br br_spcapital br_sp bg_en bg_bg
+              ca ca_qc ca_ab ca_sk ca_on ca_bc ca_nb ca_mb ca_ns ca_pe ca_nl
+              ca_nt ca_nu ca_yt us ch_zh ch_be ch_lu ch_ur ch_sz ch_ow ch_nw
+              ch_gl ch_zg ch_fr ch_so ch_bs ch_bl ch_sh ch_ar ch_ai ch_sg ch_gr
+              ch_ag ch_tg ch_ti ch_vd ch_ne ch_ge ch_ju ch_vs ch cl co cr cz dk
+              de de_bw de_by de_he de_nw de_rp de_sl de_sn_sorbian de_th_cath
+              de_sn de_st de_be de_by_cath de_by_augsburg de_bb de_mv de_th
+              de_hb de_hh de_ni de_sh ecbtarget ee el es_pv es_na es_an es_ib
+              es_cm es_mu es_m es_ar es_cl es_cn es_lo es_ga es_ce es_o es_ex es
+              es_ct es_v es_vc federalreserve federalreservebanks fedex fi fr_a
+              fr_m fr gb gb_eng gb_wls gb_eaw gb_nir je gb_jsy gg gb_gsy gb_sct
+              gb_con im gb_iom ge hr hk hu ie in is it it_ve it_tv it_vr it_pd
+              it_fi it_ge it_to it_rm it_vi it_bl it_ro kr kz li lt lv ma mt_mt
+              mt_en mx mx_pue nerc nl lu no nyse nz nz_sl nz_we nz_ak nz_nl
+              nz_ne nz_ot nz_ta nz_sc nz_hb nz_mb nz_ca nz_ch nz_wl pe ph pl pt
+              pt_li pt_po ro rs_cyrl rs_la ru se sa tn tr ua us_fl us_la us_ct
+              us_de us_gu us_hi us_in us_ky us_nj us_nc us_nd us_pr us_tn us_ms
+              us_id us_ar us_tx us_dc us_md us_va us_vt us_ak us_ca us_me us_ma
+              us_al us_ga us_ne us_mo us_sc us_wv us_vi us_ut us_ri us_az us_co
+              us_il us_mt us_nm us_ny us_oh us_pa us_mi us_mn us_nv us_or us_sd
+              us_wa us_wi us_wy us_ia us_ks us_nh us_ok unitednations ups za ve
+              sk si jp vi sg my th ng
+            )
+          )
+        end
+
+        it "returns a 404 for a member" do
+          sign_in(member)
+          get "/admin/discourse-calendar/holiday-regions.json"
+
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when the calendar plugin is not enabled" do
+        let(:calendar_enabled) { false }
+
+        it "returns a 404 for an admin" do
+          sign_in(admin)
+          get "/admin/discourse-calendar/holiday-regions.json"
+
+          expect(response.status).to eq(404)
+        end
+
+        it "returns a 404 for a member" do
+          sign_in(member)
+          get "/admin/discourse-calendar/holiday-regions.json"
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/admin/admin_holidays_controller_spec.rb
+++ b/spec/requests/admin/admin_holidays_controller_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Admin::DiscourseCalendar
+  describe AdminHolidaysController do
+    fab!(:admin) { Fabricate(:user, admin: true) }
+    fab!(:member) { Fabricate(:user) }
+
+    before do
+      SiteSetting.calendar_enabled = calendar_enabled
+    end
+
+    describe "#index" do
+      context "when the calendar plugin is enabled" do
+        let(:calendar_enabled) { true }
+
+        context "when an admin is signed in" do
+          before do
+            sign_in(admin)
+          end
+
+          it "returns a list of holidays for a given region" do
+            get "/admin/discourse-calendar/holiday-regions/mx/holidays.json"
+
+            expect(response.parsed_body["holidays"]).to eq([
+              { "date" => "2022-01-01", "name" => "Año nuevo", "regions" => ["mx"] },
+              { "date" => "2022-02-07", "name" => "Día de la Constitución", "regions" => ["mx"] },
+              { "date" => "2022-03-21", "name" => "Natalicio de Benito Juárez", "regions" => ["mx"] },
+              { "date" => "2022-05-01", "name" => "Día del Trabajo", "regions" => ["mx"] },
+              { "date" => "2022-09-15", "name" => "Grito de Dolores", "regions" => ["mx"] },
+              { "date" => "2022-09-16", "name" => "Día de la Independencia", "regions" => ["mx"] },
+              { "date" => "2022-11-21", "name" => "Día de la Revolución", "regions" => ["mx"] },
+              { "date" => "2022-12-25", "name" => "Navidad", "regions" => ["mx"] }
+            ])
+          end
+
+          it "returns a 422 and an error message for an invalid region" do
+            get "/admin/discourse-calendar/holiday-regions/regionxyz/holidays.json"
+
+            expect(response.status).to eq(422)
+            expect(response.parsed_body["errors"]).to include(
+              I18n.t("system_messages.discourse_calendar_holiday_region_invalid")
+            )
+          end
+        end
+
+        it "returns a 404 for a member" do
+          sign_in(member)
+          get "/admin/discourse-calendar/holiday-regions/mx/holidays.json"
+
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when the calendar plugin is not enabled" do
+        let(:calendar_enabled) { false }
+
+        it "returns a 404 for an admin" do
+          sign_in(admin)
+          get "/admin/discourse-calendar/holiday-regions/mx/holidays.json"
+
+          expect(response.status).to eq(404)
+        end
+
+        it "returns a 404 for a member" do
+          sign_in(member)
+          get "/admin/discourse-calendar/holiday-regions/mx/holidays.json"
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will make two new endpoints available to admins:
* `/admin/discourse-calendar/holiday-regions` - this will return a list of holiday regions (as defined by the Holidays gem)
* `/admin/discourse-calendar/holiday-regions/:id/holidays` - this will return all of the holidays for a given region

The next piece I will work on for this will be a UI update so that admins can select a region and view all of the holidays for that region (and eventually the ability to enable/disable holidays).

I wanted to keep the PRs smaller to make them easier to review, and also to make sure I'm on the right track. Still new to contributing so any feedback is welcome! :smiley: 