### PR TITLE
FIX: calendar wasn't resetting expired statuses

### DIFF
--- a/jobs/scheduled/update_holiday_usernames.rb
+++ b/jobs/scheduled/update_holiday_usernames.rb
@@ -54,6 +54,7 @@ module Jobs
       status = user.user_status
 
       if status.blank? ||
+        status.expired? ||
         (DiscourseCalendar::HolidayStatus.is_holiday_status?(status) && status.ends_at != ends_at)
 
         user.set_status!(


### PR DESCRIPTION
Starting from ccb4993e5700b0f090999ad3c636111015b2a7d4 the calendar plugin sets user status in Core when user is on holiday. But in case a user already set a status by themselves, the calendar plugin doesn't overwrite that status.

Sometimes users set status with the removing timer. After such a status expired, it disappears everywhere, but still there is a row in the table in the database (when ends_at is in the past backend doesn't send such status to the client). The calendar plugin was seeing such expired rows in the user_statuses table, and hence wasn't setting a holiday status.

Since effectively an expired status doesn't exist, the calendar plugin should be overwriting such status when a user is on holiday.

