### PR TITLE
Update event.rb

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -92,7 +92,7 @@ module DiscoursePostEvent
     end
 
     MIN_NAME_LENGTH = 5
-    MAX_NAME_LENGTH = 30
+    MAX_NAME_LENGTH = 255
     validates :name,
               length: { in: MIN_NAME_LENGTH..MAX_NAME_LENGTH },
               unless: ->(event) { event.name.blank? }


### PR DESCRIPTION
Matching the event name length to the default topic title length in Discourse core. If there is no event name entered, defaults to topic title anyway.

Has been requested several times, 30 character limit is extremely restrictive.

It would be even better if this used the discourse_max_topic_title_length setting instead to ensure consistency where instances have changed this setting.