### PR TITLE
FIX: Quebec's national holiday observed Monday

### DIFF
--- a/vendor/holidays/lib/generated_definitions/ca.rb
+++ b/vendor/holidays/lib/generated_definitions/ca.rb
@@ -36,7 +36,7 @@ module Holidays
             {:wday => 0, :week => 2, :type => :informal, :name => "Mother's Day", :regions => [:us, :ca]},
             {:wday => 6, :week => 3, :type => :informal, :name => "Armed Forces Day", :regions => [:us]}],
       6 => [{:mday => 24, :type => :informal, :name => "Discovery Day", :regions => [:ca_nl]},
-            {:mday => 24, :name => "Fête Nationale", :regions => [:ca_qc]},
+            {:mday => 24, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Fête Nationale", :regions => [:ca_qc]},
             {:mday => 21, :name => "National Aboriginal Day", :regions => [:ca_nt]},
             {:mday => 21, :year_ranges => { :from => 2017 },:name => "National Aboriginal Day", :regions => [:ca_yt]},
             {:wday => 0, :week => 3, :type => :informal, :name => "Father's Day", :regions => [:us, :ca]}],

--- a/vendor/holidays/lib/generated_definitions/northamerica.rb
+++ b/vendor/holidays/lib/generated_definitions/northamerica.rb
@@ -68,7 +68,7 @@ module Holidays
             {:wday => 0, :week => 2, :type => :informal, :name => "Mother's Day", :regions => [:us, :ca]},
             {:wday => 6, :week => 3, :type => :informal, :name => "Armed Forces Day", :regions => [:us]}],
       6 => [{:mday => 24, :type => :informal, :name => "Discovery Day", :regions => [:ca_nl]},
-            {:mday => 24, :name => "Fête Nationale", :regions => [:ca_qc]},
+            {:mday => 24, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Fête Nationale", :regions => [:ca_qc]},
             {:mday => 21, :name => "National Aboriginal Day", :regions => [:ca_nt]},
             {:mday => 21, :year_ranges => { :from => 2017 },:name => "National Aboriginal Day", :regions => [:ca_yt]},
             {:wday => 0, :week => 3, :type => :informal, :name => "Día del Padre", :regions => [:mx]},


### PR DESCRIPTION
Update config so that Saint Jean Baptiste, on June 26 is observed on Monday (June 26), since it falls on a weekend this year.