### PR TITLE
Add GB holiday definition for Queen's State Funeral (2022-09-19)

### DIFF
--- a/vendor/holidays/definitions/gb.yaml
+++ b/vendor/holidays/definitions/gb.yaml
@@ -103,6 +103,12 @@ months:
     regions: [gb_eng, gb_wls, gb_eaw, gb_nir, je, gb_jsy, gg, gb_gsy]
     week: -1
     wday: 1
+  9:
+  - name: State Funeral of Queen Elizabeth II
+    regions: [gb]
+    mday: 19
+    year_ranges:
+      limited: [2022]
   11:
   - name: Guy Fawkes Day
     regions: [gb]
@@ -495,3 +501,13 @@ tests:
       regions: ["gb"]
     expect:
       name: "Bank Holiday"
+  - given:
+      date: '2022-09-19'
+      regions: ["gb"]
+    expect:
+      name: "State Funeral of Queen Elizabeth II"
+  - given:
+      date: '2023-09-19'
+      regions: ["gb"]
+    expect:
+      holiday: false

--- a/vendor/holidays/lib/generated_definitions/europe.rb
+++ b/vendor/holidays/lib/generated_definitions/europe.rb
@@ -512,6 +512,7 @@ module Holidays
             {:mday => 8, :name => "Día de Extremadura", :regions => [:es_ex]},
             {:mday => 11, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Fiesta Nacional de Cataluña", :regions => [:es_ct]},
             {:mday => 24, :name => "La Mercè", :regions => [:es_ct]},
+            {:mday => 19, :year_ranges => { :limited => [2022] },:name => "State Funeral of Queen Elizabeth II", :regions => [:gb]},
             {:mday => 8, :name => "Festa della Madonna di Monte Berico", :regions => [:it_vi]},
             {:mday => 8, :name => "Maria Geburt", :regions => [:li]},
             {:mday => 24, :year_ranges => { :limited => [2018] },:name => "Viņa Svētības pāvesta Franciska pastorālās vizītes Latvijā diena", :regions => [:lv]},

--- a/vendor/holidays/lib/generated_definitions/gb.rb
+++ b/vendor/holidays/lib/generated_definitions/gb.rb
@@ -31,6 +31,7 @@ module Holidays
             {:mday => 12, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Battle of the Boyne", :regions => [:gb_nir]}],
       8 => [{:wday => 1, :week => 1, :name => "Bank Holiday", :regions => [:gb_sct]},
             {:wday => 1, :week => -1, :name => "Bank Holiday", :regions => [:gb_eng, :gb_wls, :gb_eaw, :gb_nir, :je, :gb_jsy, :gg, :gb_gsy]}],
+      9 => [{:mday => 19, :year_ranges => { :limited => [2022] },:name => "State Funeral of Queen Elizabeth II", :regions => [:gb]}],
       11 => [{:mday => 5, :type => :informal, :name => "Guy Fawkes Day", :regions => [:gb]},
             {:mday => 30, :year_ranges => { :until => 2006 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :type => :informal, :name => "St. Andrew's Day", :regions => [:gb_sct]},
             {:mday => 30, :year_ranges => { :from => 2007 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "St. Andrew's Day", :regions => [:gb_sct]}],

--- a/vendor/holidays/test/defs/test_defs_europe.rb
+++ b/vendor/holidays/test/defs/test_defs_europe.rb
@@ -585,6 +585,10 @@ class EuropeDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "Bank Holiday", (Holidays.on(Date.civil(2023, 5, 29), [:gb])[0] || {})[:name]
 
+    assert_equal "State Funeral of Queen Elizabeth II", (Holidays.on(Date.civil(2022, 9, 19), [:gb])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2023, 9, 19), [:gb])[0] || {})[:name]
+
     assert_equal "Nova godina", (Holidays.on(Date.civil(2012, 1, 1), [:hr], [:informal])[0] || {})[:name]
 
     assert_equal "Bogojavljenje ili Sveta tri kralja", (Holidays.on(Date.civil(2012, 1, 6), [:hr], [:informal])[0] || {})[:name]

--- a/vendor/holidays/test/defs/test_defs_gb.rb
+++ b/vendor/holidays/test/defs/test_defs_gb.rb
@@ -137,5 +137,9 @@ class GbDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "Bank Holiday", (Holidays.on(Date.civil(2023, 5, 29), [:gb])[0] || {})[:name]
 
+    assert_equal "State Funeral of Queen Elizabeth II", (Holidays.on(Date.civil(2022, 9, 19), [:gb])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2023, 9, 19), [:gb])[0] || {})[:name]
+
   end
 end


### PR DESCRIPTION
https://www.gov.uk/bank-holidays

The only human-made change is to `gb.yaml`. The other changes were created by `rake generate:definitions`