### PR TITLE
FEATURE: Display calendar events adjusted for timezones

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -579,23 +579,25 @@ function initializeDiscourseCalendar(api) {
             detail.from = moment.tz(detail.from, detail.timezone);
             detail.to = moment.tz(detail.to, detail.timezone);
 
-            const eventUtcOffset = moment.tz(detail.timezone).utcOffset();
-            const timezoneOffset = (calendarUtcOffset - eventUtcOffset) / 60;
-            detail.timezoneOffset = timezoneOffset;
-            detail.eventDaysDuration =
-              detail.to.diff(detail.from, "days") + 1 || 1;
+            if (siteSettings.enable_timezone_offset_for_calendar_events) {
+              const eventUtcOffset = moment.tz(detail.timezone).utcOffset();
+              const timezoneOffset = (calendarUtcOffset - eventUtcOffset) / 60;
+              detail.timezoneOffset = timezoneOffset;
+              detail.eventDaysDuration =
+                detail.to.diff(detail.from, "days") + 1 || 1;
 
-            if (timezoneOffset > 0) {
-              if (detail.to.isValid()) {
-                detail.to.add(1, "day");
-              } else {
-                detail.to = detail.from.clone().add(1, "day");
+              if (timezoneOffset > 0) {
+                if (detail.to.isValid()) {
+                  detail.to.add(1, "day");
+                } else {
+                  detail.to = detail.from.clone().add(1, "day");
+                }
+              } else if (timezoneOffset < 0) {
+                if (!detail.to.isValid()) {
+                  detail.to = detail.from.clone();
+                }
+                detail.from.subtract(1, "day");
               }
-            } else if (timezoneOffset < 0) {
-              if (!detail.to.isValid()) {
-                detail.to = detail.from.clone();
-              }
-              detail.from.subtract(1, "day");
             }
 
             detail.from = detail.from.format("YYYY-MM-DD");
@@ -692,6 +694,10 @@ function initializeDiscourseCalendar(api) {
   }
 
   function _setTimezoneOffset(info) {
+    if (!siteSettings.enable_timezone_offset_for_calendar_events) {
+      return;
+    }
+
     const timezoneOffset = info.event.extendedProps.timezoneOffset;
     const eventDaysDuration = info.event.extendedProps.eventDaysDuration;
     if (timezoneOffset) {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -528,20 +528,21 @@ function initializeDiscourseCalendar(api) {
     calendar.addEvent(event);
   }
 
-  function _addGroupedEvent(calendar, post, detail, timezone) {
-    const data = siteSettings.enable_timezone_offset_for_calendar_events
-      ? _splitGroupEventByTimezone(detail, timezone)
-      : [detail];
+  function _addGroupedEvent(calendar, post, detail, calendarTz) {
+    const groupedEventData =
+      siteSettings.enable_timezone_offset_for_calendar_events
+        ? _splitGroupEventByTimezone(detail, calendarTz)
+        : [detail];
 
-    data.forEach((el) => {
+    groupedEventData.forEach((eventData) => {
       let htmlContent = "";
       let users = [];
       let localEventNames = [];
 
-      Object.keys(el.localEvents)
+      Object.keys(eventData.localEvents)
         .sort()
         .forEach((key) => {
-          const localEvent = el.localEvents[key];
+          const localEvent = eventData.localEvents[key];
           htmlContent += `<b>${key}</b>: ${localEvent.users
             .map((u) => u.username)
             .sort()
@@ -550,7 +551,7 @@ function initializeDiscourseCalendar(api) {
           localEventNames.push(key);
         });
 
-      const event = _buildEvent(el);
+      const event = _buildEvent(eventData);
       event.classNames = ["grouped-event"];
 
       if (users.length > 2) {
@@ -577,8 +578,8 @@ function initializeDiscourseCalendar(api) {
     });
   }
 
-  function _splitGroupEventByTimezone(detail, timezone) {
-    const calendarUtcOffset = moment.tz(timezone).utcOffset();
+  function _splitGroupEventByTimezone(detail, calendarTz) {
+    const calendarUtcOffset = moment.tz(calendarTz).utcOffset();
     let timezonesOffsets = [];
     let splittedEvents = [];
 
@@ -634,9 +635,9 @@ function initializeDiscourseCalendar(api) {
     return splittedEvents;
   }
 
-  function _setDynamicCalendarEvents(calendar, post, fullDay, timezone) {
+  function _setDynamicCalendarEvents(calendar, post, fullDay, calendarTz) {
     const groupedEvents = [];
-    const calendarUtcOffset = moment.tz(timezone).utcOffset();
+    const calendarUtcOffset = moment.tz(calendarTz).utcOffset();
 
     (post.calendar_details || []).forEach((detail) => {
       switch (detail.type) {
@@ -714,7 +715,7 @@ function initializeDiscourseCalendar(api) {
 
     Object.keys(formattedGroupedEvents).forEach((key) => {
       const formattedGroupedEvent = formattedGroupedEvents[key];
-      _addGroupedEvent(calendar, post, formattedGroupedEvent, timezone);
+      _addGroupedEvent(calendar, post, formattedGroupedEvent, calendarTz);
     });
   }
 

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -611,7 +611,7 @@ function initializeDiscourseCalendar(api) {
       });
     });
 
-    [...new Set(timezonesOffsets)].forEach((offset) => {
+    [...new Set(timezonesOffsets)].forEach((offset, i) => {
       let filteredLocalEvents = {};
       let eventTimezones = [];
 
@@ -620,7 +620,8 @@ function initializeDiscourseCalendar(api) {
           siteSettings.split_grouped_events_by_timezone_threshold;
 
         const filtered = detail.localEvents[key].users.filter(
-          (u) => Math.abs(u.timezoneOffset - offset) <= threshold
+          (u) =>
+            Math.abs(u.timezoneOffset - (offset + threshold * i)) <= threshold
         );
         if (filtered.length > 0) {
           filteredLocalEvents[key] = {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -544,9 +544,9 @@ function initializeDiscourseCalendar(api) {
     calendar.addEvent(event);
   }
 
-  function _addGroupedEvent(calendar, post, detail, calendarTz) {
+  function _addGroupedEvent(calendar, post, detail, fullDay, calendarTz) {
     const groupedEventData =
-      siteSettings.enable_timezone_offset_for_calendar_events
+      siteSettings.enable_timezone_offset_for_calendar_events && fullDay
         ? _splitGroupEventByTimezone(detail, calendarTz)
         : [detail];
 
@@ -768,7 +768,13 @@ function initializeDiscourseCalendar(api) {
 
     Object.keys(formattedGroupedEvents).forEach((key) => {
       const formattedGroupedEvent = formattedGroupedEvents[key];
-      _addGroupedEvent(calendar, post, formattedGroupedEvent, calendarTz);
+      _addGroupedEvent(
+        calendar,
+        post,
+        formattedGroupedEvent,
+        fullDay,
+        calendarTz
+      );
     });
   }
 

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -739,9 +739,12 @@ function initializeDiscourseCalendar(api) {
         _insertAddToCalendarLinks(calendar);
       });
 
-      moment.tz.names().forEach((tz) => {
-        tzPicker.appendChild(new Option(tz, tz));
-      });
+      moment.tz
+        .names()
+        .filter((t) => !t.startsWith("Etc/GMT"))
+        .forEach((tz) => {
+          tzPicker.appendChild(new Option(tz, tz));
+        });
 
       tzPicker.value = timezone;
     } else {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -307,7 +307,7 @@ function initializeDiscourseCalendar(api) {
         $calendarTitle.innerText = info.view.title;
       },
 
-      eventRender: (info) => {
+      eventPositioned: (info) => {
         _setTimezoneOffset(info);
       },
     });
@@ -490,7 +490,6 @@ function initializeDiscourseCalendar(api) {
 
     if (detail.timezoneOffset) {
       event.extendedProps.timezoneOffset = detail.timezoneOffset;
-      event.extendedProps.eventDaysDuration = detail.eventDaysDuration;
     }
 
     return event;
@@ -627,7 +626,6 @@ function initializeDiscourseCalendar(api) {
       splittedEvents.push({
         timezoneOffset: offset,
         localEvents: filteredLocalEvents,
-        eventDaysDuration: 1,
         from: from.format("YYYY-MM-DD"),
         to: to.format("YYYY-MM-DD"),
       });
@@ -654,9 +652,7 @@ function initializeDiscourseCalendar(api) {
             if (siteSettings.enable_timezone_offset_for_calendar_events) {
               const eventUtcOffset = moment.tz(detail.timezone).utcOffset();
               const timezoneOffset = (calendarUtcOffset - eventUtcOffset) / 60;
-
               eventDetail.timezoneOffset = timezoneOffset;
-              eventDetail.eventDaysDuration = to.diff(from, "days") + 1 || 1;
 
               if (timezoneOffset > 0) {
                 if (to.isValid()) {
@@ -773,36 +769,38 @@ function initializeDiscourseCalendar(api) {
     }
 
     const timezoneOffset = info.event.extendedProps.timezoneOffset;
-    const eventDaysDuration = info.event.extendedProps.eventDaysDuration;
-    if (timezoneOffset) {
-      const baseOffset = 100 / (eventDaysDuration + 1);
-      const pxOffset = `${3.5 - (eventDaysDuration - 1) / 2.5}px`;
+    const segmentDuration = info.el.parentNode?.colSpan;
 
-      const notStart = info.el.classList.contains("fc-not-start");
-      const notEnd = info.el.classList.contains("fc-not-end");
+    const basePctOffset = 100 / segmentDuration;
+    const basePxOffset = 5.5 - (segmentDuration - 1) * 0.78;
+    const notStart = info.el.classList.contains("fc-not-start");
+    const notEnd = info.el.classList.contains("fc-not-end");
 
-      if (timezoneOffset > 0) {
-        if (!notStart) {
-          const leftK = Math.abs(timezoneOffset) / 24;
-          const pctOffset = `${baseOffset * leftK * (notEnd ? 2 : 1)}%`;
-          info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
-        }
-        if (!notEnd) {
-          const rightK = (24 - Math.abs(timezoneOffset)) / 24;
-          const pctOffset = `${baseOffset * rightK * (notStart ? 2 : 1)}%`;
-          info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
-        }
-      } else if (timezoneOffset < 0) {
-        if (!notStart) {
-          const leftK = (24 - Math.abs(timezoneOffset)) / 24;
-          const pctOffset = `${baseOffset * leftK * (notEnd ? 2 : 1)}%`;
-          info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
-        }
-        if (!notEnd) {
-          const rightK = Math.abs(timezoneOffset) / 24;
-          const pctOffset = `${baseOffset * rightK * (notStart ? 2 : 1)}%`;
-          info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
-        }
+    if (timezoneOffset > 0) {
+      if (!notStart) {
+        const leftK = Math.abs(timezoneOffset) / 24;
+        const pctOffset = `${basePctOffset * leftK}%`;
+        const pxOffset = `${basePxOffset * leftK}px`;
+        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
+      }
+      if (!notEnd) {
+        const rightK = (24 - Math.abs(timezoneOffset)) / 24;
+        const pctOffset = `${basePctOffset * rightK}%`;
+        const pxOffset = `${basePxOffset * rightK}px`;
+        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
+      }
+    } else if (timezoneOffset < 0) {
+      if (!notStart) {
+        const leftK = (24 - Math.abs(timezoneOffset)) / 24;
+        const pctOffset = `${basePctOffset * leftK}%`;
+        const pxOffset = `${basePxOffset * leftK}px`;
+        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
+      }
+      if (!notEnd) {
+        const rightK = Math.abs(timezoneOffset) / 24;
+        const pctOffset = `${basePctOffset * rightK}%`;
+        const pxOffset = `${basePxOffset * rightK}px`;
+        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
       }
     }
   }

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -241,7 +241,13 @@ function initializeDiscourseCalendar(api) {
       _setDynamicCalendarOptions(calendar, $calendar);
     }
 
-    _setupTimezonePicker(calendar, timezone);
+    const resetDynamicEvents = () => {
+      const selectedTimezone = calendar.getOption("timeZone");
+      calendar.getEvents().forEach((event) => event.remove());
+      _setDynamicCalendarEvents(calendar, post, fullDay, selectedTimezone);
+    };
+
+    _setupTimezonePicker(calendar, timezone, resetDynamicEvents);
   }
 
   function attachCalendar($elem, helper) {
@@ -726,13 +732,14 @@ function initializeDiscourseCalendar(api) {
     return defaultTimezone || currentUser?.timezone || moment.tz.guess();
   }
 
-  function _setupTimezonePicker(calendar, timezone) {
+  function _setupTimezonePicker(calendar, timezone, resetDynamicEvents) {
     const tzPicker = document.querySelector(
       ".discourse-calendar-timezone-picker"
     );
     if (tzPicker) {
       tzPicker.addEventListener("change", function (event) {
         calendar.setOption("timeZone", event.target.value);
+        resetDynamicEvents();
         _insertAddToCalendarLinks(calendar);
       });
 

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -791,33 +791,29 @@ function initializeDiscourseCalendar(api) {
     const segmentDuration = info.el.parentNode?.colSpan;
 
     const basePctOffset = 100 / segmentDuration;
-    const basePxOffset = 5.5 - (segmentDuration - 1) * 0.78;
+    const pxOffset = 7.5 - segmentDuration;
 
     if (timezoneOffset > 0) {
       if (info.isStart) {
         const leftK = Math.abs(timezoneOffset) / 24;
         const pctOffset = `${basePctOffset * leftK}%`;
-        const pxOffset = `${basePxOffset * leftK}px`;
-        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
+        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset}px)`;
       }
       if (info.isEnd) {
         const rightK = (24 - Math.abs(timezoneOffset)) / 24;
         const pctOffset = `${basePctOffset * rightK}%`;
-        const pxOffset = `${basePxOffset * rightK}px`;
-        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
+        info.el.style.marginRight = `calc(${pctOffset} + 2px)`;
       }
     } else if (timezoneOffset < 0) {
       if (info.isStart) {
         const leftK = (24 - Math.abs(timezoneOffset)) / 24;
         const pctOffset = `${basePctOffset * leftK}%`;
-        const pxOffset = `${basePxOffset * leftK}px`;
-        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
+        info.el.style.marginLeft = `calc(${pctOffset} + 2px)`;
       }
       if (info.isEnd) {
         const rightK = Math.abs(timezoneOffset) / 24;
         const pctOffset = `${basePctOffset * rightK}%`;
-        const pxOffset = `${basePxOffset * rightK}px`;
-        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
+        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset}px)`;
       }
     }
   }

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -339,15 +339,15 @@ function initializeDiscourseCalendar(api) {
     };
 
     let event = {
-      start: from.dateTime.toDate(),
+      start: from.dateTime.format("YYYY-MM-DD"),
       allDay: false,
     };
 
     if (to) {
       if (hasTimeSpecified(to.dateTime) || hasTimeSpecified(from.dateTime)) {
-        event.end = to.dateTime.toDate();
+        event.end = to.dateTime.format("YYYY-MM-DD");
       } else {
-        event.end = to.dateTime.add(1, "days").toDate();
+        event.end = to.dateTime.add(1, "days").format("YYYY-MM-DD");
         event.allDay = true;
       }
     } else {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -347,11 +347,14 @@ function initializeDiscourseCalendar(api) {
 
   function _buildEventObject(from, to) {
     const hasTimeSpecified = (d) => {
+      if (!d) {
+        return false;
+      }
       return d.hours() !== 0 || d.minutes() !== 0 || d.seconds() !== 0;
     };
 
     const hasTime =
-      hasTimeSpecified(to.dateTime) || hasTimeSpecified(from.dateTime);
+      hasTimeSpecified(to?.dateTime) || hasTimeSpecified(from?.dateTime);
     const dateFormat = hasTime ? "YYYY-MM-DD HH:mm:ss Z" : "YYYY-MM-DD";
 
     let event = {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -299,6 +299,7 @@ function initializeDiscourseCalendar(api) {
         center: "title",
         right: "month,basicWeek,listNextYear",
       },
+      eventOrder: ["start", _orderByTz, "-duration", "allDay", "title"],
       datesRender: (info) => {
         if (showAddToCalendar) {
           _insertAddToCalendarLinks(info);
@@ -311,6 +312,17 @@ function initializeDiscourseCalendar(api) {
         _setTimezoneOffset(info);
       },
     });
+  }
+
+  function _orderByTz(a, b) {
+    if (!siteSettings.enable_timezone_offset_for_calendar_events) {
+      return 0;
+    }
+
+    const offsetA = a.extendedProps.timezoneOffset;
+    const offsetB = b.extendedProps.timezoneOffset;
+
+    return offsetA === offsetB ? 0 : offsetA < offsetB ? -1 : 1;
   }
 
   function _convertHtmlToDate(html) {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -641,34 +641,37 @@ function initializeDiscourseCalendar(api) {
           break;
         case "standalone":
           if (fullDay && detail.timezone) {
-            detail.from = moment.tz(detail.from, detail.timezone);
-            detail.to = moment.tz(detail.to, detail.timezone);
+            const eventDetail = { ...detail };
+            let from = moment.tz(detail.from, detail.timezone);
+            let to = moment.tz(detail.to, detail.timezone);
 
             if (siteSettings.enable_timezone_offset_for_calendar_events) {
               const eventUtcOffset = moment.tz(detail.timezone).utcOffset();
               const timezoneOffset = (calendarUtcOffset - eventUtcOffset) / 60;
-              detail.timezoneOffset = timezoneOffset;
-              detail.eventDaysDuration =
-                detail.to.diff(detail.from, "days") + 1 || 1;
+
+              eventDetail.timezoneOffset = timezoneOffset;
+              eventDetail.eventDaysDuration = to.diff(from, "days") + 1 || 1;
 
               if (timezoneOffset > 0) {
-                if (detail.to.isValid()) {
-                  detail.to.add(1, "day");
+                if (to.isValid()) {
+                  to.add(1, "day");
                 } else {
-                  detail.to = detail.from.clone().add(1, "day");
+                  to = from.clone().add(1, "day");
                 }
               } else if (timezoneOffset < 0) {
-                if (!detail.to.isValid()) {
-                  detail.to = detail.from.clone();
+                if (!to.isValid()) {
+                  to = from.clone();
                 }
-                detail.from.subtract(1, "day");
+                from.subtract(1, "day");
               }
             }
+            eventDetail.from = from.format("YYYY-MM-DD");
+            eventDetail.to = to.format("YYYY-MM-DD");
 
-            detail.from = detail.from.format("YYYY-MM-DD");
-            detail.to = detail.to.format("YYYY-MM-DD");
+            _addStandaloneEvent(calendar, post, eventDetail);
+          } else {
+            _addStandaloneEvent(calendar, post, detail);
           }
-          _addStandaloneEvent(calendar, post, detail);
           break;
       }
     });

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -651,18 +651,7 @@ function initializeDiscourseCalendar(api) {
         let from = moment.tz(detail.from, eventTimezone.timezone);
         let to = moment.tz(detail.to, eventTimezone.timezone);
 
-        if (eventTimezone.timezoneOffset > 0) {
-          if (to.isValid()) {
-            to.add(1, "day");
-          } else {
-            to = from.clone().add(1, "day");
-          }
-        } else if (eventTimezone.timezoneOffset < 0) {
-          if (!to.isValid()) {
-            to = from.clone();
-          }
-          from.subtract(1, "day");
-        }
+        _modifyDatesForTimezoneOffset(from, to, eventTimezone.timezoneOffset);
 
         splittedEvents.push({
           timezoneOffset: eventTimezone.timezoneOffset,
@@ -711,18 +700,7 @@ function initializeDiscourseCalendar(api) {
               const timezoneOffset = (calendarUtcOffset - eventUtcOffset) / 60;
               eventDetail.timezoneOffset = timezoneOffset;
 
-              if (timezoneOffset > 0) {
-                if (to.isValid()) {
-                  to.add(1, "day");
-                } else {
-                  to = from.clone().add(1, "day");
-                }
-              } else if (timezoneOffset < 0) {
-                if (!to.isValid()) {
-                  to = from.clone();
-                }
-                from.subtract(1, "day");
-              }
+              _modifyDatesForTimezoneOffset(from, to, timezoneOffset);
             }
             eventDetail.from = from.format("YYYY-MM-DD");
             eventDetail.to = to.format("YYYY-MM-DD");
@@ -779,6 +757,21 @@ function initializeDiscourseCalendar(api) {
         calendarTz
       );
     });
+  }
+
+  function _modifyDatesForTimezoneOffset(from, to, timezoneOffset) {
+    if (timezoneOffset > 0) {
+      if (to.isValid()) {
+        to.add(1, "day");
+      } else {
+        to = from.clone().add(1, "day");
+      }
+    } else if (timezoneOffset < 0) {
+      if (!to.isValid()) {
+        to = from.clone();
+      }
+      from.subtract(1, "day");
+    }
   }
 
   function _getTimeZone($calendar, currentUser) {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -767,7 +767,10 @@ function initializeDiscourseCalendar(api) {
   }
 
   function _setTimezoneOffset(info) {
-    if (!siteSettings.enable_timezone_offset_for_calendar_events) {
+    if (
+      !siteSettings.enable_timezone_offset_for_calendar_events ||
+      info.view.type === "listNextYear"
+    ) {
       return;
     }
 

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -787,33 +787,51 @@ function initializeDiscourseCalendar(api) {
       return;
     }
 
+    // The timezone offset works by calculating the hour difference
+    // between a target event and the calendar event. This is used to
+    // determine whether to add an extra day before or after the event.
+    // Then, it applies inline styling to resize the event to its
+    // original size while adjusting it to the respective timezone.
+
     const timezoneOffset = info.event.extendedProps.timezoneOffset;
     const segmentDuration = info.el.parentNode?.colSpan;
 
     const basePctOffset = 100 / segmentDuration;
-    const pxOffset = 7.5 - segmentDuration;
+    // Base margin required to shrink down the event by one day
+    const basePxOffset = 5.5 - segmentDuration;
+    // Default space between two consecutive events
+    // 5.5px = ( ( ( 2px margin + 3px padding ) * 2 ) + 1px border ) / 2
+
+    // K factors are used to adjust each side of the event based on the hour difference
+    // A '2' is added to the pxOffset to account for the default margin
 
     if (timezoneOffset > 0) {
+      // When the event extends into the next day
       if (info.isStart) {
         const leftK = Math.abs(timezoneOffset) / 24;
         const pctOffset = `${basePctOffset * leftK}%`;
-        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset}px)`;
+        const pxOffset = `${basePxOffset * leftK + 2}px`;
+        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
       }
       if (info.isEnd) {
         const rightK = (24 - Math.abs(timezoneOffset)) / 24;
         const pctOffset = `${basePctOffset * rightK}%`;
-        info.el.style.marginRight = `calc(${pctOffset} + 2px)`;
+        const pxOffset = `${basePxOffset * rightK + 2}px`;
+        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
       }
     } else if (timezoneOffset < 0) {
+      // When the event starts on the previous day
       if (info.isStart) {
         const leftK = (24 - Math.abs(timezoneOffset)) / 24;
         const pctOffset = `${basePctOffset * leftK}%`;
-        info.el.style.marginLeft = `calc(${pctOffset} + 2px)`;
+        const pxOffset = `${basePxOffset * leftK + 2}px`;
+        info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
       }
       if (info.isEnd) {
         const rightK = Math.abs(timezoneOffset) / 24;
         const pctOffset = `${basePctOffset * rightK}%`;
-        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset}px)`;
+        const pxOffset = `${basePxOffset * rightK + 2}px`;
+        info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
       }
     }
   }

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -350,16 +350,20 @@ function initializeDiscourseCalendar(api) {
       return d.hours() !== 0 || d.minutes() !== 0 || d.seconds() !== 0;
     };
 
+    const hasTime =
+      hasTimeSpecified(to.dateTime) || hasTimeSpecified(from.dateTime);
+    const dateFormat = hasTime ? "YYYY-MM-DD HH:mm:ss Z" : "YYYY-MM-DD";
+
     let event = {
-      start: from.dateTime.format("YYYY-MM-DD"),
+      start: from.dateTime.format(dateFormat),
       allDay: false,
     };
 
     if (to) {
-      if (hasTimeSpecified(to.dateTime) || hasTimeSpecified(from.dateTime)) {
-        event.end = to.dateTime.format("YYYY-MM-DD");
+      if (hasTime) {
+        event.end = to.dateTime.format(dateFormat);
       } else {
-        event.end = to.dateTime.add(1, "days").format("YYYY-MM-DD");
+        event.end = to.dateTime.add(1, "days").format(dateFormat);
         event.allDay = true;
       }
     } else {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -776,30 +776,28 @@ function initializeDiscourseCalendar(api) {
 
     const basePctOffset = 100 / segmentDuration;
     const basePxOffset = 5.5 - (segmentDuration - 1) * 0.78;
-    const notStart = info.el.classList.contains("fc-not-start");
-    const notEnd = info.el.classList.contains("fc-not-end");
 
     if (timezoneOffset > 0) {
-      if (!notStart) {
+      if (info.isStart) {
         const leftK = Math.abs(timezoneOffset) / 24;
         const pctOffset = `${basePctOffset * leftK}%`;
         const pxOffset = `${basePxOffset * leftK}px`;
         info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
       }
-      if (!notEnd) {
+      if (info.isEnd) {
         const rightK = (24 - Math.abs(timezoneOffset)) / 24;
         const pctOffset = `${basePctOffset * rightK}%`;
         const pxOffset = `${basePxOffset * rightK}px`;
         info.el.style.marginRight = `calc(${pctOffset} + ${pxOffset})`;
       }
     } else if (timezoneOffset < 0) {
-      if (!notStart) {
+      if (info.isStart) {
         const leftK = (24 - Math.abs(timezoneOffset)) / 24;
         const pctOffset = `${basePctOffset * leftK}%`;
         const pxOffset = `${basePxOffset * leftK}px`;
         info.el.style.marginLeft = `calc(${pctOffset} + ${pxOffset})`;
       }
-      if (!notEnd) {
+      if (info.isEnd) {
         const rightK = Math.abs(timezoneOffset) / 24;
         const pctOffset = `${basePctOffset * rightK}%`;
         const pxOffset = `${basePxOffset * rightK}px`;

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -66,6 +66,10 @@
       display: block;
     }
 
+    .fc-event-container {
+      padding: 3px;
+    }
+
     .fc-widget-header span {
       padding: 3px 3px 3px 0.5em;
     }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -54,7 +54,6 @@ en:
     disable_resorting_on_categories_enabled: "Allow categories to disable the ability for users to sort on the event category."
     calendar_automatic_holidays_enabled: "Automatically set holiday status based on a users region (note: you can disable specific automatic holidays in plugin settings)"
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'. Requires `post event enabled`"
-    enable_timezone_offset_for_calendar_events: "[Experimental] Display each calendar event adjusted for the timezone of the user who created it."
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -54,6 +54,7 @@ en:
     disable_resorting_on_categories_enabled: "Allow categories to disable the ability for users to sort on the event category."
     calendar_automatic_holidays_enabled: "Automatically set holiday status based on a users region (note: you can disable specific automatic holidays in plugin settings)"
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'. Requires `post event enabled`"
+    enable_timezone_offset_for_calendar_events: "[Experimental] Display each calendar event adjusted for the timezone of the user who created it."
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,10 @@ discourse_calendar:
     default: false
     client: true
     hidden: true
+  split_grouped_events_by_timezone_threshold:
+    default: 0
+    client: true
+    hidden: true
 
 discourse_post_event:
   discourse_post_event_enabled:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,3 +92,6 @@ discourse_post_event:
   disable_resorting_on_categories_enabled:
     default: false
     client: true
+  enable_timezone_offset_for_calendar_events:
+    default: false
+    client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,6 +49,9 @@ discourse_calendar:
   sidebar_show_upcoming_events:
     default: true
     client: true
+  enable_timezone_offset_for_calendar_events:
+    default: false
+    client: true
 
 discourse_post_event:
   discourse_post_event_enabled:
@@ -90,8 +93,5 @@ discourse_post_event:
     default: false
     client: true
   disable_resorting_on_categories_enabled:
-    default: false
-    client: true
-  enable_timezone_offset_for_calendar_events:
     default: false
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,6 +52,7 @@ discourse_calendar:
   enable_timezone_offset_for_calendar_events:
     default: false
     client: true
+    hidden: true
 
 discourse_post_event:
   discourse_post_event_enabled:

--- a/plugin.rb
+++ b/plugin.rb
@@ -363,22 +363,23 @@ after_initialize do
         else
           identifier = "#{event.region.split("_").first}-#{event.start_date.strftime("%j")}"
 
-          grouped[identifier] ||= {
-            type: :grouped,
-            from: event.start_date,
-            name: [],
-            usernames: [],
-          }
+          grouped[identifier] ||= { type: :grouped, from: event.start_date, name: [], users: [] }
+
+          user = User.find_by_username(event.username)
 
           grouped[identifier][:name] << event.description
-          grouped[identifier][:usernames] << event.username
+          grouped[identifier][:users] << {
+            username: event.username,
+            timezone: user.present? ? user.user_option.timezone : nil,
+          }
         end
       end
 
     grouped.each do |_, v|
       v[:name].sort!.uniq!
       v[:name] = v[:name].join(", ")
-      v[:usernames].sort!.uniq!
+      v[:users].sort! { |a, b| a[:username] <=> b[:username] }
+      v[:users].uniq! { |u| u[:username] }
     end
 
     standalones + grouped.values

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -35,9 +35,11 @@ describe PostSerializer do
   it "groups calendar events correctly" do
     user = Fabricate(:user)
     user.upsert_custom_fields(::DiscourseCalendar::REGION_CUSTOM_FIELD => "ar")
+    user.user_option.update!(timezone: "America/Buenos_Aires")
 
     user2 = Fabricate(:user)
     user2.upsert_custom_fields(::DiscourseCalendar::REGION_CUSTOM_FIELD => "ar")
+    user2.user_option.update!(timezone: "America/Buenos_Aires")
 
     post = create_post(raw: "[calendar]\n[/calendar]")
     SiteSetting.holiday_calendar_topic_id = post.topic.id
@@ -52,8 +54,11 @@ describe PostSerializer do
       "Feriado puente turístico",
       "Día de la Independencia",
     )
-    expect(json[:post][:calendar_details].map { |x| x[:usernames] }).to all (
-          contain_exactly(user.username, user2.username)
+    expect(json[:post][:calendar_details].map { |x| x[:users] }).to all (
+          contain_exactly(
+            { username: user.username, timezone: "America/Buenos_Aires" },
+            { username: user2.username, timezone: "America/Buenos_Aires" },
+          )
         )
   end
 end

--- a/test/javascripts/acceptance/timezone-offset-test.js
+++ b/test/javascripts/acceptance/timezone-offset-test.js
@@ -247,6 +247,10 @@ function getEventByText(text) {
   return events.length === 1 ? events[0] : events;
 }
 
+function getRoundedPct(marginString) {
+  return Math.round(marginString.match(/(\d+(\.\d+)?)%/)[1]);
+}
+
 acceptance("Discourse Calendar - Timezone Offset", function (needs) {
   needs.settings({
     calendar_enabled: true,
@@ -273,8 +277,8 @@ acceptance("Discourse Calendar - Timezone Offset", function (needs) {
 
     const eventElement = getEventByText("Cordoba");
 
-    assert.ok(eventElement.style.marginLeft.includes("8.33")); // ( ( 1 - (-3) ) / 24 ) * 50%
-    assert.ok(eventElement.style.marginRight.includes("41.66")); // ( ( 24 - ( 1 - (-3) ) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement.style.marginLeft), 8); // ( ( 1 - (-3) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement.style.marginRight), 42); // ( ( 24 - ( 1 - (-3) ) ) / 24 ) * 50%
   });
 
   test("applies the correct offset for events that start on the previous day", async (assert) => {
@@ -282,8 +286,8 @@ acceptance("Discourse Calendar - Timezone Offset", function (needs) {
 
     const eventElement = getEventByText("Tokyo");
 
-    assert.ok(eventElement.style.marginLeft.includes("22.22")); // ( ( 24 - ( 9 - 1 ) ) / 24 ) * 33.33%
-    assert.ok(eventElement.style.marginRight.includes("11.11")); // ( ( 9 - 1 ) / 24 ) * 33.33%
+    assert.strictEqual(getRoundedPct(eventElement.style.marginLeft), 22); // ( ( 24 - ( 9 - 1 ) ) / 24 ) * 33.33%
+    assert.strictEqual(getRoundedPct(eventElement.style.marginRight), 11); // ( ( 9 - 1 ) / 24 ) * 33.33%
   });
 
   test("applies the correct offset for multiline events", async (assert) => {
@@ -291,11 +295,11 @@ acceptance("Discourse Calendar - Timezone Offset", function (needs) {
 
     const eventElement = getEventByText("Moscow");
 
-    assert.ok(eventElement[0].style.marginLeft.includes("45.83")); // ( ( 24 - ( 1 - (-1) ) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[0].style.marginLeft), 46); // ( ( 24 - ( 1 - (-1) ) ) / 24 ) * 50%
     assert.notOk(eventElement[0].style.marginRight);
 
     assert.notOk(eventElement[1].style.marginLeft);
-    assert.ok(eventElement[1].style.marginRight.includes("8.33")); // ( ( 1 - (-1) ) / 24 ) * 100%
+    assert.strictEqual(getRoundedPct(eventElement[1].style.marginRight), 8); // ( ( 1 - (-1) ) / 24 ) * 100%
   });
 });
 
@@ -320,14 +324,14 @@ acceptance("Discourse Calendar - Splitted Grouped Events", function (needs) {
     );
     assert.ok(eventElement.length === 3);
 
-    assert.ok(eventElement[0].style.marginLeft.includes("12.5")); // ( ( 1 - (-5) ) / 24 ) * 50%
-    assert.ok(eventElement[0].style.marginRight.includes("37.5")); // ( ( 24 - ( 1 - (-5) ) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[0].style.marginLeft), 13); // ( ( 1 - (-5) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[0].style.marginRight), 38); // ( ( 24 - ( 1 - (-5) ) ) / 24 ) * 50%
 
-    assert.ok(eventElement[1].style.marginLeft.includes("14.58")); // ( ( 1 - (-6) ) / 24 ) * 50%
-    assert.ok(eventElement[1].style.marginRight.includes("35.41")); // ( ( 24 - ( 1 - (-6) ) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[1].style.marginLeft), 15); // ( ( 1 - (-6) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[1].style.marginRight), 35); // ( ( 24 - ( 1 - (-6) ) ) / 24 ) * 50%
 
-    assert.ok(eventElement[2].style.marginLeft.includes("16.66")); // ( ( 1 - (-7) ) / 24 ) * 50%
-    assert.ok(eventElement[2].style.marginRight.includes("33.33")); // ( ( 24 - ( 1 - (-7) ) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[2].style.marginLeft), 17); // ( ( 1 - (-7) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[2].style.marginRight), 33); // ( ( 24 - ( 1 - (-7) ) ) / 24 ) * 50%
   });
 });
 
@@ -352,7 +356,7 @@ acceptance("Discourse Calendar - Grouped Events", function (needs) {
     );
     assert.ok(eventElement.length === 1);
 
-    assert.ok(eventElement[0].style.marginLeft.includes("14.58")); // ( ( 1 - (-6) ) / 24 ) * 50%
-    assert.ok(eventElement[0].style.marginRight.includes("35.41")); // ( ( 24 - ( 1 - (-6) ) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[0].style.marginLeft), 15); // ( ( 1 - (-6) ) / 24 ) * 50%
+    assert.strictEqual(getRoundedPct(eventElement[0].style.marginRight), 35); // ( ( 24 - ( 1 - (-6) ) ) / 24 ) * 50%
   });
 });

--- a/test/javascripts/acceptance/timezone-offset-test.js
+++ b/test/javascripts/acceptance/timezone-offset-test.js
@@ -1,0 +1,358 @@
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+
+const topicResponse = {
+  post_stream: {
+    posts: [
+      {
+        id: 375,
+        name: null,
+        username: "jan",
+        avatar_template: "/letter_avatar_proxy/v4/letter/j/ce7236/{size}.png",
+        created_at: "2023-09-08T16:50:07.638Z",
+        cooked:
+          '\u003cdiv class="discourse-calendar-wrap"\u003e\n\u003cdiv class="discourse-calendar-header"\u003e\n\u003ch2 class="discourse-calendar-title"\u003e\u003c/h2\u003e\n\u003cspan class="discourse-calendar-timezone-wrap"\u003e\n\u003cselect class="discourse-calendar-timezone-picker"\u003e\u003c/select\u003e\n\u003c/span\u003e\n\u003c/div\u003e\n\u003cdiv class="calendar" data-calendar-type="dynamic" data-calendar-default-timezone="Europe/Lisbon" data-weekends="true" data-calendar-show-add-to-calendar="false" data-calendar-full-day="true"\u003e\u003c/div\u003e\n\u003c/div\u003e',
+        post_number: 1,
+        post_type: 1,
+        updated_at: "2023-09-08T16:50:07.638Z",
+        reply_count: 0,
+        reply_to_post_number: null,
+        quote_count: 0,
+        incoming_link_count: 2,
+        reads: 1,
+        readers_count: 0,
+        score: 10.2,
+        yours: true,
+        topic_id: 252,
+        topic_slug: "awesome-calendar",
+        display_username: null,
+        primary_group_name: null,
+        flair_name: null,
+        flair_url: null,
+        flair_bg_color: null,
+        flair_color: null,
+        flair_group_id: null,
+        version: 1,
+        can_edit: true,
+        can_delete: false,
+        can_recover: false,
+        can_see_hidden_post: true,
+        can_wiki: true,
+        read: true,
+        user_title: null,
+        bookmarked: false,
+        actions_summary: [
+          { id: 3, can_act: true },
+          { id: 4, can_act: true },
+          { id: 8, can_act: true },
+          { id: 7, can_act: true },
+        ],
+        moderator: false,
+        admin: true,
+        staff: true,
+        user_id: 1,
+        hidden: false,
+        trust_level: 1,
+        deleted_at: null,
+        user_deleted: false,
+        edit_reason: null,
+        can_view_edit_history: true,
+        wiki: false,
+        reviewable_id: 0,
+        reviewable_score_count: 0,
+        reviewable_score_pending_count: 0,
+        mentioned_users: [],
+        calendar_details: [
+          {
+            type: "standalone",
+            post_number: 2,
+            message: "Cordoba",
+            from: "2023-09-14T00:00:00.000Z",
+            to: "2023-09-14T00:00:00.000Z",
+            username: "jan",
+            recurring: null,
+            post_url: "/t/-/252/2",
+            timezone: "America/Cordoba",
+          },
+          {
+            type: "standalone",
+            post_number: 4,
+            message: "Moscow",
+            from: "2023-09-17T00:00:00.000Z",
+            to: "2023-09-18T00:00:00.000Z",
+            username: "jan",
+            recurring: null,
+            post_url: "/t/-/252/3",
+            timezone: "Europe/Moscow",
+          },
+          {
+            type: "standalone",
+            post_number: 3,
+            message: "Tokyo",
+            from: "2023-09-20T00:00:00.000Z",
+            to: "2023-09-21T00:00:00.000Z",
+            username: "jan",
+            recurring: null,
+            post_url: "/t/-/252/4",
+            timezone: "Asia/Tokyo",
+          },
+          {
+            type: "standalone",
+            post_number: 5,
+            message: "Lisbon",
+            from: "2023-09-28T00:00:00.000Z",
+            to: "2023-09-28T00:00:00.000Z",
+            username: "jan",
+            recurring: null,
+            post_url: "/t/-/252/5",
+            timezone: "Europe/Lisbon",
+          },
+          {
+            type: "grouped",
+            from: "2023-09-04T05:00:00.000Z",
+            name: "Labor Day",
+            users: [
+              {
+                username: "gmt-5_user",
+                timezone: "America/Chicago",
+              },
+              {
+                username: "gmt-6_user",
+                timezone: "America/Denver",
+              },
+              {
+                username: "gmt-7_user",
+                timezone: "America/Los_Angeles",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  timeline_lookup: [[1, 0]],
+  tags: [],
+  tags_descriptions: {},
+  id: 252,
+  title: "Awesome Calendar",
+  fancy_title: "Awesome Calendar",
+  posts_count: 5,
+  created_at: "2023-09-08T16:50:07.371Z",
+  views: 1,
+  reply_count: 0,
+  like_count: 0,
+  last_posted_at: "2023-09-08T16:50:52.936Z",
+  visible: true,
+  closed: false,
+  archived: false,
+  has_summary: false,
+  archetype: "regular",
+  slug: "awesome-calendar",
+  category_id: 5,
+  word_count: 56,
+  deleted_at: null,
+  user_id: 1,
+  featured_link: null,
+  pinned_globally: false,
+  pinned_at: null,
+  pinned_until: null,
+  image_url: null,
+  slow_mode_seconds: 0,
+  draft: null,
+  draft_key: "topic_252",
+  draft_sequence: 9,
+  posted: true,
+  unpinned: null,
+  pinned: false,
+  current_post_number: 1,
+  highest_post_number: 4,
+  last_read_post_number: 4,
+  last_read_post_id: 378,
+  deleted_by: null,
+  has_deleted: false,
+  actions_summary: [
+    { id: 4, count: 0, hidden: false, can_act: true },
+    { id: 8, count: 0, hidden: false, can_act: true },
+    { id: 7, count: 0, hidden: false, can_act: true },
+  ],
+  chunk_size: 20,
+  bookmarked: false,
+  bookmarks: [],
+  topic_timer: null,
+  message_bus_last_id: 16,
+  participant_count: 1,
+  show_read_indicator: false,
+  thumbnails: null,
+  slow_mode_enabled_until: null,
+  summarizable: false,
+  details: {
+    can_edit: true,
+    notification_level: 3,
+    notifications_reason_id: 1,
+    can_move_posts: true,
+    can_delete: true,
+    can_remove_allowed_users: true,
+    can_invite_to: true,
+    can_invite_via_email: true,
+    can_create_post: true,
+    can_reply_as_new_topic: true,
+    can_flag_topic: true,
+    can_convert_topic: true,
+    can_review_topic: true,
+    can_close_topic: true,
+    can_archive_topic: true,
+    can_split_merge_topic: true,
+    can_edit_staff_notes: true,
+    can_toggle_topic_visibility: true,
+    can_pin_unpin_topic: true,
+    can_moderate_category: true,
+    can_remove_self_id: 1,
+    participants: [
+      {
+        id: 1,
+        username: "jan",
+        name: null,
+        avatar_template: "/letter_avatar_proxy/v4/letter/j/ce7236/{size}.png",
+        post_count: 4,
+        primary_group_name: null,
+        flair_name: null,
+        flair_url: null,
+        flair_color: null,
+        flair_bg_color: null,
+        flair_group_id: null,
+        admin: true,
+        trust_level: 1,
+      },
+    ],
+    created_by: {
+      id: 1,
+      username: "jan",
+      name: null,
+      avatar_template: "/letter_avatar_proxy/v4/letter/j/ce7236/{size}.png",
+    },
+    last_poster: {
+      id: 1,
+      username: "jan",
+      name: null,
+      avatar_template: "/letter_avatar_proxy/v4/letter/j/ce7236/{size}.png",
+    },
+  },
+};
+
+function getEventByText(text) {
+  const events = [...document.querySelectorAll(".fc-day-grid-event")].filter(
+    (event) => event.textContent.includes(text)
+  );
+  return events.length === 1 ? events[0] : events;
+}
+
+acceptance("Discourse Calendar - Timezone Offset", function (needs) {
+  needs.settings({
+    calendar_enabled: true,
+    enable_timezone_offset_for_calendar_events: true,
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/t/252.json", () => {
+      return helper.response(topicResponse);
+    });
+  });
+
+  test("doesn't apply an offset for events in the same timezone", async (assert) => {
+    await visit("/t/252");
+
+    const eventElement = getEventByText("Lisbon");
+
+    assert.notOk(eventElement.style.marginLeft);
+    assert.notOk(eventElement.style.marginRight);
+  });
+
+  test("applies the correct offset for events that extend into the next day", async (assert) => {
+    await visit("/t/252");
+
+    const eventElement = getEventByText("Cordoba");
+
+    assert.ok(eventElement.style.marginLeft.includes("8.33")); // ( ( 1 - (-3) ) / 24 ) * 50%
+    assert.ok(eventElement.style.marginRight.includes("41.66")); // ( ( 24 - ( 1 - (-3) ) ) / 24 ) * 50%
+  });
+
+  test("applies the correct offset for events that start on the previous day", async (assert) => {
+    await visit("/t/252");
+
+    const eventElement = getEventByText("Tokyo");
+
+    assert.ok(eventElement.style.marginLeft.includes("22.22")); // ( ( 24 - ( 9 - 1 ) ) / 24 ) * 33.33%
+    assert.ok(eventElement.style.marginRight.includes("11.11")); // ( ( 9 - 1 ) / 24 ) * 33.33%
+  });
+
+  test("applies the correct offset for multiline events", async (assert) => {
+    await visit("/t/252");
+
+    const eventElement = getEventByText("Moscow");
+
+    assert.ok(eventElement[0].style.marginLeft.includes("45.83")); // ( ( 24 - ( 1 - (-1) ) ) / 24 ) * 50%
+    assert.notOk(eventElement[0].style.marginRight);
+
+    assert.notOk(eventElement[1].style.marginLeft);
+    assert.ok(eventElement[1].style.marginRight.includes("8.33")); // ( ( 1 - (-1) ) / 24 ) * 100%
+  });
+});
+
+acceptance("Discourse Calendar - Splitted Grouped Events", function (needs) {
+  needs.settings({
+    calendar_enabled: true,
+    enable_timezone_offset_for_calendar_events: true,
+    split_grouped_events_by_timezone_threshold: 0,
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/t/252.json", () => {
+      return helper.response(topicResponse);
+    });
+  });
+
+  test("splits holidays events by timezone", async (assert) => {
+    await visit("/t/252");
+
+    const eventElement = document.querySelectorAll(
+      ".fc-day-grid-event.grouped-event"
+    );
+    assert.ok(eventElement.length === 3);
+
+    assert.ok(eventElement[0].style.marginLeft.includes("12.5")); // ( ( 1 - (-5) ) / 24 ) * 50%
+    assert.ok(eventElement[0].style.marginRight.includes("37.5")); // ( ( 24 - ( 1 - (-5) ) ) / 24 ) * 50%
+
+    assert.ok(eventElement[1].style.marginLeft.includes("14.58")); // ( ( 1 - (-6) ) / 24 ) * 50%
+    assert.ok(eventElement[1].style.marginRight.includes("35.41")); // ( ( 24 - ( 1 - (-6) ) ) / 24 ) * 50%
+
+    assert.ok(eventElement[2].style.marginLeft.includes("16.66")); // ( ( 1 - (-7) ) / 24 ) * 50%
+    assert.ok(eventElement[2].style.marginRight.includes("33.33")); // ( ( 24 - ( 1 - (-7) ) ) / 24 ) * 50%
+  });
+});
+
+acceptance("Discourse Calendar - Grouped Events", function (needs) {
+  needs.settings({
+    calendar_enabled: true,
+    enable_timezone_offset_for_calendar_events: true,
+    split_grouped_events_by_timezone_threshold: 2,
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/t/252.json", () => {
+      return helper.response(topicResponse);
+    });
+  });
+
+  test("groups holidays events according to threshold", async (assert) => {
+    await visit("/t/252");
+
+    const eventElement = document.querySelectorAll(
+      ".fc-day-grid-event.grouped-event"
+    );
+    assert.ok(eventElement.length === 1);
+
+    assert.ok(eventElement[0].style.marginLeft.includes("14.58")); // ( ( 1 - (-6) ) / 24 ) * 50%
+    assert.ok(eventElement[0].style.marginRight.includes("35.41")); // ( ( 24 - ( 1 - (-6) ) ) / 24 ) * 50%
+  });
+});

--- a/test/javascripts/acceptance/timezone-offset-test.js
+++ b/test/javascripts/acceptance/timezone-offset-test.js
@@ -11,6 +11,7 @@ const topicResponse = {
         username: "jan",
         avatar_template: "/letter_avatar_proxy/v4/letter/j/ce7236/{size}.png",
         created_at: "2023-09-08T16:50:07.638Z",
+        raw: '[calendar weekends=true tzPicker="true" fullDay="true" showAddToCalendar="false" defaultTimezone="Europe/Lisbon"] [/calendar]',
         cooked:
           '\u003cdiv class="discourse-calendar-wrap"\u003e\n\u003cdiv class="discourse-calendar-header"\u003e\n\u003ch2 class="discourse-calendar-title"\u003e\u003c/h2\u003e\n\u003cspan class="discourse-calendar-timezone-wrap"\u003e\n\u003cselect class="discourse-calendar-timezone-picker"\u003e\u003c/select\u003e\n\u003c/span\u003e\n\u003c/div\u003e\n\u003cdiv class="calendar" data-calendar-type="dynamic" data-calendar-default-timezone="Europe/Lisbon" data-weekends="true" data-calendar-show-add-to-calendar="false" data-calendar-full-day="true"\u003e\u003c/div\u003e\n\u003c/div\u003e',
         post_number: 1,


### PR DESCRIPTION
This PR adds the option to enable a timezone adjustment for calendar events. This will make it so events render offset from the grid to reflect the appropriate start and end moments according to the viewer's timezone.

- Events will rerender when changing the timezone from the timezone picker
- The calendar needs to be full day (`fullDay="true"`)
- The hidden site setting is `enable_timezone_offset_for_calendar_events`

<div align="center"> <h3>Denver (GMT-6) / Tokyo (GMT+9)</h3>

![calendar demo](https://github.com/discourse/discourse-calendar/assets/66427541/01548efa-84b4-4c96-a017-d0c46d339c03)

</div>

By default, grouped events (holidays) get split by timezone. This can be configured. If the timezone difference between events is less than a set threshold, events get grouped anyway and will be displayed with the timezone closest to the average.

- The hidden site setting is `split_grouped_events_by_timezone_threshold`

<div align="center"> <h3>Threshold<br>3 / 1 / 0</h3>

![threshold](https://github.com/discourse/discourse-calendar/assets/66427541/2f678735-ad36-468e-91b1-c698b04f24d7)

</div> 
