### PR TITLE
FIX: Add translation entry for Indonesia

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -168,6 +168,7 @@ en:
           hk: "Hong Kong"
           hr: "Croatia"
           hu: "Hungary"
+          id: "Indonesia"
           ie: "Ireland"
           im: "Isle of Man"
           in: "India"


### PR DESCRIPTION
The missing entry caused an untranslated string to be present in the region dropdown.