### PR TITLE
FEATURE: Add user option to toggle timezone adjustment

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -833,10 +833,11 @@ function initializeDiscourseCalendar(api) {
     );
     const timezoneButton = document.createElement("button");
 
+    timezoneButton.title = "Toggle timezone offset";
     timezoneButton.classList.add(
       "timezone-offset-button",
       "btn",
-      "btn-small",
+      "btn-default",
       "btn-icon",
       "no-text"
     );

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -833,7 +833,9 @@ function initializeDiscourseCalendar(api) {
     );
     const timezoneButton = document.createElement("button");
 
-    timezoneButton.title = "Toggle timezone offset";
+    timezoneButton.title = I18n.t(
+      "discourse_calendar.toggle_timezone_offset_title"
+    );
     timezoneButton.classList.add(
       "timezone-offset-button",
       "btn",

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -833,29 +833,20 @@ function initializeDiscourseCalendar(api) {
     );
     const timezoneButton = document.createElement("button");
 
-    timezoneButton.classList.add("fc-timezoneOffset-button");
-    timezoneButton.classList.add("fc-button");
+    timezoneButton.classList.add(
+      "timezone-offset-button",
+      "btn",
+      "btn-small",
+      "btn-icon",
+      "no-text"
+    );
     timezoneButton.innerHTML = iconHTML("globe");
-
-    if (enableTimezoneOffset) {
-      timezoneButton.classList.add("fc-state-active");
-    } else {
-      timezoneButton.classList.add("fc-state-default");
-    }
-
     timezoneWrapper.appendChild(timezoneButton);
+
     timezoneButton.addEventListener("click", () => {
       enableTimezoneOffset = !enableTimezoneOffset;
-
-      if (enableTimezoneOffset) {
-        timezoneButton.classList.add("fc-state-active");
-        timezoneButton.classList.remove("fc-state-default");
-      } else {
-        timezoneButton.classList.add("fc-state-default");
-        timezoneButton.classList.remove("fc-state-active");
-      }
-
       resetDynamicEvents();
+      timezoneButton.blur();
     });
   }
 

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -189,6 +189,27 @@ a.holiday {
     font-weight: 700;
     text-transform: capitalize;
   }
+
+  .fc-button {
+    border-radius: 0;
+    box-shadow: none;
+    background: var(--primary-low);
+    text-transform: capitalize;
+    color: var(--primary);
+    text-shadow: none;
+    border: none;
+    padding: 6px 12px;
+
+    &:hover {
+      background: var(--primary-medium);
+      color: var(--secondary);
+    }
+
+    &.fc-state-active {
+      background: var(--tertiary);
+      color: var(--secondary);
+    }
+  }
 }
 
 .discourse-calendar-header .discourse-calendar-timezone-picker {

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -189,27 +189,6 @@ a.holiday {
     font-weight: 700;
     text-transform: capitalize;
   }
-
-  .fc-button {
-    border-radius: 0;
-    box-shadow: none;
-    background: var(--primary-low);
-    text-transform: capitalize;
-    color: var(--primary);
-    text-shadow: none;
-    border: none;
-    padding: 6px 12px;
-
-    &:hover {
-      background: var(--primary-medium);
-      color: var(--secondary);
-    }
-
-    &.fc-state-active {
-      background: var(--tertiary);
-      color: var(--secondary);
-    }
-  }
 }
 
 .discourse-calendar-header .discourse-calendar-timezone-picker {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -32,6 +32,7 @@ en:
         disabled_holidays_description: "Disabled holidays will be excluded from the staff holiday calendar."
       date: "Date"
       add_to_calendar: "Add to Google Calendar"
+      toggle_timezone_offset_title: "Toggle timezone offset"
       region:
         title: "Region"
         none: "None"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,6 +57,10 @@ discourse_calendar:
     default: 0
     client: true
     hidden: true
+  default_timezone_offset_user_option:
+    default: false
+    client: true
+    hidden: true
 
 discourse_post_event:
   discourse_post_event_enabled:

--- a/test/javascripts/acceptance/timezone-offset-test.js
+++ b/test/javascripts/acceptance/timezone-offset-test.js
@@ -256,6 +256,7 @@ acceptance("Discourse Calendar - Timezone Offset", function (needs) {
   needs.settings({
     calendar_enabled: true,
     enable_timezone_offset_for_calendar_events: true,
+    default_timezone_offset_user_option: true,
   });
 
   needs.pretender((server, helper) => {
@@ -308,6 +309,7 @@ acceptance("Discourse Calendar - Splitted Grouped Events", function (needs) {
   needs.settings({
     calendar_enabled: true,
     enable_timezone_offset_for_calendar_events: true,
+    default_timezone_offset_user_option: true,
     split_grouped_events_by_timezone_threshold: 0,
   });
 
@@ -340,6 +342,7 @@ acceptance("Discourse Calendar - Grouped Events", function (needs) {
   needs.settings({
     calendar_enabled: true,
     enable_timezone_offset_for_calendar_events: true,
+    default_timezone_offset_user_option: true,
     split_grouped_events_by_timezone_threshold: 2,
   });
 


### PR DESCRIPTION
- The button only appears when `enable_timezone_offset_for_calendar_events` is set to true.
- The option is not persistent; it resets each time the calendar is loaded.
- By default, the offset is disabled and is configurable via `default_timezone_offset_user_option`.
- Similar to changing the timezone, it takes some time to rerender the events, depending on the number of them.

![demo](https://github.com/discourse/discourse-calendar/assets/66427541/e29ee987-c47c-4e49-8b1a-36d0abef423b)

