### PR TITLE
FIX: handle localised automatic group names in event validation

### DIFF
--- a/lib/discourse_post_event/event_validator.rb
+++ b/lib/discourse_post_event/event_validator.rb
@@ -93,7 +93,11 @@ module DiscoursePostEvent
       return true unless event[:"allowed-groups"]
 
       event[:"allowed-groups"].split(',').each do |group_name|
-        group = Group.find_by(name: group_name)
+        group = begin
+          Group.lookup_group(group_name.to_sym)
+        rescue ArgumentError
+          nil
+        end
 
         if !group || !guardian.can_see_group?(group)
           @post.errors.add(:base, I18n.t("discourse_post_event.errors.models.event.invalid_allowed_groups"))

--- a/spec/integration/post_spec.rb
+++ b/spec/integration/post_spec.rb
@@ -295,6 +295,18 @@ describe Post do
             expect(post.event.raw_invitees).to eq([])
           end
 
+          it "works with localised automatic group names" do
+            I18n.locale = SiteSetting.default_locale = 'fr'
+
+            group = Group.find(Group::AUTO_GROUPS[:trust_level_0])
+            group.update!(name: I18n.t("groups.default_names.trust_level_0"))
+
+            post =
+              create_post_with_event(user, 'status="public" allowedGroups="trust_level_0"')
+                .reload
+            expect(post.event.raw_invitees).to eq(%w[trust_level_0])
+          end
+
           it 'works with reminders attribute' do
             post = create_post_with_event(user).reload
             expect(post.event.reminders).to eq(nil)


### PR DESCRIPTION
Context: https://meta.discourse.org/t/event-calendar-plugin-official-broken-publik-events/246731