### PR TITLE
FEATURE: handle subsequent and intersected holidays

### DIFF
--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -21,7 +21,11 @@ class CalendarEvent < ActiveRecord::Base
 
   def underway?
     now = Time.zone.now
-    start_date < now && now < ends_at
+    start_date <= now && now < ends_at
+  end
+
+  def in_future?
+    start_date > Time.zone.now
   end
 
   def self.update(post)

--- a/lib/users_on_holiday.rb
+++ b/lib/users_on_holiday.rb
@@ -15,14 +15,14 @@ module DiscourseCalendar
     private
 
     def self.current_holiday(user_events)
-      holiday_ends_at = holiday_ends_at(user_events)
-      return nil unless holiday_ends_at
+      ends_at = holiday_ends_at(user_events)
+      return nil unless ends_at
 
       [
         user_events[0].user_id,
         {
           username: user_events[0].username,
-          ends_at: holiday_ends_at
+          ends_at: ends_at
         }
       ]
     end
@@ -59,14 +59,14 @@ module DiscourseCalendar
     def self.holiday_ends_at(events)
       sorted_events = events.sort_by(&:start_date)
       return nil if sorted_events.first.in_future?
-      return sorted_events.first.ends_at if events.count === 1
+      return sorted_events.first.ends_at if events.count == 1
 
       result = sorted_events.first.ends_at
       sorted_events.each_cons(2) do |pair|
         if pair[0].ends_at < pair[1].start_date
           return result
-        else
-          result = pair[1].ends_at if pair[1].ends_at > result
+        elsif pair[1].ends_at > result
+          result = pair[1].ends_at
         end
       end
 

--- a/lib/users_on_holiday.rb
+++ b/lib/users_on_holiday.rb
@@ -5,17 +5,72 @@ module DiscourseCalendar
     def self.from(calendar_events)
       calendar_events
         .filter { |e| e.user_id.present? && e.username.present? }
-        .filter { |e| e.underway? }
+        .filter { |e| e.underway? || e.in_future? }
         .group_by(&:user_id)
-        .map { |_, events| events.sort_by(&:ends_at).last }
-        .to_h { |e| [
-          e.user_id,
-          {
-            username: e.username,
-            ends_at: e.ends_at
-          }
-        ]
+        .map { |_, events| current_holiday(events) }
+        .compact
+        .to_h
+    end
+
+    private
+
+    def self.current_holiday(user_events)
+      holiday_ends_at = holiday_ends_at(user_events)
+      return nil unless holiday_ends_at
+
+      [
+        user_events[0].user_id,
+        {
+          username: user_events[0].username,
+          ends_at: holiday_ends_at
         }
+      ]
+    end
+
+    # If a user has several holidays one after another
+    # we want to show the farthest end date.
+    #
+    # Let's say today is Monday and I am sick,
+    # and I also have days off from Tuesday to Friday:
+    #
+    # sick      ▭
+    # days off   ▭▭▭▭
+    #
+    # We want to show Friday as an end date of my holiday.
+    #
+    # This algorithm also works in case the holidays intersect,
+    # like this:
+    #
+    # event_1  ▭▭▭▭
+    # event_2    ▭▭▭▭
+    # event_3       ▭▭▭▭
+    #
+    # or like this:
+    #
+    # event_1  ▭▭▭▭
+    # event_2  ▭▭▭▭▭▭▭▭
+    # event_3    ▭▭▭▭▭▭▭▭▭▭
+    #
+    # or like this:
+    #
+    # event_1  ▭▭▭▭▭▭▭▭▭▭
+    # event_2      ▭
+    #
+    def self.holiday_ends_at(events)
+      sorted_events = events.sort_by(&:start_date)
+      return nil if sorted_events.first.in_future?
+      return sorted_events.first.ends_at if events.count === 1
+
+      result = sorted_events.first.ends_at
+      sorted_events.each_cons(2) do |pair|
+        if pair[0].ends_at < pair[1].start_date
+          return result
+        else
+          result = pair[1].ends_at if pair[1].ends_at > result
+        end
+      end
+
+      result
     end
   end
 end

--- a/spec/lib/users_on_holiday_spec.rb
+++ b/spec/lib/users_on_holiday_spec.rb
@@ -28,7 +28,7 @@ describe DiscourseCalendar::UsersOnHoliday do
     expect(users_on_holiday).to be_empty
   end
 
-  it "ignore events without usernames" do
+  it "ignore holidays without usernames" do
     event1 = Fabricate(:calendar_event, start_date: "2000-01-01")
     event2 = Fabricate(:calendar_event, start_date: "2000-01-01")
     event3 = Fabricate(:calendar_event, start_date: "2000-01-01", username: nil)
@@ -40,17 +40,97 @@ describe DiscourseCalendar::UsersOnHoliday do
     expect(usernames).to contain_exactly(event1.username, event2.username)
   end
 
-  it "chooses the holiday with the biggest end date if user has several holidays" do
-    user = Fabricate(:user)
-    biggest_end_date = "2000-01-04"
-    event1 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: "2000-01-02")
-    event2 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: "2000-01-03")
-    event3 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: biggest_end_date)
+  it "don't pick up holidays in the future" do
+    event1 = Fabricate(:calendar_event, start_date: "2000-01-02")
+    event2 = Fabricate(:calendar_event, start_date: "2000-01-03")
+    event3 = Fabricate(:calendar_event, start_date: "2000-01-04")
+    event4 = Fabricate(:calendar_event, start_date: "2000-01-05")
 
     freeze_time Time.utc(2000, 1, 1, 8, 0)
