### PR TITLE
DEV: Drop hidden setting which was making holiday status public

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,9 +5,6 @@ discourse_calendar:
   holiday_calendar_topic_id:
     default: ""
     client: true
-  holiday_calendar_users_public:
-    default: false
-    hidden: true
   delete_expired_event_posts_after:
     min: -1
     default: -1

--- a/plugin.rb
+++ b/plugin.rb
@@ -508,7 +508,7 @@ after_initialize do
     DiscourseCalendar.users_on_holiday
   end
 
-  add_to_serializer(:site, :include_users_on_holiday?) { SiteSetting.holiday_calendar_users_public || scope.is_staff? }
+  add_to_serializer(:site, :include_users_on_holiday?) { scope.is_staff? }
 
   reloadable_patch do
     module DiscoursePostEvent::ExportCsvControllerExtension

--- a/spec/requests/site_spec.rb
+++ b/spec/requests/site_spec.rb
@@ -24,11 +24,4 @@ describe "calendar site additions" do
     expect(response.status).to eq(200)
     expect(response.parsed_body["users_on_holiday"]).to eq([user.username])
   end
-
-  it "makes it public when enabled" do
-    SiteSetting.holiday_calendar_users_public = true
-    get "/site.json"
-    expect(response.status).to eq(200)
-    expect(response.parsed_body["users_on_holiday"]).to eq([user.username])
-  end
 end


### PR DESCRIPTION
It was a temporary addition, see 67b81b3d691437089aefb00d01995ecc5973780a. After ccb4993e5700b0f090999ad3c636111015b2a7d4 it doesn't take any effect.