### PR TITLE
DEV: Add `pluginId` to suppress console warning

### DIFF
--- a/assets/javascripts/initializers/disable-sort.js
+++ b/assets/javascripts/initializers/disable-sort.js
@@ -6,6 +6,8 @@ export default {
   initialize() {
     withPluginApi("0.8", (api) => {
       api.modifyClass("component:topic-list", {
+        pluginId: "discourse-calendar",
+
         @discourseComputed("category")
         sortable(category) {
           let disableSort = true;


### PR DESCRIPTION
This PR suppresses the console warning:

```
[PLUGIN discourse-calendar] To prevent errors in tests, add a `pluginId` key to your `modifyClass` call. This will ensure the modification is only applied once.
```

by adding the `pluginId` attribute to the topic-list component class modification.