### PR TITLE
FIX: exclude deleted events from MonitorEventJob

### DIFF
--- a/app/models/discourse_post_event/event_date.rb
+++ b/app/models/discourse_post_event/event_date.rb
@@ -5,7 +5,7 @@ module DiscoursePostEvent
     self.table_name = 'discourse_calendar_post_event_dates'
     belongs_to :event
 
-    scope :pending, -> { where(finished_at: nil) }
+    scope :pending, -> { where(finished_at: nil).joins(:event).where("discourse_post_event_events.deleted_at is NULL") }
     scope :expired, -> { where('ends_at IS NOT NULL AND ends_at < ?', Time.now) }
     scope :not_expired, -> { where('ends_at IS NULL OR ends_at > ?', Time.now) }
 

--- a/spec/jobs/scheduled/monitor_event_dates_spec.rb
+++ b/spec/jobs/scheduled/monitor_event_dates_spec.rb
@@ -30,6 +30,14 @@ describe DiscourseCalendar::MonitorEventDates do
         described_class.new.execute({})
       end
     end
+
+    it 'does not lodge reminder jobs when event is deleted' do
+      freeze_time (7.days.after - 59.minutes)
+      past_event.update!(deleted_at: Time.now)
+      expect_not_enqueued_with(job: :discourse_post_event_send_reminder) do
+        described_class.new.execute({})
+      end
+    end
   end
 
   describe '#trigger_events' do


### PR DESCRIPTION
When the post is deleted, the linked event is automatically deleted as well. 
Job should not try to process deleted events.