### PR TITLE
FIX: Update regions translation to include Ghana

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -161,6 +161,7 @@ en:
           gb: "United Kingdom"
           ge: "Georgia"
           gg: "Guernsey"
+          gh: "Ghana"
           hk: "Hong Kong"
           hr: "Croatia"
           hu: "Hungary"


### PR DESCRIPTION
Ensure new Ghana holiday region is properly translated and displayed in UI