### PR TITLE
FIX: Ensure date/time pickers behave correctly in all timezones

### DIFF
--- a/assets/javascripts/discourse/controllers/discourse-post-event-builder.js
+++ b/assets/javascripts/discourse/controllers/discourse-post-event-builder.js
@@ -146,13 +146,9 @@ export default Controller.extend(ModalFunctionality, {
 
   @action
   onChangeDates(changes) {
-    // from/to are in the browser's local timezone. Ideally the DateTimeInputRange
-    // component would support a timezone parameter. For now, let's just ignore the timezone
-    // and replace with the event timezone
-    const eventTz = this.model.eventModel.timezone || "UTC";
     this.model.eventModel.setProperties({
-      starts_at: replaceTimezone(changes.from, eventTz),
-      ends_at: changes.to && replaceTimezone(changes.to, eventTz),
+      starts_at: changes.from,
+      ends_at: changes.to,
     });
   },
 

--- a/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
+++ b/assets/javascripts/discourse/templates/modal/discourse-post-event-builder.hbs
@@ -9,6 +9,7 @@
         to=endsAt
         toTimeFirst=true
         clearable=true
+        timezone=model.eventModel.timezone
         onChange=(action "onChangeDates")
       }}
 


### PR DESCRIPTION
Requires https://github.com/discourse/discourse/pull/17654 to function, but will be a safe no-op without so we don't need a `.discourse-compatibility` change