### PR TITLE
UX: tiny css fix

### DIFF
--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -43,14 +43,11 @@ $interested: #fb985d;
 
   .event-header {
     display: flex;
-    align-items: center;
-    padding: 0 1em;
-    height: 75px;
+    align-items: flex-start;
+    padding: 1em;
 
     .more-dropdown {
       margin-left: auto;
-      align-self: flex-start;
-      margin-top: 1em;
 
       &.has-no-actions {
         display: none;
@@ -102,7 +99,6 @@ $interested: #fb985d;
 
     .name {
       font-weight: 700;
-      @include ellipsis;
       max-width: 45vw;
     }
     .status-and-creators {

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -43,11 +43,14 @@ $interested: #fb985d;
 
   .event-header {
     display: flex;
-    align-items: flex-start;
-    padding: 1em;
+    align-items: center;
+    padding: 0 1em;
+    height: 75px;
 
     .more-dropdown {
       margin-left: auto;
+      align-self: flex-start;
+      margin-top: 1em;
 
       &.has-no-actions {
         display: none;
@@ -99,6 +102,7 @@ $interested: #fb985d;
 
     .name {
       font-weight: 700;
+      @include ellipsis;
       max-width: 45vw;
     }
     .status-and-creators {

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -99,6 +99,8 @@ $interested: #fb985d;
   .event-info {
     display: flex;
     flex-direction: column;
+    min-width: 0;
+    margin-right: 0.5rem;
 
     .name {
       font-weight: 700;


### PR DESCRIPTION
Just saw a little ui bug: when the name of an event is too long it overflows and the dropdown isn't visible

<img width="779" alt="image" src="https://user-images.githubusercontent.com/101828855/173911613-f8bd6466-0354-4030-b544-6f644a8474a9.png">

added css to make ellipsis work:

<img width="722" alt="image" src="https://user-images.githubusercontent.com/101828855/173913203-7cae4dfc-5230-4519-9a85-69870951d30e.png">
