### PR TITLE
DEV: Fix a spec tied to a specific year

### DIFF
--- a/spec/requests/admin/admin_holidays_controller_spec.rb
+++ b/spec/requests/admin/admin_holidays_controller_spec.rb
@@ -17,6 +17,8 @@ module Admin::DiscourseCalendar
           before { sign_in(admin) }
 
           it "returns a list of holidays for a given region" do
+            freeze_time DateTime.parse("2022-12-24 12:00")
+
             get "/admin/discourse-calendar/holiday-regions/mx/holidays.json"
 
             expect(response.parsed_body["holidays"]).to include(


### PR DESCRIPTION
The spec checks specific 2022 holidays, so it started to fail as soon as we entered 2023. 😉 Freezing the time to 2022 fixes the problem.