-    users_on_holiday = DiscourseCalendar::UsersOnHoliday.from([event1, event2, event3])
+    users_on_holiday = DiscourseCalendar::UsersOnHoliday.from([event1, event2, event3, event4])
 
-    expect(users_on_holiday.length).to be(1)
-    expect(users_on_holiday.values[0][:ends_at]).to eq(biggest_end_date)
+    expect(users_on_holiday).to be_empty
+  end
+
+  context "with subsequent and intersected holidays" do
+    it "chooses the farthest end date if a user has several holidays" do
+      user = Fabricate(:user)
+      biggest_end_date = "2000-01-04"
+      #
+      # event1  ▭▭▭▭
+      # event2  ▭▭▭▭▭▭▭▭
+      # event3  ▭▭▭▭▭▭▭▭▭▭▭▭
+      #                     ↑
+      event1 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: "2000-01-02")
+      event2 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: "2000-01-03")
+      event3 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: biggest_end_date)
+
+      freeze_time Time.utc(2000, 1, 1, 8, 0)
+      users_on_holiday = DiscourseCalendar::UsersOnHoliday.from([event1, event2, event3])
+
+      expect(users_on_holiday.length).to be(1)
+      expect(users_on_holiday.values[0][:ends_at]).to eq(biggest_end_date)
+    end
+
+    it "chooses the farthest end date if a user has a short holiday in the middle of a long vacation" do
+      user = Fabricate(:user)
+      biggest_end_date = "2000-01-07"
+      #
+      # event1  ▭▭▭▭▭▭▭▭
+      # event2     ▭    ↑
+      #
+      event1 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: biggest_end_date)
+      event2 = Fabricate(:calendar_event, user: user, start_date: "2000-01-04", end_date: "2000-01-05")
+
+      freeze_time Time.utc(2000, 1, 1, 8, 0)
+      users_on_holiday = DiscourseCalendar::UsersOnHoliday.from([event1, event2])
+
+      expect(users_on_holiday.length).to be(1)
+      expect(users_on_holiday.values[0][:ends_at]).to eq(biggest_end_date)
+    end
+
+    it "chooses the farthest end date if a user has several subsequent holidays" do
+      user = Fabricate(:user)
+      farthest_end_date = "2000-01-04"
+      #
+      # event1  ▭▭▭▭
+      # event2      ▭▭▭▭
+      # event3          ▭▭▭▭
+      # event4              ↑        ▭▭▭▭
+      #
+      event1 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01", end_date: "2000-01-02")
+      event2 = Fabricate(:calendar_event, user: user, start_date: "2000-01-02", end_date: "2000-01-03")
+      event3 = Fabricate(:calendar_event, user: user, start_date: "2000-01-03", end_date: farthest_end_date)
+      # this event isn't a part of the chain of subsequent holidays
+      event4 = Fabricate(:calendar_event, user: user, start_date: "2000-01-08", end_date: "2000-01-10")
+
+      freeze_time Time.utc(2000, 1, 1, 8, 0)
+      users_on_holiday = DiscourseCalendar::UsersOnHoliday.from([event1, event2, event3, event4])
+
+      expect(users_on_holiday.length).to be(1)
+      expect(users_on_holiday.values[0][:ends_at]).to eq(farthest_end_date)
+    end
+
+    it "chooses the farthest end date if a user has several subsequent holidays with intersections" do
+      user = Fabricate(:user)
+      farthest_end_date = "2000-01-04 08:00:00"
+      #
+      # event1  ▭▭▭▭
+      # event2    ▭▭▭▭
+      # event3       ▭▭▭▭
+      # event4           ↑       ▭▭▭▭
+      #
+      event1 = Fabricate(:calendar_event, user: user, start_date: "2000-01-01 08:00:00", end_date: "2000-01-02 10:00:00")
+      event2 = Fabricate(:calendar_event, user: user, start_date: "2000-01-02 08:00:00", end_date: "2000-01-03 12:00:00")
+      event3 = Fabricate(:calendar_event, user: user, start_date: "2000-01-03 08:00:00", end_date: farthest_end_date)
+      # this event isn't a part of the chain of subsequent holidays
+      event4 = Fabricate(:calendar_event, user: user, start_date: "2000-01-08", end_date: "2000-01-10")
+
+      freeze_time Time.utc(2000, 1, 1, 8, 0)
+      users_on_holiday = DiscourseCalendar::UsersOnHoliday.from([event1, event2, event3, event4])
+
+      expect(users_on_holiday.length).to be(1)
+      expect(users_on_holiday.values[0][:ends_at]).to eq(farthest_end_date)
+    end
   end
 end


### PR DESCRIPTION
If a user has several holidays one after another, we want to show the farthest end date.

For example, let's say today is Monday, and I am sick, and I also have days off from Tuesday to Friday. Then we want to show Friday as an end date of my time off.

Or let's say I have a vacation from Monday to Friday and at the same time there is a public holiday in my country on Monday. We want to show Friday as the end of my time off in this case.