### PR TITLE
FEATURE: Allow post events to be edited based on post guardian

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -201,7 +201,7 @@ after_initialize do
     end
     @can_act_on_discourse_post_event = begin
       return true if staff?
-      can_create_discourse_post_event? && event.post.user_id == id
+      can_create_discourse_post_event? && Guardian.new(self).can_edit_post?(event.post)
     rescue StandardError
       false
     end

--- a/spec/models/discourse_post_event/user_spec.rb
+++ b/spec/models/discourse_post_event/user_spec.rb
@@ -59,6 +59,18 @@ describe User do
             expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(false)
           end
         end
+
+        context 'user didn’t create the event, but is allowed to edit the post' do
+          let(:user_2) { Fabricate(:user) }
+          let(:topic_1) { Fabricate(:topic, user: user_2) }
+          let(:post_1) { Fabricate(:post, topic: topic_1, user: user_2) }
+          let(:post_event_1) { Fabricate(:event, post: post_1) }
+          before { user_1.update(trust_level: 4) }
+
+          it 'can act on the event' do
+            expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(true)
+          end
+        end
       end
 
       context 'user is not in list of allowed groups' do


### PR DESCRIPTION
If someone has edit access on a post (e.g. they're TL4), then it makes sense for them to be able to edit the attached event