### PR TITLE
FIX: add outlet names, they're no longer passed in

### DIFF
--- a/assets/javascripts/connectors/before-topic-list-body/category-calendar.js
+++ b/assets/javascripts/connectors/before-topic-list-body/category-calendar.js
@@ -1,5 +1,7 @@
 export default {
   shouldRender(_, ctx) {
-    return ctx.siteSettings.calendar_categories_outlet === ctx.name;
+    return (
+      ctx.siteSettings.calendar_categories_outlet === "before-topic-list-body"
+    );
   },
 };

--- a/assets/javascripts/connectors/discovery-list-container-top/category-calendar.js
+++ b/assets/javascripts/connectors/discovery-list-container-top/category-calendar.js
@@ -1,5 +1,8 @@
 export default {
   shouldRender(_, ctx) {
-    return ctx.siteSettings.calendar_categories_outlet === ctx.name;
+    return (
+      ctx.siteSettings.calendar_categories_outlet ===
+      "discovery-list-container-top"
+    );
   },
 };


### PR DESCRIPTION
The `calendar categories` feature was broken because `ctx.name` returns `undefined` (I believe due to the way arguments are passed in to plugin outlets after core updates?).

Hardcoding the name here works.  
