### PR TITLE
Add Juneteenth holiday for US

### DIFF
--- a/vendor/holidays/definitions/us.yaml
+++ b/vendor/holidays/definitions/us.yaml
@@ -200,6 +200,10 @@ months:
   - name: Emancipation Day in Texas # fixed
     regions: [us_tx]
     mday: 19
+  - name: Juneteenth # fixed
+    regions: [us]
+    mday: 19
+    observed: to_weekday_if_weekend(date)
   - name: West Virginia Day
     regions: [us_wv]
     mday: 20

--- a/vendor/holidays/lib/generated_definitions/northamerica.rb
+++ b/vendor/holidays/lib/generated_definitions/northamerica.rb
@@ -76,6 +76,7 @@ module Holidays
             {:mday => 3, :name => "Birthday of Jefferson Davis", :regions => [:us_fl]},
             {:mday => 11, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "King Kamehameha I Day", :regions => [:us_hi]},
             {:mday => 19, :name => "Emancipation Day in Texas", :regions => [:us_tx]},
+            {:mday => 19, :function => "to_weekday_if_weekend(date)", :function_arguments => [:date], :name => "Juneteenth", :regions => [:us]},
             {:mday => 20, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "West Virginia Day", :regions => [:us_wv]},
             {:wday => 0, :week => 3, :type => :informal, :name => "Father's Day", :regions => [:us, :ca]}],
       7 => [{:mday => 1, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Canada Day", :regions => [:ca]},

--- a/vendor/holidays/lib/generated_definitions/us.rb
+++ b/vendor/holidays/lib/generated_definitions/us.rb
@@ -53,6 +53,7 @@ module Holidays
             {:mday => 3, :name => "Birthday of Jefferson Davis", :regions => [:us_fl]},
             {:mday => 11, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "King Kamehameha I Day", :regions => [:us_hi]},
             {:mday => 19, :name => "Emancipation Day in Texas", :regions => [:us_tx]},
+            {:mday => 19, :function => "to_weekday_if_weekend(date)", :function_arguments => [:date], :name => "Juneteenth", :regions => [:us]},
             {:mday => 20, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "West Virginia Day", :regions => [:us_wv]},
             {:wday => 0, :week => 3, :type => :informal, :name => "Father's Day", :regions => [:us, :ca]}],
       7 => [{:mday => 3, :name => "Emancipation Day", :regions => [:us_vi]},


### PR DESCRIPTION
According to https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays#url=2022, Juneteenth should be added to the US holiday list with observance on the closest weekday it falls on a weekend.