### PR TITLE
DEV: Add support for the experimental user menu

### DIFF
--- a/assets/javascripts/discourse/widgets/event-invitation-notification-item.js
+++ b/assets/javascripts/discourse/widgets/event-invitation-notification-item.js
@@ -4,7 +4,7 @@ import { DefaultNotificationItem } from "discourse/widgets/default-notification-
 import { escapeExpression, formatUsername } from "discourse/lib/utilities";
 import { iconNode } from "discourse-common/lib/icon-library";
 
-// TODO: delete the strings marked with TODO in translation files when
+// TODO(osama): delete the strings marked with TODO in translation files when
 // this file is removed
 
 createWidgetFrom(

--- a/assets/javascripts/discourse/widgets/event-invitation-notification-item.js
+++ b/assets/javascripts/discourse/widgets/event-invitation-notification-item.js
@@ -4,6 +4,9 @@ import { DefaultNotificationItem } from "discourse/widgets/default-notification-
 import { escapeExpression, formatUsername } from "discourse/lib/utilities";
 import { iconNode } from "discourse-common/lib/icon-library";
 
+// TODO: delete the strings marked with TODO in translation files when
+// this file is removed
+
 createWidgetFrom(
   DefaultNotificationItem,
   "event-invitation-notification-item",
@@ -23,7 +26,14 @@ createWidgetFrom(
         description = this.description(data);
       }
 
-      return I18n.t(data.message, { description, username });
+      let translationKey = data.message;
+      if (
+        translationKey ===
+        "discourse_post_event.notifications.invite_user_predefined_attendance_notification"
+      ) {
+        translationKey += "_html";
+      }
+      return I18n.t(translationKey, { description, username });
     },
 
     icon(notificationName, data) {

--- a/assets/javascripts/discourse/widgets/event-reminder-notification-item.js
+++ b/assets/javascripts/discourse/widgets/event-reminder-notification-item.js
@@ -4,6 +4,9 @@ import { DefaultNotificationItem } from "discourse/widgets/default-notification-
 import { escapeExpression, formatUsername } from "discourse/lib/utilities";
 import { iconNode } from "discourse-common/lib/icon-library";
 
+// TODO: delete the strings marked with TODO in translation files when
+// this file is removed
+
 createWidgetFrom(DefaultNotificationItem, "event-reminder-notification-item", {
   notificationTitle(notificationName, data) {
     return data.title ? I18n.t(data.title) : "";
@@ -21,7 +24,7 @@ createWidgetFrom(DefaultNotificationItem, "event-reminder-notification-item", {
       description = this.description(data);
     }
 
-    return I18n.t(data.message, { description, username });
+    return I18n.t(`${data.message}_html`, { description, username });
   },
 
   icon(notificationName, data) {

--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -173,6 +173,61 @@ function initializeDiscourseCalendar(api) {
     }
   );
 
+  if (api.registerNotificationTypeRenderer) {
+    api.registerNotificationTypeRenderer(
+      "event_reminder",
+      (NotificationTypeBase) => {
+        return class extends NotificationTypeBase {
+          get linkTitle() {
+            if (this.notification.data.title) {
+              return I18n.t(this.notification.data.title);
+            } else {
+              return super.linkTitle;
+            }
+          }
+
+          get icon() {
+            return "calendar-day";
+          }
+
+          get label() {
+            return I18n.t(this.notification.data.message);
+          }
+
+          get description() {
+            return this.notification.data.topic_title;
+          }
+        };
+      }
+    );
+    api.registerNotificationTypeRenderer(
+      "event_invitation",
+      (NotificationTypeBase) => {
+        return class extends NotificationTypeBase {
+          get icon() {
+            return "calendar-day";
+          }
+
+          get label() {
+            if (
+              this.notification.data.message ===
+              "discourse_post_event.notifications.invite_user_predefined_attendance_notification"
+            ) {
+              return I18n.t(this.notification.data.message, {
+                username: this.username,
+              });
+            }
+            return super.label;
+          }
+
+          get description() {
+            return this.notification.data.topic_title;
+          }
+        };
+      }
+    );
+  }
+
   function render($calendar, post) {
     $calendar = $calendar.empty();
 
@@ -548,11 +603,10 @@ function initializeDiscourseCalendar(api) {
         localEvents: {},
       };
 
-      formattedGroupedEvents[identifier].localEvents[
-        groupedEvent.name
-      ] = formattedGroupedEvents[identifier].localEvents[groupedEvent.name] || {
-        usernames: [],
-      };
+      formattedGroupedEvents[identifier].localEvents[groupedEvent.name] =
+        formattedGroupedEvents[identifier].localEvents[groupedEvent.name] || {
+          usernames: [],
+        };
 
       formattedGroupedEvents[identifier].localEvents[
         groupedEvent.name
@@ -595,9 +649,8 @@ function initializeDiscourseCalendar(api) {
 
       tzPicker.value = timezone;
     } else {
-      document.querySelector(
-        ".discourse-calendar-timezone-wrap"
-      ).innerText = timezone;
+      document.querySelector(".discourse-calendar-timezone-wrap").innerText =
+        timezone;
     }
   }
 

--- a/assets/javascripts/initializers/discourse-calendar.js
+++ b/assets/javascripts/initializers/discourse-calendar.js
@@ -603,10 +603,11 @@ function initializeDiscourseCalendar(api) {
         localEvents: {},
       };
 
-      formattedGroupedEvents[identifier].localEvents[groupedEvent.name] =
-        formattedGroupedEvents[identifier].localEvents[groupedEvent.name] || {
-          usernames: [],
-        };
+      formattedGroupedEvents[identifier].localEvents[
+        groupedEvent.name
+      ] = formattedGroupedEvents[identifier].localEvents[groupedEvent.name] || {
+        usernames: [],
+      };
 
       formattedGroupedEvents[identifier].localEvents[
         groupedEvent.name
@@ -649,8 +650,9 @@ function initializeDiscourseCalendar(api) {
 
       tzPicker.value = timezone;
     } else {
-      document.querySelector(".discourse-calendar-timezone-wrap").innerText =
-        timezone;
+      document.querySelector(
+        ".discourse-calendar-timezone-wrap"
+      ).innerText = timezone;
     }
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8,6 +8,9 @@ en:
           discourse_calendar: "Discourse Calendar"
   js:
     notifications:
+      titles:
+        event_reminder: "event reminder"
+        event_invitation: "event invitation"
       popup:
         event_reminder: Event reminder
     discourse_automation:
@@ -293,11 +296,18 @@ en:
       group_availability: "%{group} availability"
     discourse_post_event:
       notifications:
+        invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to"
+        before_event_reminder: "An event is about to start"
+        after_event_reminder: "An event has ended"
+        ongoing_event_reminder: "An event is ongoing"
+        # TODO: delete the following keys (until ongoing_event_reminder_html)
+        # when event-invitation and event-reminder notification item widgets
+        # are removed
         invite_user_notification: "%{username} %{description}"
-        invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to %{description}"
-        before_event_reminder: "An event is about to start %{description}"
-        after_event_reminder: "An event has ended %{description}"
-        ongoing_event_reminder: "An event is ongoing  %{description}"
+        invite_user_predefined_attendance_notification_html: "%{username} has automatically set your attendance and invited you to %{description}"
+        before_event_reminder_html: "An event is about to start %{description}"
+        after_event_reminder_html: "An event has ended %{description}"
+        ongoing_event_reminder_html: "An event is ongoing  %{description}"
       preview:
         more_than_one_event: "You can’t have more than one event."
       edit_reason: "Event updated"

--- a/test/javascripts/acceptance/notifications-test.js
+++ b/test/javascripts/acceptance/notifications-test.js
@@ -1,6 +1,6 @@
 import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import I18n from "I18n";
 
 acceptance("Discourse Calendar - Notifications", function (needs) {

--- a/test/javascripts/acceptance/notifications-test.js
+++ b/test/javascripts/acceptance/notifications-test.js
@@ -1,0 +1,199 @@
+import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+import I18n from "I18n";
+
+acceptance("Discourse Calendar - Notifications", function (needs) {
+  needs.user({ redesigned_user_menu_enabled: true });
+  needs.settings({ calendar_enabled: true });
+
+  needs.pretender((server, helper) => {
+    server.get("/notifications", () => {
+      return helper.response({
+        notifications: [
+          {
+            id: 8832,
+            user_id: 12,
+            notification_type: 27,
+            read: true,
+            high_priority: false,
+            created_at: "2021-01-07 13:31:10 UTC",
+            post_number: 1,
+            topic_id: 993,
+            fancy_title: "Monthly Hangout #3",
+            slug: "monthly-hangout-3",
+            data: {
+              topic_title: "Monthly Hangout #3",
+              display_username: "fun-haver",
+              message:
+                "discourse_post_event.notifications.before_event_reminder",
+            },
+          },
+          {
+            id: 123,
+            user_id: 12,
+            notification_type: 27,
+            read: true,
+            high_priority: false,
+            created_at: "2021-04-26 13:00:02 UTC",
+            post_number: 1,
+            topic_id: 339,
+            fancy_title: "Fancy title and pants",
+            slug: "fancy-title-and-pants",
+            data: {
+              topic_title: "Fancy title and pants",
+              display_username: "fancy-pants-wearer",
+              message:
+                "discourse_post_event.notifications.ongoing_event_reminder",
+            },
+          },
+          {
+            id: 88844,
+            user_id: 12,
+            notification_type: 27,
+            read: true,
+            high_priority: false,
+            created_at: "2021-09-23 01:40:51 UTC",
+            post_number: 1,
+            topic_id: 834,
+            fancy_title: "Topic with event and after_event reminder",
+            slug: "topic-with-event-and-after_event-reminder",
+            data: {
+              topic_title: "Topic with event and after_event reminder",
+              display_username: "attender-no193",
+              message:
+                "discourse_post_event.notifications.after_event_reminder",
+            },
+          },
+          {
+            id: 7542,
+            user_id: 12,
+            notification_type: 28,
+            read: true,
+            high_priority: false,
+            created_at: "2020-10-06 21:00:01 UTC",
+            post_number: 1,
+            topic_id: 195,
+            fancy_title: "Tuesdays are for Among Us",
+            slug: "tuesdays-are-for-among-us",
+            data: {
+              topic_title: "Tuesdays are for Among Us",
+              display_username: "imposter",
+              message:
+                "discourse_post_event.notifications.invite_user_notification",
+            },
+          },
+          {
+            id: 9034,
+            user_id: 12,
+            notification_type: 28,
+            read: true,
+            high_priority: false,
+            created_at: "2022-03-11 02:59:25 UTC",
+            post_number: 1,
+            topic_id: 348,
+            fancy_title: "Asia Pacific team call",
+            slug: "asia-pacific-team-call",
+            data: {
+              topic_title: "Asia Pacific team call",
+              display_username: "apacer",
+              message:
+                "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  test("event reminder and invitation notifications", async function (assert) {
+    await visit("/");
+    await click(".d-header-icons .current-user");
+
+    const notifications = queryAll(
+      "#quick-access-all-notifications ul li.notification a"
+    );
+    assert.strictEqual(notifications.length, 5);
+
+    assert.strictEqual(
+      notifications[0].textContent.replaceAll(/\s+/g, " ").trim(),
+      `${I18n.t(
+        "discourse_post_event.notifications.before_event_reminder"
+      )} Monthly Hangout #3`,
+      "before event reminder notification has the right content"
+    );
+    assert.ok(
+      notifications[0].href.endsWith("/t/monthly-hangout-3/993"),
+      "before event reminder notification links to the event topic"
+    );
+    assert.ok(
+      notifications[0].querySelector(".d-icon-calendar-day"),
+      "before event reminder notification has the right icon"
+    );
+
+    assert.strictEqual(
+      notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
+      `${I18n.t(
+        "discourse_post_event.notifications.ongoing_event_reminder"
+      )} Fancy title and pants`,
+      "ongoing event reminder notification has the right content"
+    );
+    assert.ok(
+      notifications[1].href.endsWith("/t/fancy-title-and-pants/339"),
+      "ongoing event reminder notification links to the event topic"
+    );
+    assert.ok(
+      notifications[1].querySelector(".d-icon-calendar-day"),
+      "ongoing event reminder notification has the right icon"
+    );
+
+    assert.strictEqual(
+      notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
+      `${I18n.t(
+        "discourse_post_event.notifications.after_event_reminder"
+      )} Topic with event and after_event reminder`,
+      "after event reminder notification has the right content"
+    );
+    assert.ok(
+      notifications[2].href.endsWith(
+        "/t/topic-with-event-and-after_event-reminder/834"
+      ),
+      "after event reminder notification links to the event topic"
+    );
+    assert.ok(
+      notifications[2].querySelector(".d-icon-calendar-day"),
+      "after event reminder notification has the right icon"
+    );
+
+    assert.strictEqual(
+      notifications[3].textContent.replaceAll(/\s+/g, " ").trim(),
+      "imposter Tuesdays are for Among Us",
+      "event invitation notification has the right content"
+    );
+    assert.ok(
+      notifications[3].href.endsWith("/t/tuesdays-are-for-among-us/195"),
+      "event invitation notification links to the event topic"
+    );
+    assert.ok(
+      notifications[3].querySelector(".d-icon-calendar-day"),
+      "event invitation notification has the right icon"
+    );
+
+    assert.strictEqual(
+      notifications[4].textContent.replaceAll(/\s+/g, " ").trim(),
+      `${I18n.t(
+        "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
+        { username: "apacer" }
+      )} Asia Pacific team call`,
+      "event invitation with predefined attendance notification has the right content"
+    );
+    assert.ok(
+      notifications[4].href.endsWith("/t/asia-pacific-team-call/348"),
+      "event invitation with predefined attendance notification links to the event topic"
+    );
+    assert.ok(
+      notifications[4].querySelector(".d-icon-calendar-day"),
+      "event invitation with predefined attendance notification has the right icon"
+    );
+  });
+});


### PR DESCRIPTION
This PR ports the widgets-based implementation of the `event_reminder` and `event_invitation` notification items to the experimental Glimmer-based user menu. The changes in this PR should make event notifications in the experimental user menu consistent with they look/behave in the old user menu.

We don't need to add a `.discourse-compatibility` entry for this change because it's fully backward compatible since we check that the `registerNotificationTypeRenderer` plugin API is available before we attempt to use it.

For more context on the experimental user menu, see https://github.com/discourse/discourse/pull/17379.