### PR TITLE
FIX: Event sorting shows oldest events first

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -111,8 +111,9 @@ after_initialize do
         if category && category.custom_fields &&
              category.custom_fields["sort_topics_by_event_start_date"]
           reorder_sql = <<~SQL
-            CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN 0 ELSE 1 END,
-            COALESCE(custom_fields.value::timestamptz, topics.bumped_at) DESC
+           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN 0 ELSE 1 END,
+           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) ELSE NULL END,
+           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) < NOW() THEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) ELSE NULL END DESC
           SQL
           results =
             results.joins(

--- a/plugin.rb
+++ b/plugin.rb
@@ -110,12 +110,17 @@ after_initialize do
         category = Category.find_by(id: topic_query.options[:category_id])
         if category && category.custom_fields &&
              category.custom_fields["sort_topics_by_event_start_date"]
+          reorder_sql = <<~SQL
+           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN 0 ELSE 1 END,
+           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) ELSE NULL END,
+           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) < NOW() THEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) ELSE NULL END DESC
+          SQL
           results =
             results.joins(
               "LEFT JOIN topic_custom_fields AS custom_fields on custom_fields.topic_id = topics.id
-            AND custom_fields.name = '#{DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT}'
-            ",
-            ).reorder("topics.pinned_at ASC, custom_fields.value ASC")
+         AND custom_fields.name = '#{DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT}'
+         ",
+            ).reorder(reorder_sql)
         end
       end
       results

--- a/plugin.rb
+++ b/plugin.rb
@@ -111,9 +111,8 @@ after_initialize do
         if category && category.custom_fields &&
              category.custom_fields["sort_topics_by_event_start_date"]
           reorder_sql = <<~SQL
