### PR TITLE
FEATURE: Add a new site setting that shows upcoming events in the sidebar

### DIFF
--- a/assets/javascripts/discourse/initializers/add-hamburger-menu-action.js
+++ b/assets/javascripts/discourse/initializers/add-hamburger-menu-action.js
@@ -15,7 +15,10 @@ export default {
 
   initialize(container) {
     const siteSettings = container.lookup("service:site-settings");
-    if (siteSettings.discourse_post_event_enabled) {
+    if (
+      siteSettings.discourse_post_event_enabled &&
+      siteSettings.sidebar_show_upcoming_events
+    ) {
       withPluginApi("0.8.7", initializeHamburgerMenu);
     }
   },

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -53,6 +53,7 @@ en:
     sort_categories_by_event_start_date_enabled: "Enable the sorting of category topics by event start date."
     disable_resorting_on_categories_enabled: "Allow categories to disable the ability for users to sort on the event category."
     calendar_automatic_holidays_enabled: "Automatically set holiday status based on a users region (note: you can disable specific automatic holidays in plugin settings)"
+    sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'. Requires `post event enabled`"
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,6 +46,9 @@ discourse_calendar:
     default: 2
     client: true
   calendar_automatic_holidays_enabled: true
+  sidebar_show_upcoming_events:
+    default: true
+    client: true
 
 discourse_post_event:
   discourse_post_event_enabled:

--- a/test/javascripts/acceptance/sidebar-upcoming-events-item-test.js
+++ b/test/javascripts/acceptance/sidebar-upcoming-events-item-test.js
@@ -1,0 +1,71 @@
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Discourse Calendar - hamburger action shown", function (needs) {
+  needs.user();
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    sidebar_show_upcoming_events: true,
+    navigation_menu: "legacy",
+  });
+
+  test("upcoming events hamburger action shown", async function (assert) {
+    await visit("/");
+    await click(".hamburger-dropdown");
+    assert.ok(exists(".widget-link[title='Upcoming events']"));
+  });
+});
+
+acceptance("Discourse Calendar - hamburger action hidden", function (needs) {
+  needs.user();
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    sidebar_show_upcoming_events: false,
+    navigation_menu: "legacy",
+  });
+
+  test("upcoming events hamburger action hidden", async function (assert) {
+    await visit("/");
+    await click(".hamburger-dropdown");
+    assert.notOk(exists(".widget-link[title='Upcoming events']"));
+  });
+});
+
+acceptance("Discourse Calendar - sidebar link shown", function (needs) {
+  needs.user();
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    sidebar_show_upcoming_events: true,
+    navigation_menu: "sidebar",
+  });
+
+  test("upcoming events sidebar section link shown", async function (assert) {
+    await visit("/");
+    await click(".sidebar-more-section-links-details-summary");
+    assert.ok(
+      exists(".sidebar-section-link[data-link-name='upcoming-events']")
+    );
+  });
+});
+
+acceptance("Discourse Calendar - sidebar link hidden", function (needs) {
+  needs.user();
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    sidebar_show_upcoming_events: false,
+    navigation_menu: "sidebar",
+  });
+
+  test("upcoming events sidebar section link hidden", async function (assert) {
+    await visit("/");
+    await click(".sidebar-more-section-links-details-summary");
+    assert.notOk(
+      exists(".sidebar-section-link[data-link-name='upcoming-events']")
+    );
+  });
+});


### PR DESCRIPTION
Sidebar in core automatically adds [`hamburger-menu:generalLinks` to the "Community"'s "More"](https://github.com/discourse/discourse-calendar/blob/main/assets/javascripts/discourse/initializers/add-hamburger-menu-action.js) section. This commit adds a setting to remove that.

<img width="1123" alt="Screenshot 2023-08-28 at 7 12 32 PM" src="https://github.com/discourse/discourse-calendar/assets/1555215/cd02ac0e-d5ce-4bd1-a6f5-5ef3a3a7d6aa">

t/276345