### PR TITLE
DEV: Fix JS tests to handle default site settings

### DIFF
--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -16,6 +16,9 @@ acceptance("Post event - composer", function (needs) {
   test("composer event builder", async function (assert) {
     await visit("/");
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
     await click(".toolbar-popup-menu-options .dropdown-select-box-header");
     await click(".toolbar-popup-menu-options *[data-value='insertEvent']");
 


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413
which changes JS to load default yml site settings,
the main one needing changes is that now the
allow_uncategorized_topics setting is false
by default, so we have to choose a category
first in many places.