-           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN 0 ELSE 1 END,
-           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) ELSE NULL END,
-           CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) < NOW() THEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) ELSE NULL END DESC
+            CASE WHEN COALESCE(custom_fields.value::timestamptz, topics.bumped_at) > NOW() THEN 0 ELSE 1 END,
+            COALESCE(custom_fields.value::timestamptz, topics.bumped_at) DESC
           SQL
           results =
             results.joins(

--- a/spec/models/topic_query_spec.rb
+++ b/spec/models/topic_query_spec.rb
@@ -1,0 +1,56 @@
+require "topic_view"
+
+RSpec.describe TopicQuery do
+  Event ||= DiscoursePostEvent::Event
+  describe "sorts events" do
+    let(:user) { Fabricate(:user, admin: true) }
+    let!(:notified_user) { Fabricate(:user) }
+    let(:topic_1) { Fabricate(:topic, user: user) }
+    let(:topic_2) { Fabricate(:topic, user: user) }
+    let(:topic_3) { Fabricate(:topic, user: user) }
+    let(:topic_4) { Fabricate(:topic, user: user) }
+    let!(:post_1) { Fabricate(:post, topic: topic_1) }
+    let!(:post_2) { Fabricate(:post, topic: topic_2) }
+    let!(:post_3) { Fabricate(:post, topic: topic_3) }
+    let!(:post_4) { Fabricate(:post, topic: topic_4) }
+
+    let(:future_event_1) do
+      Event.create!(
+        id: post_1.id,
+        original_starts_at: Time.now + 5.hours,
+        original_ends_at: Time.now + 7.hours,
+      )
+    end
+    let(:future_event_2) do
+      Event.create!(
+        id: post_2.id,
+        original_starts_at: Time.now + 1.hours,
+        original_ends_at: Time.now + 2.hours,
+      )
+    end
+    let(:past_event_1) do
+      Event.create!(
+        id: post_3.id,
+        original_starts_at: Time.now - 10.hours,
+        original_ends_at: Time.now - 8.hours,
+      )
+    end
+    let(:past_event_2) do
+      Event.create!(
+        id: post_4.id,
+        original_starts_at: Time.now - 7.hours,
+        original_ends_at: Time.now - 5.hours,
+      )
+    end
+
+    it "upcoming events first, sorted by ascending order. expired events last, sorted by descending order" do
+      ordered_topics =
+        TopicQuery.new(nil, order_by_event_date: [topic_1, topic_2, topic_3, topic_4]).options[
+          :order_by_event_date
+        ]
+      expect(ordered_topics).to eq([topic_1, topic_2, topic_3, topic_4])
+
+      TopicQuery.remove_custom_filter(:order_by_event_date)
+    end
+  end
+end

--- a/spec/models/topic_query_spec.rb
+++ b/spec/models/topic_query_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "topic_view"
 
 RSpec.describe TopicQuery do

--- a/spec/models/topic_query_spec.rb
+++ b/spec/models/topic_query_spec.rb
@@ -1,43 +1,42 @@
 # frozen_string_literal: true
-require "topic_view"
+require "rails_helper"
 
-RSpec.describe TopicQuery do
-  Event ||= DiscoursePostEvent::Event
+describe TopicQuery do
   describe "sorts events" do
-    let(:user) { Fabricate(:user, admin: true) }
-    let!(:notified_user) { Fabricate(:user) }
-    let(:topic_1) { Fabricate(:topic, user: user) }
-    let(:topic_2) { Fabricate(:topic, user: user) }
-    let(:topic_3) { Fabricate(:topic, user: user) }
-    let(:topic_4) { Fabricate(:topic, user: user) }
-    let!(:post_1) { Fabricate(:post, topic: topic_1) }
-    let!(:post_2) { Fabricate(:post, topic: topic_2) }
-    let!(:post_3) { Fabricate(:post, topic: topic_3) }
-    let!(:post_4) { Fabricate(:post, topic: topic_4) }
+    fab!(:user) { Fabricate(:user, admin: true) }
+    fab!(:notified_user) { Fabricate(:user) }
+    fab!(:topic_1) { Fabricate(:topic, user: user) }
+    fab!(:topic_2) { Fabricate(:topic, user: user) }
+    fab!(:topic_3) { Fabricate(:topic, user: user) }
+    fab!(:topic_4) { Fabricate(:topic, user: user) }
+    fab!(:post_1) { Fabricate(:post, topic: topic_1) }
+    fab!(:post_2) { Fabricate(:post, topic: topic_2) }
+    fab!(:post_3) { Fabricate(:post, topic: topic_3) }
+    fab!(:post_4) { Fabricate(:post, topic: topic_4) }
 
-    let(:future_event_1) do
-      Event.create!(
+    fab!(:future_event_1) do
+      DiscoursePostEvent::Event.create!(
         id: post_1.id,
         original_starts_at: Time.now + 5.hours,
         original_ends_at: Time.now + 7.hours,
       )
     end
-    let(:future_event_2) do
-      Event.create!(
+    fab!(:future_event_2) do
+      DiscoursePostEvent::Event.create!(
         id: post_2.id,
         original_starts_at: Time.now + 1.hours,
         original_ends_at: Time.now + 2.hours,
       )
     end
-    let(:past_event_1) do
-      Event.create!(
+    fab!(:past_event_1) do
+      DiscoursePostEvent::Event.create!(
         id: post_3.id,
         original_starts_at: Time.now - 10.hours,
         original_ends_at: Time.now - 8.hours,
       )
     end
-    let(:past_event_2) do
-      Event.create!(
+    fab!(:past_event_2) do
+      DiscoursePostEvent::Event.create!(
         id: post_4.id,
         original_starts_at: Time.now - 7.hours,
         original_ends_at: Time.now - 5.hours,
@@ -50,8 +49,6 @@ RSpec.describe TopicQuery do
           :order_by_event_date
         ]
       expect(ordered_topics).to eq([topic_1, topic_2, topic_3, topic_4])
-
-      TopicQuery.remove_custom_filter(:order_by_event_date)
     end
   end
 end

--- a/spec/requests/sort_event_topics_spec.rb
+++ b/spec/requests/sort_event_topics_spec.rb
@@ -3,39 +3,39 @@
 require "rails_helper"
 
 RSpec.describe ListController do
-  fab!(:admin) { Fabricate(:admin) }
-  fab!(:user) { Fabricate(:user) }
-  fab!(:category) { Fabricate(:category) }
-  fab!(:topic_1) do
-    Fabricate(:topic, title: "This is the first topic", user: user, category: category)
-  end
-  fab!(:post_1) { Fabricate(:post, topic: topic_1) }
-  fab!(:post_event_1) do
-    Fabricate(:event, name: "event1", post: post_1, original_starts_at: 1.days.from_now)
-  end
-  fab!(:topic_2) do
-    Fabricate(:topic, title: "This is the second topic", user: user, category: category)
-  end
-  fab!(:post_2) { Fabricate(:post, topic: topic_2) }
-  fab!(:post_event_2) do
-    Fabricate(:event, name: "event2", post: post_2, original_starts_at: 2.days.from_now)
-  end
+  describe "sort event topics" do
+    fab!(:admin) { Fabricate(:admin) }
+    fab!(:user) { Fabricate(:user) }
+    fab!(:category) { Fabricate(:category) }
+    fab!(:topic_1) do
+      Fabricate(:topic, title: "This is the first topic", user: user, category: category)
+    end
+    fab!(:post_1) { Fabricate(:post, topic: topic_1) }
+    fab!(:post_event_1) do
+      Fabricate(:event, name: "event1", post: post_1, original_starts_at: 1.days.from_now)
+    end
+    fab!(:topic_2) do
+      Fabricate(:topic, title: "This is the second topic", user: user, category: category)
+    end
+    fab!(:post_2) { Fabricate(:post, topic: topic_2) }
+    fab!(:post_event_2) do
+      Fabricate(:event, name: "event2", post: post_2, original_starts_at: 2.days.from_now)
+    end
 
-  before do
-    admin
-    SiteSetting.calendar_enabled = true
-    SiteSetting.sort_categories_by_event_start_date_enabled = true
-  end
+    before :each do
+      admin
+      SiteSetting.calendar_enabled = true
+      SiteSetting.sort_categories_by_event_start_date_enabled = true
+    end
 
-  describe "#sort_event_topics" do
     it "gets topics in order of event_date if sort_topics_by_event_start_date is true" do
       category.custom_fields["sort_topics_by_event_start_date"] = true
       category.save
+      TopicQuery.new(user, order_by_event_date: [topic_1, topic_2]).options[:order_by_event_date]
 
       get "/c/#{category.slug}/#{category.id}/l/latest.json?ascending=false"
 
       topics = response.parsed_body["topic_list"]["topics"]
-
       expect(topics[0]["id"]).to eq(topic_1.id)
       expect(topics[1]["id"]).to eq(topic_2.id)
     end
@@ -47,7 +47,6 @@ RSpec.describe ListController do
       get "/c/#{category.slug}/#{category.id}/l/latest.json?ascending=false"
 
       topics = response.parsed_body["topic_list"]["topics"]
-
       expect(topics[0]["id"]).to eq(topic_2.id)
       expect(topics[1]["id"]).to eq(topic_1.id)
     end

--- a/spec/requests/sort_event_topics_spec.rb
+++ b/spec/requests/sort_event_topics_spec.rb
@@ -3,39 +3,39 @@
 require "rails_helper"
 
 RSpec.describe ListController do
-  describe "sort event topics" do
-    fab!(:admin) { Fabricate(:admin) }
-    fab!(:user) { Fabricate(:user) }
-    fab!(:category) { Fabricate(:category) }
-    fab!(:topic_1) do
-      Fabricate(:topic, title: "This is the first topic", user: user, category: category)
-    end
-    fab!(:post_1) { Fabricate(:post, topic: topic_1) }
-    fab!(:post_event_1) do
-      Fabricate(:event, name: "event1", post: post_1, original_starts_at: 1.days.from_now)
-    end
-    fab!(:topic_2) do
-      Fabricate(:topic, title: "This is the second topic", user: user, category: category)
-    end
-    fab!(:post_2) { Fabricate(:post, topic: topic_2) }
-    fab!(:post_event_2) do
-      Fabricate(:event, name: "event2", post: post_2, original_starts_at: 2.days.from_now)
-    end
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic_1) do
+    Fabricate(:topic, title: "This is the first topic", user: user, category: category)
+  end
+  fab!(:post_1) { Fabricate(:post, topic: topic_1) }
+  fab!(:post_event_1) do
+    Fabricate(:event, name: "event1", post: post_1, original_starts_at: 1.days.from_now)
+  end
+  fab!(:topic_2) do
+    Fabricate(:topic, title: "This is the second topic", user: user, category: category)
+  end
+  fab!(:post_2) { Fabricate(:post, topic: topic_2) }
+  fab!(:post_event_2) do
+    Fabricate(:event, name: "event2", post: post_2, original_starts_at: 2.days.from_now)
+  end
 
-    before :each do
-      admin
-      SiteSetting.calendar_enabled = true
-      SiteSetting.sort_categories_by_event_start_date_enabled = true
-    end
+  before do
+    admin
+    SiteSetting.calendar_enabled = true
+    SiteSetting.sort_categories_by_event_start_date_enabled = true
+  end
 
+  describe "#sort_event_topics" do
     it "gets topics in order of event_date if sort_topics_by_event_start_date is true" do
       category.custom_fields["sort_topics_by_event_start_date"] = true
       category.save
-      TopicQuery.new(user, order_by_event_date: [topic_1, topic_2]).options[:order_by_event_date]
 
       get "/c/#{category.slug}/#{category.id}/l/latest.json?ascending=false"
 
       topics = response.parsed_body["topic_list"]["topics"]
+
       expect(topics[0]["id"]).to eq(topic_1.id)
       expect(topics[1]["id"]).to eq(topic_2.id)
     end
@@ -47,6 +47,7 @@ RSpec.describe ListController do
       get "/c/#{category.slug}/#{category.id}/l/latest.json?ascending=false"
 
       topics = response.parsed_body["topic_list"]["topics"]
+
       expect(topics[0]["id"]).to eq(topic_2.id)
       expect(topics[1]["id"]).to eq(topic_1.id)
     end


### PR DESCRIPTION
**Context**
The discourse calendar plugin allows the creation of events. These events can be sorted by the `created_at` date when the `sort categories by event start date enabled` `SiteSetting` is enabled.

**Problem**
When the `sort categories by event start date enabled` `SiteSetting` is enabled the events are sorted from oldest to recent making it very difficult for the user to navigate and find Topics of interest

**Solution**
Fix how events are sorted so events that are closer to happening appear first and events that already happened appear from oldest to most recent