### PR TITLE
FIX: Make users_on_holiday return type consistent

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -92,7 +92,7 @@ after_initialize do
     GROUP_TIMEZONES_CUSTOM_FIELD ||= "group-timezones"
 
     def self.users_on_holiday
-      PluginStore.get(PLUGIN_NAME, USERS_ON_HOLIDAY_KEY)
+      PluginStore.get(PLUGIN_NAME, USERS_ON_HOLIDAY_KEY) || []
     end
 
     def self.users_on_holiday=(usernames)

--- a/spec/integration/curently_away_report_spec.rb
+++ b/spec/integration/curently_away_report_spec.rb
@@ -7,16 +7,25 @@ describe "currently_away report" do
   fab!(:user_2) { Fabricate(:user) }
   fab!(:group_1) { Fabricate(:group) }
 
-  before do
-    group_1.add(user_1)
+  before { group_1.add(user_1) }
 
-    DiscourseCalendar.users_on_holiday = [user_1.username]
+  context "when users_on_holiday is not set" do
+    it "does not generate report with data" do
+      report = Report.find("currently_away", filters: { group: group_1.id })
+
+      expect(report.data).to eq([])
+      expect(report.total).to eq(0)
+    end
   end
 
-  it "generates a correct report" do
-    report = Report.find("currently_away", filters: { group: group_1.id })
+  context "when users_on_holiday is set" do
+    before { DiscourseCalendar.users_on_holiday = [user_1.username] }
 
-    expect(report.data).to contain_exactly({ username: user_1.username })
-    expect(report.total).to eq(1)
+    it "generates a correct report" do
+      report = Report.find("currently_away", filters: { group: group_1.id })
+
+      expect(report.data).to contain_exactly({ username: user_1.username })
+      expect(report.total).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Return an empty array instead of nil when the plugin store has not yet been populated with `users_on_holiday`.

At the moment, the `currently_away` report fails if the `UpdateHolidayUsernames` never gets the chance to update `users_on_holiday`.