### PR TITLE
FIX: Disable invitation notifications for recurrent events

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -55,8 +55,10 @@ module DiscoursePostEvent
 
       publish_update!
       invitees.update_all(status: nil, notified: false)
-      notify_invitees!
-      notify_missing_invitees!
+      if !next_dates[:rescheduled]
+        notify_invitees!
+        notify_missing_invitees!
+      end
     end
 
     def set_topic_bump
@@ -363,7 +365,7 @@ module DiscoursePostEvent
 
     def calculate_next_date
       if !original_ends_at || self.recurrence.blank? || original_starts_at > Time.current
-        return { starts_at: original_starts_at, ends_at: original_ends_at }
+        return { starts_at: original_starts_at, ends_at: original_ends_at, rescheduled: false }
       end
 
       localized_start = original_starts_at.in_time_zone(timezone)
@@ -398,7 +400,7 @@ module DiscoursePostEvent
       difference = original_ends_at - original_starts_at
       next_ends_at = next_starts_at + difference.seconds
 
-      { starts_at: next_starts_at, ends_at: next_ends_at }
+      { starts_at: next_starts_at, ends_at: next_ends_at, rescheduled: true }
     end
   end
 end

--- a/spec/integration/post_spec.rb
+++ b/spec/integration/post_spec.rb
@@ -132,10 +132,10 @@ describe Post do
               end
 
               # that will be handled by new job, uncomment when finishedh
-              it "resends event creation notification to invitees" do
-                expect { event_1.update_with_params!(original_ends_at: Time.now) }.to change {
+              it "doesn’t resend event creation notification to invitees" do
+                expect { event_1.update_with_params!(original_ends_at: Time.now) }.not_to change {
                   going_user.notifications.count
-                }.by(1)
+                }
               end
             end
           end
@@ -467,14 +467,12 @@ describe Post do
           status: Event.statuses[:private],
           raw_invitees: [group_1.name],
           recurrence: "FREQ=WEEKLY;BYDAY=MO",
-          original_starts_at: 3.hours.ago,
+          original_starts_at: 2.hours.from_now,
           original_ends_at: nil,
         )
       end
 
       before do
-        Invitee.create_attendance!(invitee_1.id, event_1.id, :going)
-
         # we stop processing jobs immediately at this point to prevent infinite loop
         # as future event ended job would finish now, trigger next recurrence, and anodther job...
         Jobs.run_later!
@@ -482,9 +480,7 @@ describe Post do
 
       context "when updating the end" do
         it "resends event creation notification to invitees and possible invitees" do
-          expect(event_1.invitees.count).to eq(1)
-
-          expect { event_1.update_with_params!(original_ends_at: 2.hours.ago) }.to change {
+          expect { event_1.update_with_params!(original_ends_at: 3.hours.from_now) }.to change {
             invitee_1.notifications.count + invitee_2.notifications.count
           }.by(2)
         end

--- a/spec/integration/recurrence_spec.rb
+++ b/spec/integration/recurrence_spec.rb
@@ -26,9 +26,10 @@ describe "discourse_post_event_recurrence" do
   it "delete previous notifications before creating a new one for invites" do
     going_user = Fabricate(:user)
     DiscoursePostEvent::Invitee.create_attendance!(going_user.id, post_event_1.id, :going)
-    post_event_1.update!(recurrence: "every_month")
 
+    post_event_1.update!(original_starts_at: starts_at + 10.minutes)
     post_event_1.set_next_date
+    post_event_1.update!(original_starts_at: starts_at - 10.minutes)
     post_event_1.set_next_date
 
     expect(


### PR DESCRIPTION
Invitation notifications for events are sent to all those who participate in them whenever the event dates are modified. While this is useful for keeping everyone on track with the latest changes, it may not be necessary for recurring events where the next scheduled date is already known.

This PR disables notifications in such situations. Note that the reminders will still be sent if changes are made manually, and configurable reminders will remain the same.