### PR TITLE
DEV: Add Eid-ul-Adha Holiday for Ghana

### DIFF
--- a/vendor/holidays/definitions/gh.yaml
+++ b/vendor/holidays/definitions/gh.yaml
@@ -46,6 +46,12 @@ months:
     regions: [gh]
     mday: 25
     type: informal
+  6:
+  - name: Eid-ul-Adha
+    regions: [gh]
+    mday: 28
+    year_ranges:
+      limited: [2023]
   7:
   - name: Republic Day
     regions: [gh]
@@ -122,6 +128,12 @@ tests:
       options: ["informal"]
     expect:
       name: "African Union Day"
+  - given:
+      date: "2023-06-28"
+      regions: ["gh"]
+      options: ["observed"]
+    expect:
+      name: "Eid-ul-Adha"
   - given:
       date: "2022-07-01"
       regions: ["gh"]

--- a/vendor/holidays/lib/generated_definitions/gh.rb
+++ b/vendor/holidays/lib/generated_definitions/gh.rb
@@ -20,6 +20,7 @@ module Holidays
       4 => [{:mday => 22, :year_ranges => { :limited => [2023] },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Eid-ul-Fitr", :regions => [:gh]}],
       5 => [{:mday => 1, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "May Day (Workers' Day)", :regions => [:gh]},
             {:mday => 25, :type => :informal, :name => "African Union Day", :regions => [:gh]}],
+      6 => [{:mday => 28, :year_ranges => { :limited => [2023] },:name => "Eid-ul-Adha", :regions => [:gh]}],
       7 => [{:mday => 1, :type => :informal, :name => "Republic Day", :regions => [:gh]}],
       8 => [{:mday => 4, :year_ranges => { :from => 2019 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Founders' Day", :regions => [:gh]}],
       9 => [{:mday => 21, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Kwame Nkrumah Memorial Day", :regions => [:gh]}],

--- a/vendor/holidays/test/defs/test_defs_gh.rb
+++ b/vendor/holidays/test/defs/test_defs_gh.rb
@@ -23,6 +23,8 @@ class GhDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "African Union Day", (Holidays.on(Date.civil(2022, 5, 25), [:gh], [:informal])[0] || {})[:name]
 
+    assert_equal "Eid-ul-Adha", (Holidays.on(Date.civil(2023, 6, 28), [:gh], [:observed])[0] || {})[:name]
+
     assert_equal "Republic Day", (Holidays.on(Date.civil(2022, 7, 1), [:gh], [:informal])[0] || {})[:name]
 
     assert_equal "Founders' Day", (Holidays.on(Date.civil(2022, 8, 4), [:gh])[0] || {})[:name]


### PR DESCRIPTION
See: https://www.mint.gov.gh/declaration-of-wednesday-28th-june-2023-as-a-statutory-public-holiday/