### PR TITLE
FIX: Missing event user notifications

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -17,7 +17,7 @@ module DiscoursePostEvent
       event = Event.find(params[:id])
       guardian.ensure_can_act_on_discourse_post_event!(event)
       invites = Array(params.permit(invites: [])[:invites])
-      users = Invitee.extract_uniq_usernames(invites)
+      users = User.real.where(username: invites)
 
       users.each { |user| event.create_notification!(user, event.post) }
 

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -199,8 +199,7 @@ module DiscoursePostEvent
     end
 
     def create_notification!(user, post, predefined_attendance: false)
-      byebug
-      # return if post.event.starts_at < Time.current
+      return if post.event.starts_at < Time.current
 
       message =
         if predefined_attendance

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -199,7 +199,8 @@ module DiscoursePostEvent
     end
 
     def create_notification!(user, post, predefined_attendance: false)
-      return if post.event.starts_at < Time.current
+      byebug
+      # return if post.event.starts_at < Time.current
 
       message =
         if predefined_attendance
@@ -213,6 +214,7 @@ module DiscoursePostEvent
         topic_id: post.topic_id,
         post_number: post.post_number,
         data: {
+          user_id: user.id,
           topic_title: self.name || post.topic.title,
           display_username: post.user.username,
           message: message,

--- a/spec/models/discourse_post_event/event_spec.rb
+++ b/spec/models/discourse_post_event/event_spec.rb
@@ -32,7 +32,7 @@ describe DiscoursePostEvent::Event do
         original_ends_at: Time.now + 2.hours,
       )
     end
-    let(:late_event) do 
+    let(:late_event) do
       Event.create!(
         id: first_post.id,
         original_starts_at: Time.now - 10.hours,
@@ -81,18 +81,16 @@ describe DiscoursePostEvent::Event do
         describe "notify an user" do
           describe "before the event starts" do
             it "does notify the user" do
-              
-              expect {
-                event.create_notification!(notified_user, first_post)
-              }.to change {Notification.count}.by(1)
-              
+              expect { event.create_notification!(notified_user, first_post) }.to change {
+                Notification.count
+              }.by(1)
             end
           end
           describe "after the event starts" do
             it "doesn't notify the user" do
-              expect {
-                late_event.create_notification!(notified_user, first_post)
-              }.not_to change {Notification.count}
+              expect { late_event.create_notification!(notified_user, first_post) }.not_to change {
+                Notification.count
+              }
             end
           end
         end


### PR DESCRIPTION
**Context**
The calendar plugin allows the creation of events, and the notification of users of the existence of that event after it has been created

**Problem**
When trying to notify a user the notification never shows on the user's side. The methods involved in the notification seem to be missing information

**Solution**
Fix the methods involved in the notification flow 