### PR TITLE
DEV: Refresh auto groups in user_spec

### DIFF
--- a/spec/models/discourse_post_event/user_spec.rb
+++ b/spec/models/discourse_post_event/user_spec.rb
@@ -63,7 +63,10 @@ describe User do
           let(:topic_1) { Fabricate(:topic, user: user_2) }
           let(:post_1) { Fabricate(:post, topic: topic_1, user: user_2) }
           let(:post_event_1) { Fabricate(:event, post: post_1) }
-          before { user_1.update(trust_level: 4) }
+          before do
+            user_1.update(trust_level: 4)
+            Group.refresh_automatic_groups!
+          end
 
           it "can act on the event" do
             expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(true)


### PR DESCRIPTION
Same issue outlined in this PR - https://github.com/discourse/discourse-staff-alias/pull/53
Core change relies on user's group_ids and they need to be refreshed for spec to pass.