### PR TITLE
DEV: Update service references

### DIFF
--- a/assets/javascripts/initializers/add-event-ui-builder.js
+++ b/assets/javascripts/initializers/add-event-ui-builder.js
@@ -55,7 +55,7 @@ export default {
   name: "add-discourse-post-event-builder",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.discourse_post_event_enabled) {
       withPluginApi("0.8.7", initializeEventBuilder);
     }

--- a/assets/javascripts/initializers/add-hamburger-menu-action.js
+++ b/assets/javascripts/initializers/add-hamburger-menu-action.js
@@ -14,7 +14,7 @@ export default {
   name: "add-hamburger-menu-action",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.discourse_post_event_enabled) {
       withPluginApi("0.8.7", initializeHamburgerMenu);
     }

--- a/assets/javascripts/initializers/add-holiday-flair.js
+++ b/assets/javascripts/initializers/add-holiday-flair.js
@@ -29,7 +29,7 @@ export default {
 
   initialize() {
     withPluginApi("0.10.1", (api) => {
-      const usernames = api.container.lookup("site:main").users_on_holiday;
+      const usernames = api.container.lookup("service:site").users_on_holiday;
 
       if (usernames && usernames.length > 0) {
         api.addUsernameSelectorDecorator((username) => {
@@ -44,7 +44,7 @@ export default {
     });
 
     withPluginApi("0.8", (api) => {
-      const usernames = api.container.lookup("site:main").users_on_holiday;
+      const usernames = api.container.lookup("service:site").users_on_holiday;
 
       if (usernames?.length > 0) {
         let flairHandler;

--- a/assets/javascripts/initializers/decorate-topic-title.js
+++ b/assets/javascripts/initializers/decorate-topic-title.js
@@ -35,7 +35,7 @@ export default {
   name: "decorate-topic-title",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.discourse_post_event_enabled) {
       withPluginApi("0.8.40", initializeDecorateTopicTitle);
     }

--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -28,7 +28,7 @@ let eventPopper;
 const EVENT_POPOVER_ID = "event-popover";
 
 function initializeDiscourseCalendar(api) {
-  const siteSettings = api.container.lookup("site-settings:main");
+  const siteSettings = api.container.lookup("service:site-settings");
 
   if (siteSettings.login_required && !api.getCurrentUser()) {
     return;
@@ -37,7 +37,7 @@ function initializeDiscourseCalendar(api) {
   let _topicController;
   const outletName = siteSettings.calendar_categories_outlet;
 
-  const site = api.container.lookup("site:main");
+  const site = api.container.lookup("service:site");
   const isMobileView = site && site.mobileView;
 
   let selector = `.${outletName}-outlet`;
@@ -670,7 +670,7 @@ export default {
   name: "discourse-calendar",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.calendar_enabled) {
       withPluginApi("0.8.22", initializeDiscourseCalendar);
     }

--- a/assets/javascripts/initializers/discourse-group-timezones.js
+++ b/assets/javascripts/initializers/discourse-group-timezones.js
@@ -44,7 +44,7 @@ export default {
             members,
             group,
             usersOnHoliday:
-              api.container.lookup("site:main").users_on_holiday || [],
+              api.container.lookup("service:site").users_on_holiday || [],
             size: groupTimezone.getAttribute("data-size") || "medium",
           });
         });

--- a/assets/javascripts/initializers/discourse-post-event-decorator.js
+++ b/assets/javascripts/initializers/discourse-post-event-decorator.js
@@ -126,7 +126,7 @@ function _attachWidget(api, cooked, eventModel) {
       eventModel.ends_at && moment(eventModel.ends_at).tz(timezone);
     const format = guessDateFormat(startsAt, endsAt);
 
-    const siteSettings = api.container.lookup("site-settings:main");
+    const siteSettings = api.container.lookup("service:site-settings");
     if (siteSettings.discourse_local_dates_enabled) {
       const dates = [];
       dates.push(
@@ -278,7 +278,7 @@ export default {
   name: "discourse-post-event-decorator",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.discourse_post_event_enabled) {
       withPluginApi("0.8.7", initializeDiscoursePostEventDecorator);
     }


### PR DESCRIPTION
**Update** the following services references:
- `site-settings:main` ->  `service:site-settings`
- `site-main` -> `service:site`

to remove the following deprecation warnings:
```bash
[PLUGIN discourse-calendar] Deprecation notice: "site-settings:main" is deprecated, use "service:site-settings" instead (deprecated since Discourse 2.9.0.beta7) (removal in Discourse 3.0.0)

[PLUGIN discourse-calendar] Deprecation notice: "site:main" is deprecated, use "service:site" instead (deprecated since Discourse 2.9.0.beta7) (removal in Discourse 3.0.0)
```