### PR TITLE
FIX: Handle non-UTC events correctly

### DIFF
--- a/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
+++ b/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
@@ -31,7 +31,7 @@
       {{#event-field class="timezone" label="discourse_post_event.builder_modal.timezone.label"}}
         {{timezone-input
           value=model.eventModel.timezone
-          onChange=(action (mut model.eventModel.timezone))
+          onChange=(action "onChangeTimezone")
           class="input-xxlarge"
           none="discourse_post_event.builder_modal.timezone.remove_timezone"
         }}

--- a/assets/javascripts/initializers/add-event-ui-builder.js
+++ b/assets/javascripts/initializers/add-event-ui-builder.js
@@ -39,6 +39,8 @@ function initializeEventBuilder(api) {
         );
         eventModel.set("status", "public");
         eventModel.set("custom_fields", {});
+        eventModel.set("starts_at", moment());
+        eventModel.set("timezone", moment.tz.guess());
 
         showModal("discourse-post-event-builder").setProperties({
           toolbarEvent: this.toolbarEvent,

--- a/assets/javascripts/lib/raw-event-helper.js
+++ b/assets/javascripts/lib/raw-event-helper.js
@@ -1,11 +1,9 @@
 export function buildParams(startsAt, endsAt, eventModel, siteSettings) {
   const params = {};
 
-  if (startsAt) {
-    params.start = moment(startsAt).utc().format("YYYY-MM-DD HH:mm");
-  } else {
-    params.start = moment().utc().format("YYYY-MM-DD HH:mm");
-  }
+  const eventTz = eventModel.timezone || "UTC";
+
+  params.start = moment(startsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
 
   if (eventModel.status) {
     params.status = eventModel.status;
@@ -28,7 +26,7 @@ export function buildParams(startsAt, endsAt, eventModel, siteSettings) {
   }
 
   if (endsAt) {
-    params.end = moment(endsAt).utc().format("YYYY-MM-DD HH:mm");
+    params.end = moment(endsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
   }
 
   if (eventModel.status === "private") {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -73,6 +73,7 @@ en:
           start_must_be_present_and_a_valid_date: "An event requires a valid start date."
           end_must_be_a_valid_date: "End date must be a valid date."
           invalid_recurrence: "Recurrence must be one of: every_month, every_week, every_two_weeks, every_day, every_weekday."
+          invalid_timezone: "Timezone not recognized."
           acting_user_not_allowed_to_create_event: "Current user is not allowed to create events."
           acting_user_not_allowed_to_act_on_this_event: "Current user is not allowed to act on this event."
           custom_field_is_invalid: "The custom field `%{field}` is not allowed."

--- a/db/migrate/20220724130519_fix_post_event_timezones.rb
+++ b/db/migrate/20220724130519_fix_post_event_timezones.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class FixPostEventTimezones < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE discourse_post_event_events
+      SET
+        original_starts_at = (original_starts_at::timestamp AT TIME ZONE timezone),
+        original_ends_at = (original_ends_at::timestamp AT TIME ZONE timezone)
+      WHERE timezone IS NOT NULL;
+    SQL
+
+    execute <<~SQL
+      UPDATE discourse_calendar_post_event_dates
+      SET
+        starts_at = (starts_at::timestamp AT TIME ZONE timezone),
+        ends_at = (ends_at::timestamp AT TIME ZONE timezone)
+      FROM discourse_post_event_events
+      WHERE discourse_post_event_events.id = discourse_calendar_post_event_dates.event_id
+      AND discourse_post_event_events.timezone IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE topic_custom_fields
+      SET value = (value::timestamp AT TIME ZONE discourse_post_event_events.timezone) AT TIME ZONE 'UTC'
+      FROM discourse_post_event_events
+      JOIN posts ON discourse_post_event_events.id = posts.id
+      WHERE discourse_post_event_events.timezone IS NOT NULL
+      AND topic_custom_fields.topic_id = posts.topic_id
+      AND topic_custom_fields.name IN ('TopicEventStartsAt', 'TopicEventEndsAt')
+    SQL
+  end
+end

--- a/spec/acceptance/post_spec.rb
+++ b/spec/acceptance/post_spec.rb
@@ -579,16 +579,16 @@ describe Post do
     it "stores the correct information in the database" do
       expected_datetime = ActiveSupport::TimeZone["Australia/Sydney"].parse("2022-07-24 14:01")
 
-      p = PostCreator.create!(
+      post = PostCreator.create!(
         user,
         title: 'Beach party',
         raw: "[event start='2022-07-24 14:01' timezone='Australia/Sydney']\n[/event]"
       ).reload
 
-      expect(p.event.timezone).to eq("Australia/Sydney")
-      expect(p.event.original_starts_at).to eq_time(expected_datetime)
-      expect(p.event.starts_at).to eq_time(expected_datetime)
-      expect(p.event.event_dates.first.starts_at).to eq_time(expected_datetime)
+      expect(post.event.timezone).to eq("Australia/Sydney")
+      expect(post.event.original_starts_at).to eq_time(expected_datetime)
+      expect(post.event.starts_at).to eq_time(expected_datetime)
+      expect(post.event.event_dates.first.starts_at).to eq_time(expected_datetime)
     end
 
     it "raises an error for invalid timezone" do
@@ -606,15 +606,15 @@ describe Post do
       expected_original_datetime = ActiveSupport::TimeZone["Australia/Sydney"].parse("2022-07-01 09:01")
       expected_next_datetime = ActiveSupport::TimeZone["Australia/Sydney"].parse("2022-07-29 09:01")
 
-      p = PostCreator.create!(
+      post = PostCreator.create!(
         user,
         title: 'Friday beach party',
         raw: "[event start='2022-07-01 09:01' end='2022-07-01 10:01' timezone='Australia/Sydney' recurrence='every_week']\n[/event]"
       ).reload
 
-      expect(p.event.timezone).to eq("Australia/Sydney")
-      expect(p.event.original_starts_at).to eq_time(expected_original_datetime)
-      expect(p.event.starts_at).to eq_time(expected_next_datetime)
+      expect(post.event.timezone).to eq("Australia/Sydney")
+      expect(post.event.original_starts_at).to eq_time(expected_original_datetime)
+      expect(post.event.starts_at).to eq_time(expected_next_datetime)
     end
 
     it "handles recurrence across daylight saving" do
@@ -623,15 +623,15 @@ describe Post do
       expected_original_datetime = ActiveSupport::TimeZone["Europe/Paris"].parse("2022-03-20 09:01")
       expected_next_datetime = ActiveSupport::TimeZone["Europe/Paris"].parse("2022-07-25 09:01")
 
-      p = PostCreator.create!(
+      post = PostCreator.create!(
         user,
         title: 'Friday beach party',
         raw: "[event start='2022-03-20 09:01' end='2022-03-20 10:01' timezone='Europe/Paris' recurrence='every_day']\n[/event]"
       ).reload
 
-      expect(p.event.timezone).to eq("Europe/Paris")
-      expect(p.event.original_starts_at).to eq_time(expected_original_datetime)
-      expect(p.event.starts_at).to eq_time(expected_next_datetime)
+      expect(post.event.timezone).to eq("Europe/Paris")
+      expect(post.event.original_starts_at).to eq_time(expected_original_datetime)
+      expect(post.event.starts_at).to eq_time(expected_next_datetime)
     end
   end
 end

--- a/spec/acceptance/post_spec.rb
+++ b/spec/acceptance/post_spec.rb
@@ -570,4 +570,68 @@ describe Post do
       end
     end
   end
+
+  describe "timezone handling" do
+    before do
+      freeze_time Time.utc(2022, 7, 24, 13, 00)
+    end
+
+    it "stores the correct information in the database" do
+      expected_datetime = ActiveSupport::TimeZone["Australia/Sydney"].parse("2022-07-24 14:01")
+
+      p = PostCreator.create!(
+        user,
+        title: 'Beach party',
+        raw: "[event start='2022-07-24 14:01' timezone='Australia/Sydney']\n[/event]"
+      ).reload
+
+      expect(p.event.timezone).to eq("Australia/Sydney")
+      expect(p.event.original_starts_at).to eq_time(expected_datetime)
+      expect(p.event.starts_at).to eq_time(expected_datetime)
+      expect(p.event.event_dates.first.starts_at).to eq_time(expected_datetime)
+    end
+
+    it "raises an error for invalid timezone" do
+      expect {
+        PostCreator.create!(
+          user,
+          title: 'Beach party',
+          raw: "[event start='2022-07-24 14:01' timezone='Westeros/Winterfell']\n[/event]"
+        )
+      }.to raise_error(I18n.t("discourse_post_event.errors.models.event.invalid_timezone"))
+    end
+
+    it "handles simple weekly recurrence correctly" do
+      # Friday in Aus, Thursday in UTC
+      expected_original_datetime = ActiveSupport::TimeZone["Australia/Sydney"].parse("2022-07-01 09:01")
+      expected_next_datetime = ActiveSupport::TimeZone["Australia/Sydney"].parse("2022-07-29 09:01")
+
+      p = PostCreator.create!(
+        user,
+        title: 'Friday beach party',
+        raw: "[event start='2022-07-01 09:01' end='2022-07-01 10:01' timezone='Australia/Sydney' recurrence='every_week']\n[/event]"
+      ).reload
+
+      expect(p.event.timezone).to eq("Australia/Sydney")
+      expect(p.event.original_starts_at).to eq_time(expected_original_datetime)
+      expect(p.event.starts_at).to eq_time(expected_next_datetime)
+    end
+
+    it "handles recurrence across daylight saving" do
+      # DST starts on 27th March. Original datetime is before that. Expecting
+      # local time to be correct after the DST change
+      expected_original_datetime = ActiveSupport::TimeZone["Europe/Paris"].parse("2022-03-20 09:01")
+      expected_next_datetime = ActiveSupport::TimeZone["Europe/Paris"].parse("2022-07-25 09:01")
+
+      p = PostCreator.create!(
+        user,
+        title: 'Friday beach party',
+        raw: "[event start='2022-03-20 09:01' end='2022-03-20 10:01' timezone='Europe/Paris' recurrence='every_day']\n[/event]"
+      ).reload
+
+      expect(p.event.timezone).to eq("Europe/Paris")
+      expect(p.event.original_starts_at).to eq_time(expected_original_datetime)
+      expect(p.event.starts_at).to eq_time(expected_next_datetime)
+    end
+  end
 end

--- a/spec/acceptance/recurrence_spec.rb
+++ b/spec/acceptance/recurrence_spec.rb
@@ -103,7 +103,7 @@ describe 'discourse_post_event_recurrence' do
 
         post_event_1.set_next_date
 
-        expect(post_event_1.starts_at).to eq_time(Time.zone.parse('2020-10-08 23:00'))
+        expect(post_event_1.starts_at).to eq_time(Time.zone.parse('2020-10-08 19:00'))
       end
     end
   end

--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -19,9 +19,9 @@ acceptance("Post event - composer", function (needs) {
     await click(".toolbar-popup-menu-options .dropdown-select-box-header");
     await click(".toolbar-popup-menu-options *[data-value='insertEvent']");
 
-    const m = ".discourse-post-event-builder-modal";
+    const modal = ".discourse-post-event-builder-modal";
 
-    const timezoneInput = selectKit(`${m} .event-field.timezone`);
+    const timezoneInput = selectKit(`${modal} .event-field.timezone`);
     await timezoneInput.expand();
     await timezoneInput.selectRowByValue("Europe/London");
     assert.equal(
@@ -30,16 +30,16 @@ acceptance("Post event - composer", function (needs) {
       "Timezone can be changed"
     );
 
-    const fromDate = query(`${m} .from input[type=date]`);
+    const fromDate = query(`${modal} .from input[type=date]`);
     fromDate.value = "2022-07-25";
 
-    const fromTime = selectKit(`${m} .from .d-time-input`);
+    const fromTime = selectKit(`${modal} .from .d-time-input`);
     await fromTime.expand();
     await fromTime.selectRowByName("12:00");
 
-    const toDate = query(`${m} .to input[type=date]`);
+    const toDate = query(`${modal} .to input[type=date]`);
     toDate.value = "2022-07-25";
-    const toTime = selectKit(`${m} .to .d-time-input`);
+    const toTime = selectKit(`${modal} .to .d-time-input`);
     await toTime.expand();
     await toTime.selectRowByName("13:00");
 
@@ -49,7 +49,7 @@ acceptance("Post event - composer", function (needs) {
     assert.strictEqual(fromTime.header().name(), "12:00");
     assert.strictEqual(toTime.header().name(), "13:00");
 
-    await click(`${m} .modal-footer .btn-primary`);
+    await click(`${modal} .modal-footer .btn-primary`);
 
     const composerContent = query(".d-editor-input").value;
 

--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -1,0 +1,69 @@
+import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { click, visit } from "@ember/test-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+
+acceptance("Post event - composer", function (needs) {
+  needs.user({ admin: true, can_create_discourse_post_event: true });
+  needs.settings({
+    discourse_local_dates_enabled: true,
+    discourse_calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    discourse_post_event_allowed_on_groups: "",
+    discourse_post_event_allowed_custom_fields: "",
+  });
+
+  test("composer event builder", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    await click(".toolbar-popup-menu-options .dropdown-select-box-header");
+    await click(".toolbar-popup-menu-options *[data-value='insertEvent']");
+
+    const m = ".discourse-post-event-builder-modal";
+
+    const timezoneInput = selectKit(`${m} .event-field.timezone`);
+    await timezoneInput.expand();
+    await timezoneInput.selectRowByValue("Europe/London");
+    assert.equal(
+      timezoneInput.header().value(),
+      "Europe/London",
+      "Timezone can be changed"
+    );
+
+    const fromDate = query(`${m} .from input[type=date]`);
+    fromDate.value = "2022-07-25";
+
+    const fromTime = selectKit(`${m} .from .d-time-input`);
+    await fromTime.expand();
+    await fromTime.selectRowByName("12:00");
+
+    const toDate = query(`${m} .to input[type=date]`);
+    toDate.value = "2022-07-25";
+    const toTime = selectKit(`${m} .to .d-time-input`);
+    await toTime.expand();
+    await toTime.selectRowByName("13:00");
+
+    await timezoneInput.expand();
+    await timezoneInput.selectRowByName("Europe/Paris");
+
+    assert.strictEqual(fromTime.header().name(), "12:00");
+    assert.strictEqual(toTime.header().name(), "13:00");
+
+    await click(`${m} .modal-footer .btn-primary`);
+
+    const composerContent = query(".d-editor-input").value;
+
+    assert.true(
+      composerContent.includes('start="2022-07-24 12:00"'),
+      "bbcode has correct start time"
+    );
+    assert.true(
+      composerContent.includes('end="2022-07-24 13:00"'),
+      "bbcode has correct end time"
+    );
+    assert.true(
+      composerContent.includes('timezone="Europe/Paris"'),
+      "bbcode has correct end time"
+    );
+  });
+});

--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -1,6 +1,6 @@
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
-import { click, visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Post event - composer", function (needs) {
@@ -21,7 +21,9 @@ acceptance("Post event - composer", function (needs) {
 
     const modal = ".discourse-post-event-builder-modal";
 
-    const timezoneInput = selectKit(`${modal} .event-field.timezone`);
+    const timezoneInput = selectKit(
+      `${modal} .event-field.timezone .timezone-input`
+    );
     await timezoneInput.expand();
     await timezoneInput.selectRowByValue("Europe/London");
     assert.equal(
@@ -31,15 +33,15 @@ acceptance("Post event - composer", function (needs) {
     );
 
     const fromDate = query(`${modal} .from input[type=date]`);
-    fromDate.value = "2022-07-25";
+    fillIn(fromDate, "2022-07-01");
 
-    const fromTime = selectKit(`${modal} .from .d-time-input`);
+    const fromTime = selectKit(`${modal} .from .d-time-input .select-kit`);
     await fromTime.expand();
     await fromTime.selectRowByName("12:00");
 
     const toDate = query(`${modal} .to input[type=date]`);
-    toDate.value = "2022-07-25";
-    const toTime = selectKit(`${modal} .to .d-time-input`);
+    fillIn(toDate, "2022-07-01");
+    const toTime = selectKit(`${modal} .to .d-time-input .select-kit`);
     await toTime.expand();
     await toTime.selectRowByName("13:00");
 
@@ -54,11 +56,11 @@ acceptance("Post event - composer", function (needs) {
     const composerContent = query(".d-editor-input").value;
 
     assert.true(
-      composerContent.includes('start="2022-07-24 12:00"'),
+      composerContent.includes('start="2022-07-01 12:00"'),
       "bbcode has correct start time"
     );
     assert.true(
-      composerContent.includes('end="2022-07-24 13:00"'),
+      composerContent.includes('end="2022-07-01 13:00"'),
       "bbcode has correct end time"
     );
     assert.true(


### PR DESCRIPTION
Previously we were storing a 'UTC' datetime in the database which was in fact a local datetime. That means that, every time it was accessed, consumers would have to ignore the "Z" suffix and parse it using the specified `timezone`.

Adding that kind of logic to every consumer would be very error-prone. Instead, this commit changes the implementation so that `original_start_time` and `original_end_time` are 'technically correct', truly-UTC timestamps. Consumers that need to obtain the original 'local' timestamp (e.g. recurrence) can do something like `original_start_time.in_timezone(timezone)`. Most consumers (e.g. notifications, event-countdown UI, etc.) don't care about the original timezone, and so they can now stick to using `original_start_time` without issue.

A number of specs are introduced to test timezone behaviour, including recurrence across daylight-saving transitions.

A migration will fix existing erroneous data in the database.

A number of JS fixes are also included, and a basic JS acceptance test is introduced.