### PR TITLE
DEV: Fix specs for personal_message_enabled_groups setting

### DIFF
--- a/spec/lib/discourse_post_event/event_finder_spec.rb
+++ b/spec/lib/discourse_post_event/event_finder_spec.rb
@@ -2,14 +2,15 @@
 require "rails_helper"
 
 describe DiscoursePostEvent::EventFinder do
-  let(:current_user) { Fabricate(:user) }
-  let(:user) { Fabricate(:user) }
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user) }
 
   subject { DiscoursePostEvent::EventFinder }
 
   before do
     Jobs.run_immediately!
     SiteSetting.discourse_post_event_enabled = true
+    Group.refresh_automatic_groups!
   end
 
   context 'when the event is associated to a visible post' do


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/18437, we are removing any references to enable_personal_messages in core and using only personal_message_enabled_groups, which requires auto groups to be assigned in certain specs for them to keep working.