### PR TITLE
FEATURE: allow disabling automatic holidays globally

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -51,6 +51,7 @@ en:
     events_calendar_categories: "Display an events calendar at the top of a category."
     sort_categories_by_event_start_date_enabled: "Enable the sorting of category topics by event start date."
     disable_resorting_on_categories_enabled: "Allow categories to disable the ability for users to sort on the event category."
+    calendar_automatic_holidays_enabled: "Automatically set holiday status based on a users region (note: you can disable specific automatic holidays in plugin settings)"
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,7 @@ discourse_calendar:
   close_to_working_day_hours_extension:
     default: 2
     client: true
+  calendar_automatic_holidays_enabled: true
 
 discourse_post_event:
   discourse_post_event_enabled:

--- a/jobs/scheduled/create_holiday_events.rb
+++ b/jobs/scheduled/create_holiday_events.rb
@@ -5,8 +5,12 @@ module Jobs
     every 10.minutes
 
     def execute(args)
-      return unless SiteSetting.calendar_enabled
-      return unless topic_id = SiteSetting.holiday_calendar_topic_id.presence
+      return if !SiteSetting.calendar_enabled
+      return if !SiteSetting.calendar_automatic_holidays_enabled
+
+      topic_id = SiteSetting.holiday_calendar_topic_id.presence
+
+      return if !topic_id
 
       require "holidays" if !defined?(Holidays)
 

--- a/spec/jobs/scheduled/create_holiday_events_spec.rb
+++ b/spec/jobs/scheduled/create_holiday_events_spec.rb
@@ -18,6 +18,16 @@ describe DiscourseCalendar::CreateHolidayEvents do
     SiteSetting.holiday_calendar_topic_id = calendar_post.topic_id
   end
 
+  it "can be disabled" do
+    SiteSetting.calendar_automatic_holidays_enabled = false
+
+    frenchy
+    freeze_time Time.zone.local(2019, 8, 1)
+    subject.execute(nil)
+
+    expect(CalendarEvent.where(user_id: frenchy.id).count).to eq(0)
+  end
+
   it "adds all holidays in the next 6 months" do
     frenchy
     freeze_time Time.zone.local(2019, 8, 1)


### PR DESCRIPTION
Automatic holidays can not be disabled by disabling
`calendar_automatic_holidays_enabled`

By default we will set automatic holidays
