### PR TITLE
Add upcoming Saudi holidays (Eid Al Fitr)

### DIFF
--- a/assets/javascripts/lib/regions.js
+++ b/assets/javascripts/lib/regions.js
@@ -369,7 +369,6 @@ export const TIME_ZONE_TO_REGION = {
   "America/Whitehorse": "ca",
   "America/Winnipeg": "ca",
   "America/Yakutat": "us",
-  "America/Yellowknife": "ca",
   "Antarctica/Macquarie": "au",
   "Asia/Almaty": "kz",
   "Asia/Anadyr": "ru",

--- a/vendor/holidays/definitions/sa.yaml
+++ b/vendor/holidays/definitions/sa.yaml
@@ -6,6 +6,22 @@ months:
   - name: Foundation Day
     regions: [sa]
     mday: 22
+  4:
+  - name: Festival of Breaking the Fast
+    regions: [sa]
+    mday: 21
+    year_ranges:
+      limited: [2023]
+  - name: Second Day of the Festival of Breaking the Fast
+    regions: [sa]
+    mday: 22
+    year_ranges:
+      limited: [2023]
+  - name: Third Day of the Festival of Breaking the Fast
+    regions: [sa]
+    mday: 23
+    year_ranges:
+      limited: [2023]
   5:
   - name: Festival of Breaking the Fast
     regions: [sa]

--- a/vendor/holidays/lib/generated_definitions/ca.rb
+++ b/vendor/holidays/lib/generated_definitions/ca.rb
@@ -36,7 +36,7 @@ module Holidays
             {:wday => 0, :week => 2, :type => :informal, :name => "Mother's Day", :regions => [:us, :ca]},
             {:wday => 6, :week => 3, :type => :informal, :name => "Armed Forces Day", :regions => [:us]}],
       6 => [{:mday => 24, :type => :informal, :name => "Discovery Day", :regions => [:ca_nl]},
-            {:mday => 24, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Fête Nationale", :regions => [:ca_qc]},
+            {:mday => 24, :name => "Fête Nationale", :regions => [:ca_qc]},
             {:mday => 21, :name => "National Aboriginal Day", :regions => [:ca_nt]},
             {:mday => 21, :year_ranges => { :from => 2017 },:name => "National Aboriginal Day", :regions => [:ca_yt]},
             {:wday => 0, :week => 3, :type => :informal, :name => "Father's Day", :regions => [:us, :ca]}],

--- a/vendor/holidays/lib/generated_definitions/northamerica.rb
+++ b/vendor/holidays/lib/generated_definitions/northamerica.rb
@@ -68,7 +68,7 @@ module Holidays
             {:wday => 0, :week => 2, :type => :informal, :name => "Mother's Day", :regions => [:us, :ca]},
             {:wday => 6, :week => 3, :type => :informal, :name => "Armed Forces Day", :regions => [:us]}],
       6 => [{:mday => 24, :type => :informal, :name => "Discovery Day", :regions => [:ca_nl]},
-            {:mday => 24, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Fête Nationale", :regions => [:ca_qc]},
+            {:mday => 24, :name => "Fête Nationale", :regions => [:ca_qc]},
             {:mday => 21, :name => "National Aboriginal Day", :regions => [:ca_nt]},
             {:mday => 21, :year_ranges => { :from => 2017 },:name => "National Aboriginal Day", :regions => [:ca_yt]},
             {:wday => 0, :week => 3, :type => :informal, :name => "Día del Padre", :regions => [:mx]},

--- a/vendor/holidays/lib/generated_definitions/sa.rb
+++ b/vendor/holidays/lib/generated_definitions/sa.rb
@@ -13,6 +13,9 @@ module Holidays
     def self.holidays_by_month
       {
                 2 => [{:mday => 22, :name => "Foundation Day", :regions => [:sa]}],
+      4 => [{:mday => 21, :year_ranges => { :limited => [2023] },:name => "Festival of Breaking the Fast", :regions => [:sa]},
+            {:mday => 22, :year_ranges => { :limited => [2023] },:name => "Second Day of the Festival of Breaking the Fast", :regions => [:sa]},
+            {:mday => 23, :year_ranges => { :limited => [2023] },:name => "Third Day of the Festival of Breaking the Fast", :regions => [:sa]}],
       5 => [{:mday => 2, :year_ranges => { :limited => [2022] },:name => "Festival of Breaking the Fast", :regions => [:sa]},
             {:mday => 3, :year_ranges => { :limited => [2022] },:name => "Second Day of the Festival of Breaking the Fast", :regions => [:sa]},
             {:mday => 4, :year_ranges => { :limited => [2022] },:name => "Third Day of the Festival of Breaking the Fast", :regions => [:sa]}],


### PR DESCRIPTION
The 21st of April to the 23rd of April of 2023 is a public holiday in Saudi Arabia as per https://holidayapi.com/countries/sa/2023.

(Holiday days may be shifted one day depending on crescent sighting.)