### PR TITLE
FIX: Sometimes the event doesn't load after creating it

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -254,7 +254,9 @@ after_initialize do
     SiteSetting.discourse_post_event_enabled && !object.nil? && !object.deleted_at.present?
   end
 
-  on(:post_process_cooked) { |doc, post| DiscoursePostEvent::Event.update_from_raw(post) }
+  on(:post_created) { |post| DiscoursePostEvent::Event.update_from_raw(post) }
+
+  on(:post_edited) { |post| DiscoursePostEvent::Event.update_from_raw(post) }
 
   on(:post_destroyed) do |post|
     if SiteSetting.discourse_post_event_enabled && post.event


### PR DESCRIPTION
![Screenshot from 2023-01-03 09-01-30](https://user-images.githubusercontent.com/66427541/211581946-6578ca81-e11a-478e-a5be-15899e0e4d98.png)

Currently, the `update_from_raw` function gets called by the `:post_process_cooked` event,. This sometimes causes the event not to load after creating it. I haven't been able to pinpoint the exact problem here, but my best bet is that it's some sort of timing-related issue, as it's fairly inconsistent to reproduce.

Since `update_from_raw` doesn't affect the cooked output, triggering it earlier solves the loading problem.