### PR TITLE
FIX: add missing Malaysia holidays for 2023

### DIFF
--- a/vendor/holidays/definitions/in.yaml
+++ b/vendor/holidays/definitions/in.yaml
@@ -75,7 +75,7 @@ months:
       limited: [2023]
   6:
   - name: Eid al-Adha
-    regions: [in_rj, in_tn, in_gj]
+    regions: [in_rj, in_tn, in_gj, in_mh]
     mday: 29
     year_ranges:
       limited: [2023]

--- a/vendor/holidays/definitions/my.yaml
+++ b/vendor/holidays/definitions/my.yaml
@@ -15,15 +15,61 @@ months:
     regions: [my]
     mday: 1
     observed: to_weekday_if_weekend(date)
+  - name: Chinese New Year
+    regions: [my]
+    mday: 23
+    observed: to_weekday_if_weekend(date)
+  - name: Chinese New Year (Day 2)
+    regions: [my]
+    mday: 24
+    year_ranges:
+      limited: [2023]
+  2:
+  - name: Thaipusam
+    regions: [my]
+    mday: 5
+    observed: to_weekday_if_weekend(date)
+  4:
+  - name: Nuzul Al-Quran
+    regions: [my]
+    mday: 8
+    year_ranges:
+      limited: [2023]
+  - name: Hari Raya Aidilfitri
+    regions: [my]
+    mday: 21
+    year_ranges:
+      limited: [2023]
+  - name: Hari Raya Aidilfitri (Day 2)
+    regions: [my]
+    mday: 24
+    year_ranges:
+      limited: [2023]
   5:
   - name: Labour Day
     regions: [my]
     mday: 1
+  - name: Wesak Day
+    regions: [my]
+    mday: 4
+    year_ranges:
+      limited: [2023]
   6:
   - name: Agong's Birthday
     regions: [my]
     mday: 4
     observed: to_weekday_if_weekend(date)
+  - name: Hari Raya Haji
+    regions: [my]
+    mday: 29
+    year_ranges:
+      limited: [2023]
+  7:
+  - name: Awal Muharram
+    regions: [my]
+    mday: 19
+    year_ranges:
+      limited: [2023]
   8:
   - name: Independence Day
     regions: [my]
@@ -34,7 +80,22 @@ months:
     regions: [my]
     mday: 16
     observed: to_weekday_if_weekend(date)
+  - name: Prophet Muhammad's Birthday
+    regions: [my]
+    mday: 28
+    year_ranges:
+      limited: [2023]
+  11:
+  - name: Deepavali (Observed)
+    regions: [my]
+    mday: 13
+    observed: to_weekday_if_weekend(date)
   12:
+  - name: Sultan of Selangor's Birthday
+    regions: [my]
+    mday: 11
+    year_ranges:
+      limited: [2023]
   - name: Christmas Day
     regions: [my]
     mday: 25
@@ -42,37 +103,61 @@ months:
 
 tests:
   - given:
-      date: '2016-01-01'
+      date: '2023-01-01'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "New Year's Day"
   - given:
-      date: '2016-05-01'
+      date: '2023-05-01'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "Labour Day"
   - given:
-      date: '2016-06-04'
+      date: '2023-06-04'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "Agong's Birthday"
   - given:
-      date: '2016-08-31'
+      date: '2023-06-29'
+      regions: ["my"]
+      options: ["observed"]
+    expect:
+      name: "Hari Raya Haji"
+  - given:
+      date: '2023-07-19'
+      regions: ["my"]
+      options: ["informal"]
+    expect:
+      name: "Awal Muharram"
+  - given:
+      date: '2023-08-31'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "Independence Day"
   - given:
-      date: '2016-09-16'
+      date: '2023-09-16'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "Malaysia Day"
   - given:
-      date: '2016-12-25'
+      date: '2023-09-28'
+      regions: ["my"]
+      options: ["informal"]
+    expect:
+      name: "Prophet Muhammad's Birthday"
+  - given:
+      date: '2023-11-13'
+      regions: ["my"]
+      options: ["observed"]
+    expect:
+      name: "Deepavali (Observed)"
+  - given:
+      date: '2023-12-25'
       regions: ["my"]
       options: ["informal"]
     expect:

--- a/vendor/holidays/lib/generated_definitions/my.rb
+++ b/vendor/holidays/lib/generated_definitions/my.rb
@@ -12,12 +12,24 @@ module Holidays
 
     def self.holidays_by_month
       {
-                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:my]}],
-      5 => [{:mday => 1, :name => "Labour Day", :regions => [:my]}],
-      6 => [{:mday => 4, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Agong's Birthday", :regions => [:my]}],
+                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:my]},
+            {:mday => 23, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Chinese New Year", :regions => [:my]},
+            {:mday => 24, :year_ranges => { :limited => [2023] },:name => "Chinese New Year (Day 2)", :regions => [:my]}],
+      2 => [{:mday => 5, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Thaipusam", :regions => [:my]}],
+      4 => [{:mday => 8, :year_ranges => { :limited => [2023] },:name => "Nuzul Al-Quran", :regions => [:my]},
+            {:mday => 21, :year_ranges => { :limited => [2023] },:name => "Hari Raya Aidilfitri", :regions => [:my]},
+            {:mday => 24, :year_ranges => { :limited => [2023] },:name => "Hari Raya Aidilfitri (Day 2)", :regions => [:my]}],
+      5 => [{:mday => 1, :name => "Labour Day", :regions => [:my]},
+            {:mday => 4, :year_ranges => { :limited => [2023] },:name => "Wesak Day", :regions => [:my]}],
+      6 => [{:mday => 4, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Agong's Birthday", :regions => [:my]},
+            {:mday => 29, :year_ranges => { :limited => [2023] },:name => "Hari Raya Haji", :regions => [:my]}],
+      7 => [{:mday => 19, :year_ranges => { :limited => [2023] },:name => "Awal Muharram", :regions => [:my]}],
       8 => [{:mday => 31, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Independence Day", :regions => [:my]}],
-      9 => [{:mday => 16, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Malaysia Day", :regions => [:my]}],
-      12 => [{:mday => 25, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:my]}]
+      9 => [{:mday => 16, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Malaysia Day", :regions => [:my]},
+            {:mday => 28, :year_ranges => { :limited => [2023] },:name => "Prophet Muhammad's Birthday", :regions => [:my]}],
+      11 => [{:mday => 13, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Deepavali (Observed)", :regions => [:my]}],
+      12 => [{:mday => 11, :year_ranges => { :limited => [2023] },:name => "Sultan of Selangor's Birthday", :regions => [:my]},
+            {:mday => 25, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:my]}]
       }
     end
 

--- a/vendor/holidays/test/defs/test_defs_my.rb
+++ b/vendor/holidays/test/defs/test_defs_my.rb
@@ -7,17 +7,25 @@ require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
 class MyDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
   def test_my
-    assert_equal "New Year's Day", (Holidays.on(Date.civil(2016, 1, 1), [:my], [:informal])[0] || {})[:name]
+    assert_equal "New Year's Day", (Holidays.on(Date.civil(2023, 1, 1), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Labour Day", (Holidays.on(Date.civil(2016, 5, 1), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Labour Day", (Holidays.on(Date.civil(2023, 5, 1), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Agong's Birthday", (Holidays.on(Date.civil(2016, 6, 4), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Agong's Birthday", (Holidays.on(Date.civil(2023, 6, 4), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Independence Day", (Holidays.on(Date.civil(2016, 8, 31), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Hari Raya Haji", (Holidays.on(Date.civil(2023, 6, 29), [:my], [:observed])[0] || {})[:name]
 
-    assert_equal "Malaysia Day", (Holidays.on(Date.civil(2016, 9, 16), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Awal Muharram", (Holidays.on(Date.civil(2023, 7, 19), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Christmas Day", (Holidays.on(Date.civil(2016, 12, 25), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Independence Day", (Holidays.on(Date.civil(2023, 8, 31), [:my], [:informal])[0] || {})[:name]
+
+    assert_equal "Malaysia Day", (Holidays.on(Date.civil(2023, 9, 16), [:my], [:informal])[0] || {})[:name]
+
+    assert_equal "Prophet Muhammad's Birthday", (Holidays.on(Date.civil(2023, 9, 28), [:my], [:informal])[0] || {})[:name]
+
+    assert_equal "Deepavali (Observed)", (Holidays.on(Date.civil(2023, 11, 13), [:my], [:observed])[0] || {})[:name]
+
+    assert_equal "Christmas Day", (Holidays.on(Date.civil(2023, 12, 25), [:my], [:informal])[0] || {})[:name]
 
   end
 end


### PR DESCRIPTION
Adds missing dates for Malaysia and fixes missing yaml entry for India (Eid al-Adha)

Malaysia: https://publicholidays.com.my/selangor/2023-dates/