### PR TITLE
FIX: Stable core still needs a 6.1 migration

### DIFF
--- a/db/post_migrate/20220613073844_unescape_event_name.rb
+++ b/db/post_migrate/20220613073844_unescape_event_name.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UnescapeEventName < ActiveRecord::Migration[7.0]
+class UnescapeEventName < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   TEMP_INDEX_NAME = "_temp_discourse_calendar_unescape_event_name_migration"


### PR DESCRIPTION
The stable version of discourse is still on rails 6, so we can't use a
version 7 migration here.

See: https://meta.discourse.org/t/229985