### PR TITLE
FIX: consistent desert island icon for holidays

### DIFF
--- a/assets/javascripts/initializers/add-holiday-flair.js
+++ b/assets/javascripts/initializers/add-holiday-flair.js
@@ -13,8 +13,11 @@ function applyFlairOnMention(element, username) {
   const mentions = element.querySelectorAll(`a.mention[href="${href}"]`);
 
   mentions.forEach((mention) => {
-    if (!mention.querySelector(".d-icon-calendar-alt")) {
-      mention.insertAdjacentHTML("beforeend", emojiUnescape(":desert_island:"));
+    if (!mention.querySelector(".on-holiday")) {
+      mention.insertAdjacentHTML(
+        "beforeend",
+        emojiUnescape(":desert_island:", { class: "on-holiday" })
+      );
     }
     mention.classList.add("on-holiday");
   });
@@ -31,7 +34,8 @@ export default {
         api.addUsernameSelectorDecorator((username) => {
           if (usernames.includes(username)) {
             return `<span class="on-holiday">${emojiUnescape(
-              ":desert_island:"
+              ":desert_island:",
+              { class: "on-holiday" }
             )}</span>`;
           }
         });

--- a/assets/javascripts/initializers/add-holiday-flair.js
+++ b/assets/javascripts/initializers/add-holiday-flair.js
@@ -1,8 +1,8 @@
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { iconHTML } from "discourse-common/lib/icon-library";
 import { cancel, later } from "@ember/runloop";
 import getURL from "discourse-common/lib/get-url";
+import { emojiUnescape } from "discourse/lib/text";
 
 function applyFlairOnMention(element, username) {
   if (!element) {
@@ -14,7 +14,7 @@ function applyFlairOnMention(element, username) {
 
   mentions.forEach((mention) => {
     if (!mention.querySelector(".d-icon-calendar-alt")) {
-      mention.insertAdjacentHTML("beforeend", iconHTML("calendar-alt"));
+      mention.insertAdjacentHTML("beforeend", emojiUnescape(":desert_island:"));
     }
     mention.classList.add("on-holiday");
   });
@@ -30,8 +30,8 @@ export default {
       if (usernames && usernames.length > 0) {
         api.addUsernameSelectorDecorator((username) => {
           if (usernames.includes(username)) {
-            return `<span class="on-holiday">${iconHTML(
-              "calendar-alt"
+            return `<span class="on-holiday">${emojiUnescape(
+              ":desert_island:"
             )}</span>`;
           }
         });

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -154,9 +154,11 @@
   }
 }
 
-.mention .d-icon {
+.mention .emoji {
   margin-left: 0.3em;
-  vertical-align: baseline;
+  vertical-align: center;
+  width: 15px;
+  height: 15px;
 }
 
 a.holiday {

--- a/test/javascripts/acceptance/holiday-flair-test.js
+++ b/test/javascripts/acceptance/holiday-flair-test.js
@@ -73,6 +73,9 @@ acceptance("Discourse Calendar - Holiday Flair", function (needs) {
   test("shows holiday emoji on mention", async function (assert) {
     await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
     assert.ok(exists(".mention.on-holiday img.on-holiday"));
-    assert.strictEqual(query(".mention.on-holiday").innerText.trim(), "@eviltrout");
+    assert.strictEqual(
+      query(".mention.on-holiday").innerText.trim(),
+      "@eviltrout"
+    );
   });
 });

--- a/test/javascripts/acceptance/holiday-flair-test.js
+++ b/test/javascripts/acceptance/holiday-flair-test.js
@@ -73,6 +73,6 @@ acceptance("Discourse Calendar - Holiday Flair", function (needs) {
   test("shows holiday emoji on mention", async function (assert) {
     await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
     assert.ok(exists(".mention.on-holiday img.on-holiday"));
-    assert.equal(query(".mention.on-holiday").innerText.trim(), "@eviltrout");
+    assert.strictEqual(query(".mention.on-holiday").innerText.trim(), "@eviltrout");
   });
 });

--- a/test/javascripts/acceptance/holiday-flair-test.js
+++ b/test/javascripts/acceptance/holiday-flair-test.js
@@ -1,4 +1,8 @@
-import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
@@ -6,7 +10,7 @@ acceptance("Discourse Calendar - Holiday Flair", function (needs) {
   needs.user();
   needs.settings({ calendar_enabled: true });
   needs.site({
-    users_on_holiday: ["foo"],
+    users_on_holiday: ["foo", "eviltrout"],
   });
 
   needs.pretender((server, helper) => {
@@ -64,5 +68,11 @@ acceptance("Discourse Calendar - Holiday Flair", function (needs) {
     assert.ok(exists(".holiday-flair"));
     assert.ok(exists("div[data-username='foo'] .holiday-flair"));
     assert.ok(!exists("div[data-username='bar'] .holiday-flair"));
+  });
+
+  test("shows holiday emoji on mention", async function (assert) {
+    await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
+    assert.ok(exists(".mention.on-holiday img.on-holiday"));
+    assert.equal(query(".mention.on-holiday").innerText.trim(), "@eviltrout");
   });
 });


### PR DESCRIPTION
In some places like mention and assign, we displayed calendar-alt for holiday. It should be consistent, and we should display tropical island everywhere.

Before:
<img width="445" alt="Screen Shot 2022-07-25 at 1 50 04 pm" src="https://user-images.githubusercontent.com/72780/180697924-0bc2d709-ce44-447f-b869-4d9868c1f027.png">
<img width="351" alt="Screen Shot 2022-07-25 at 2 10 57 pm" src="https://user-images.githubusercontent.com/72780/180697928-769eb6ae-12d4-4657-a1d7-563da4659914.png">

After
<img width="445" alt="Screen Shot 2022-07-25 at 1 49 43 pm" src="https://user-images.githubusercontent.com/72780/180697921-ebea562f-c2fd-4387-b908-193ed34c9c4a.png">
<img width="393" alt="Screen Shot 2022-07-25 at 2 15 55 pm" src="https://user-images.githubusercontent.com/72780/180697938-0bb51c31-bdb7-41c2-82d3-bb378084ab68.png">



