### PR TITLE
DEV: Ensure topic_list custom field preloading persists in development

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -251,7 +251,7 @@ after_initialize do
     end
   end
 
-  TopicList.preloaded_custom_fields << DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT
+  add_preloaded_topic_list_custom_field DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT
 
   add_to_serializer(:topic_view, :event_starts_at, false) do
     object.topic.custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT]


### PR DESCRIPTION
This was causing an error on topic lists after a zeitwerk reload. Using the official plugin API takes care of reloading correctly.