### PR TITLE
FIX: Disabling of header sorting now checks the correct site setting and defaults to false

### DIFF
--- a/assets/javascripts/initializers/disable-sort.js
+++ b/assets/javascripts/initializers/disable-sort.js
@@ -16,7 +16,7 @@ export default {
           let disableSort = false;
           if (
             disable_resorting_on_categories_enabled &&
-           category?.custom_fields
+            category?.custom_fields
           ) {
             disableSort = !!category.custom_fields["disable_topic_resorting"];
           }

--- a/assets/javascripts/initializers/disable-sort.js
+++ b/assets/javascripts/initializers/disable-sort.js
@@ -8,10 +8,17 @@ export default {
       api.modifyClass("component:topic-list", {
         pluginId: "discourse-calendar",
 
-        @discourseComputed("category")
-        sortable(category) {
-          let disableSort = true;
-          if (category && category.custom_fields) {
+        @discourseComputed(
+          "category",
+          "siteSettings.disable_resorting_on_categories_enabled"
+        )
+        sortable(category, disable_resorting_on_categories_enabled) {
+          let disableSort = false;
+          if (
+            disable_resorting_on_categories_enabled &&
+            category &&
+            category.custom_fields
+          ) {
             disableSort = !!category.custom_fields["disable_topic_resorting"];
           }
           return !!this.changeSort && !disableSort;

--- a/assets/javascripts/initializers/disable-sort.js
+++ b/assets/javascripts/initializers/disable-sort.js
@@ -16,8 +16,7 @@ export default {
           let disableSort = false;
           if (
             disable_resorting_on_categories_enabled &&
-            category &&
-            category.custom_fields
+           category?.custom_fields
           ) {
             disableSort = !!category.custom_fields["disable_topic_resorting"];
           }

--- a/test/javascripts/acceptance/sort-event-topics-test.js
+++ b/test/javascripts/acceptance/sort-event-topics-test.js
@@ -1,18 +1,20 @@
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
-import { cloneJSON } from "discourse-common/lib/object";
-import CategoryFixtures from "discourse/tests/fixtures/category-fixtures";
+import Site from "discourse/models/site";
 
 acceptance("Calendar - Disable sorting headers", function (needs) {
   needs.user();
-  needs.pretender((server, helper) => {
-    const categoryResponse = cloneJSON(CategoryFixtures["/c/1/show.json"]);
-    categoryResponse.category.custom_fields["disable_topic_resorting"] = true;
-    server.get("/c/1/show.json", () => helper.response(categoryResponse));
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    disable_resorting_on_categories_enabled: true,
   });
 
   test("visiting a category page", async function (assert) {
+    const site = Site.current();
+    site.categories[15].custom_fields = { disable_topic_resorting: true };
+
     await visit("/c/bug");
     assert.ok(exists(".topic-list"), "The list of topics was rendered");
     assert.ok(


### PR DESCRIPTION
- Disabling of header sorting now checks the correct site setting and defaults to false
- Corresponding qunit test fixed to set the category's disable_topic_resorting custom_field before running the test
