### PR TITLE
FIX: Add backward compatibility for reminders

### DIFF
--- a/app/serializers/discourse_post_event/event_serializer.rb
+++ b/app/serializers/discourse_post_event/event_serializer.rb
@@ -36,7 +36,9 @@ module DiscoursePostEvent
       (object.reminders || "")
         .split(",")
         .map do |reminder|
-          type, value, unit = reminder.split(".")
+          unit, value, type = reminder.split(".").reverse
+          type ||= "notification"
+
           value = value.to_i
           { value: value.to_i.abs, unit: unit, period: value > 0 ? "before" : "after", type: type }
         end

--- a/jobs/scheduled/monitor_event_dates.rb
+++ b/jobs/scheduled/monitor_event_dates.rb
@@ -57,9 +57,10 @@ module Jobs
         .reminders
         .split(",")
         .map do |reminder|
-          type, value, unit = reminder.split(".")
+          unit, value, type = reminder.split(".").reverse
 
           next if type === "bumpTopic" || !validate_reminder_unit(unit)
+          reminder = "notification.#{value}.#{unit}" if type.blank?
 
           date = event_date.starts_at - value.to_i.public_send(unit)
           { description: reminder, date: date }

--- a/spec/jobs/scheduled/monitor_event_dates_spec.rb
+++ b/spec/jobs/scheduled/monitor_event_dates_spec.rb
@@ -10,7 +10,7 @@ describe DiscourseCalendar::MonitorEventDates do
       post: post_1,
       original_starts_at: 7.days.after,
       original_ends_at: 7.days.after + 1.hour,
-      reminders: "notification.15.minutes,notification.1.hours,bumpTopic.10.minutes",
+      reminders: "15.minutes,notification.1.hours,bumpTopic.10.minutes",
     )
   end
   let(:past_date) { past_event.event_dates.first }


### PR DESCRIPTION
The migration did not change the raw topic content. Therefore, if you edit and save the event through the composer (not the modal), it applied back the old format. This change is to deal with those cases.

old syntax:   `reminders="<value>.<unit>"`
new syntax:  `reminders="<type>.<value>.<unit>"`