### PR TITLE
DEV: Fix const redefine warnings in javascript.rake

### DIFF
--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -2,10 +2,19 @@
 
 require "open-uri"
 
-TIMEZONES_DEFINITIONS =
+TIMEZONES_DEFINITIONS ||=
   "https://raw.githubusercontent.com/moment/moment-timezone/develop/data/meta/latest.json"
-UNUSED_REGIONS = %w[ecbtarget federalreserve federalreservebanks fedex nerc unitednations ups nyse]
-HOLIDAYS_COUNTRY_OVERRIDES = { "gr" => "el" }
+UNUSED_REGIONS ||= %w[
+  ecbtarget
+  federalreserve
+  federalreservebanks
+  fedex
+  nerc
+  unitednations
+  ups
+  nyse
+]
+HOLIDAYS_COUNTRY_OVERRIDES ||= { "gr" => "el" }
 
 task "javascript:update_constants" => :environment do
   require "holidays" if !defined?(Holidays)


### PR DESCRIPTION
The consts in javascript.rake were not assigned with ||=
so we would end up with tons of errors like this when running
specs for this plugin:

> warning: already initialized constant TIMEZONES_DEFINITIONS
> warning: previous definition of TIMEZONES_DEFINITIONS was here
