### PR TITLE
FIX: Delete topic timer when reminder is removed

### DIFF
--- a/jobs/regular/discourse_post_event/bump_topic.rb
+++ b/jobs/regular/discourse_post_event/bump_topic.rb
@@ -6,10 +6,7 @@ module Jobs
 
     def execute(args)
       return unless topic = Topic.find_by(id: args[:topic_id].to_i)
-      return if args[:date].blank?
-
       event_user = User.find_by(id: topic.user_id)
-      timer = TopicTimer.find_by(topic_id: args[:topic_id].to_i)
 
       topic.set_or_create_timer(TopicTimer.types[:bump], args[:date], by_user: event_user)
     end


### PR DESCRIPTION
Now, if you remove an "auto-bump topic" reminder, it will also remove the topic timer