### PR TITLE
FIX: Update CNY for Singapore

### DIFF
--- a/vendor/holidays/definitions/sg.yaml
+++ b/vendor/holidays/definitions/sg.yaml
@@ -8,6 +8,7 @@
 
 # Source:
 # http://publicholidays.sg/
+# https://www.mom.gov.sg/employment-practices/public-holidays
 
 months:
   1:
@@ -15,17 +16,17 @@ months:
     regions: [sg]
     mday: 1
     observed: to_weekday_if_weekend(date)
+  - name: First day of Chinese New Year (Observed)
+    regions: [sg]
+    mday: 23
+    year_ranges:
+      limited: [2023]
+  - name: Second day of Chinese New Year
+    regions: [sg]
+    mday: 24
+    year_ranges:
+      limited: [2023]
   2:
-  - name: Chinese New Year
-    regions: [sg]
-    mday: 1
-    year_ranges:
-      limited: [2022]
-  - name: Chinese New Year Holiday
-    regions: [sg]
-    mday: 2
-    year_ranges:
-      limited: [2022]
   - name: Valentine's Day
     regions: [sg]
     mday: 14
@@ -37,41 +38,41 @@ months:
   4:
   - name: Good Friday
     regions: [sg]
-    mday: 15
+    mday: 7
     year_ranges:
-      limited: [2022]
+      limited: [2023]
+  - name: Hari Raya Puasa (Observed)
+    regions: [sg]
+    mday: 24
+    year_ranges:
+      limited: [2023]
   5:
   - name: Labour Day
     regions: [sg]
     mday: 1
     observed: to_weekday_if_weekend(date)
-  - name: Hari Raya Puasa
+  6:
+  - name: Vesak Day
     regions: [sg]
-    mday: 3
+    mday: 2
     year_ranges:
-      limited: [2022]
-  - name: Vesak Day Holiday
+      limited: [2023]
+  - name: Hari Raya Haji
     regions: [sg]
-    mday: 16
+    mday: 29
     year_ranges:
-      limited: [2022]
-  7:
-  - name: Hari Raya Haji Holiday
-    regions: [sg]
-    mday: 11
-    year_ranges:
-      limited: [2022]
+      limited: [2023]
   8:
   - name: National Day
     regions: [sg]
     mday: 9
     observed: to_weekday_if_weekend(date)
-  10:
-  - name: Deepavali
+  11:
+  - name: Deepavali (Observed)
     regions: [sg]
-    mday: 24
+    mday: 13
     year_ranges:
-      limited: [2022]
+      limited: [2023]
   12:
   - name: Christmas Day
     regions: [sg]


### PR DESCRIPTION
Updating 2023 holidays for Singapore since some are due to lunar, hindu, or islamic calendars. Changes:

| Date | Day | Event | Note
| -- | -- | -- | -- |
22, 23 January 2023 | Sunday Monday |  Chinese New Year | Tuesday, 24 January 2023, will be a public holiday.
7 April 2023 | Friday | Good Friday
22 April 2023 | Saturday | Hari Raya Puasa | Observed on the following Monday 24th April 2023.
2 June 2023 | Friday |   Vesak Day
29 June 2023 | Thursday   | Hari Raya Haji
12 November 2023 | Sunday |   Deepavali | Monday, 13 November 2023, will be a public holiday.


