### PR TITLE
FEATURE: Use event category's color for calendar event

### DIFF
--- a/app/serializers/discourse_post_event/event_serializer.rb
+++ b/app/serializers/discourse_post_event/event_serializer.rb
@@ -27,6 +27,7 @@ module DiscoursePostEvent
     attributes :reminders
     attributes :recurrence
     attributes :minimal
+    attributes :category_color
 
     def can_act_on_discourse_post_event
       scope.can_act_on_discourse_post_event?(object)
@@ -127,6 +128,10 @@ module DiscoursePostEvent
     def should_display_invitees
       (object.public? && object.invitees.count > 0) ||
         (object.private? && object.raw_invitees.count > 0)
+    end
+
+    def category_color
+      object.post.topic.category.color
     end
   end
 end

--- a/app/serializers/discourse_post_event/event_serializer.rb
+++ b/app/serializers/discourse_post_event/event_serializer.rb
@@ -27,7 +27,7 @@ module DiscoursePostEvent
     attributes :reminders
     attributes :recurrence
     attributes :minimal
-    attributes :category_color
+    attributes :category_id
 
     def can_act_on_discourse_post_event
       scope.can_act_on_discourse_post_event?(object)
@@ -129,9 +129,8 @@ module DiscoursePostEvent
       (object.public? && object.invitees.count > 0) ||
         (object.private? && object.raw_invitees.count > 0)
     end
-
-    def category_color
-      object.post.topic.category.color
+    def category_id
+      object.post.topic.category_id
     end
   end
 end

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -41,14 +41,15 @@ export default Component.extend({
       this._calendar = new window.FullCalendar.Calendar(calendarNode, {});
 
       (this.events || []).forEach((event) => {
-        const { starts_at, ends_at, post } = event;
+        const { starts_at, ends_at, post, category_id } = event;
+        const backgroundColor = `#${this.site.categoriesById[category_id].color}`;
         this._calendar.addEvent({
           title: formatEventName(event),
           start: starts_at,
           end: ends_at || starts_at,
           allDay: !isNotFullDayEvent(moment(starts_at), moment(ends_at)),
           url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
-          backgroundColor: `#${event.category_color}`,
+          backgroundColor,
         });
       });
 

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -48,6 +48,7 @@ export default Component.extend({
           end: ends_at || starts_at,
           allDay: !isNotFullDayEvent(moment(starts_at), moment(ends_at)),
           url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
+          backgroundColor: `#${event.category_color}`,
         });
       });
 

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -141,6 +141,7 @@ function initializeDiscourseCalendar(api) {
                 end: ends_at || starts_at,
                 allDay: !isNotFullDayEvent(moment(starts_at), moment(ends_at)),
                 url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
+                backgroundColor: `#${browsedCategory.color}`,
               });
             });
 

--- a/assets/stylesheets/common/upcoming-events-calendar.scss
+++ b/assets/stylesheets/common/upcoming-events-calendar.scss
@@ -98,7 +98,6 @@
   .fc-event,
   .fc-event-dot {
     color: var(--secondary);
-    background-color: var(--tertiary);
     border: 1px solid transparent;
 
     .fc-time {

--- a/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -12,30 +12,42 @@ describe DiscoursePostEvent::EventSerializer do
     SiteSetting.discourse_post_event_enabled = true
   end
 
-  let(:post_1) { Fabricate(:post) }
-  let(:event_1) { Fabricate(:event, post: post_1, status: Event.statuses[:private]) }
-  let(:invitee_1) { Fabricate(:user) }
-  let(:invitee_2) { Fabricate(:user) }
-  let(:group_1) do
-    Fabricate(:group).tap do |g|
-      g.add(invitee_1)
-      g.add(invitee_2)
-      g.save!
-    end
-  end
+  fab!(:category) { Fabricate(:category, color: "b878e2") }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
 
   context "with a private event" do
+    fab!(:private_event) { Fabricate(:event, post: post, status: Event.statuses[:private]) }
+    fab!(:invitee_1) { Fabricate(:user) }
+    fab!(:invitee_2) { Fabricate(:user) }
+    fab!(:group_1) do
+      Fabricate(:group).tap do |g|
+        g.add(invitee_1)
+        g.add(invitee_2)
+        g.save!
+      end
+    end
+
     context "when some invited users have not rsvp-ed yet" do
       before do
-        event_1.update_with_params!(raw_invitees: [group_1.name])
-        Invitee.create_attendance!(invitee_1.id, event_1.id, :going)
-        event_1.reload
+        private_event.update_with_params!(raw_invitees: [group_1.name])
+        Invitee.create_attendance!(invitee_1.id, private_event.id, :going)
+        private_event.reload
       end
 
       it "returns the correct stats" do
-        json = EventSerializer.new(event_1, scope: Guardian.new).as_json
+        json = EventSerializer.new(private_event, scope: Guardian.new).as_json
         expect(json[:event][:stats]).to eq(going: 1, interested: 0, invited: 2, not_going: 0)
       end
+    end
+  end
+
+  context "with a public event" do
+    fab!(:event) { Fabricate(:event, post: post) }
+
+    it "returns the event category's color" do
+      json = EventSerializer.new(event, scope: Guardian.new).as_json
+      expect(json[:event][:category_color]).to eq(category.color)
     end
   end
 end

--- a/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -12,7 +12,7 @@ describe DiscoursePostEvent::EventSerializer do
     SiteSetting.discourse_post_event_enabled = true
   end
 
-  fab!(:category) { Fabricate(:category, color: "b878e2") }
+  fab!(:category) { Fabricate(:category) }
   fab!(:topic) { Fabricate(:topic, category: category) }
   fab!(:post) { Fabricate(:post, topic: topic) }
 
@@ -45,9 +45,9 @@ describe DiscoursePostEvent::EventSerializer do
   context "with a public event" do
     fab!(:event) { Fabricate(:event, post: post) }
 
-    it "returns the event category's color" do
+    it "returns the event category's id" do
       json = EventSerializer.new(event, scope: Guardian.new).as_json
-      expect(json[:event][:category_color]).to eq(category.color)
+      expect(json[:event][:category_id]).to eq(category.id)
     end
   end
 end

--- a/test/javascripts/acceptance/upcoming-events-calendar-test.js
+++ b/test/javascripts/acceptance/upcoming-events-calendar-test.js
@@ -1,0 +1,166 @@
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+import { tomorrow } from "discourse/lib/time-utils";
+
+acceptance("Discourse Calendar - Upcoming Events Calendar", function (needs) {
+  needs.site({
+    categories: [
+      {
+        id: 1,
+        name: "Category 1",
+        slug: "caetgory-1",
+        color: "0f78be",
+      },
+      {
+        id: 2,
+        name: "Category 2",
+        slug: "category-2",
+        color: "be0a0a",
+      },
+    ],
+  });
+  needs.user();
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    events_calendar_categories: "1",
+    calendar_categories: "",
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/discourse-post-event/events.json", () => {
+      return helper.response({
+        events: [
+          {
+            id: 67501,
+            creator: {
+              id: 1500588,
+              username: "foobar",
+              name: null,
+              avatar_template:
+                "/user_avatar/localhost/foobar/{size}/1913_2.png",
+              assign_icon: "user-plus",
+              assign_path: "/u/foobar/activity/assigned",
+            },
+            sample_invitees: [],
+            watching_invitee: null,
+            starts_at: tomorrow(),
+            ends_at: null,
+            timezone: "Asia/Calcutta",
+            stats: {
+              going: 0,
+              interested: 0,
+              not_going: 0,
+              invited: 0,
+            },
+            status: "public",
+            raw_invitees: ["trust_level_0"],
+            post: {
+              id: 67501,
+              post_number: 1,
+              url: "/t/this-is-an-event/18449/1",
+              topic: {
+                id: 18449,
+                title: "This is an event",
+              },
+            },
+            name: "Awesome Event",
+            can_act_on_discourse_post_event: true,
+            can_update_attendance: true,
+            is_expired: false,
+            is_ongoing: true,
+            should_display_invitees: false,
+            url: null,
+            custom_fields: {},
+            is_public: true,
+            is_private: false,
+            is_standalone: false,
+            reminders: [],
+            recurrence: null,
+            category_id: 1,
+          },
+          {
+            id: 67502,
+            creator: {
+              id: 1500588,
+              username: "foobar",
+              name: null,
+              avatar_template:
+                "/user_avatar/localhost/foobar/{size}/1913_2.png",
+              assign_icon: "user-plus",
+              assign_path: "/u/foobar/activity/assigned",
+            },
+            sample_invitees: [],
+            watching_invitee: null,
+            starts_at: tomorrow(),
+            ends_at: null,
+            timezone: "Asia/Calcutta",
+            stats: {
+              going: 0,
+              interested: 0,
+              not_going: 0,
+              invited: 0,
+            },
+            status: "public",
+            raw_invitees: ["trust_level_0"],
+            post: {
+              id: 67501,
+              post_number: 1,
+              url: "/t/this-is-an-event-2/18450/1",
+              topic: {
+                id: 18449,
+                title: "This is an event 2",
+              },
+            },
+            name: "Another Awesome Event",
+            can_act_on_discourse_post_event: true,
+            can_update_attendance: true,
+            is_expired: false,
+            is_ongoing: true,
+            should_display_invitees: false,
+            url: null,
+            custom_fields: {},
+            is_public: true,
+            is_private: false,
+            is_standalone: false,
+            reminders: [],
+            recurrence: null,
+            category_id: 2,
+          },
+        ],
+      });
+    });
+  });
+
+  test("shows upcoming events calendar", async (assert) => {
+    await visit("/upcoming-events");
+
+    assert.ok(
+      exists("#upcoming-events-calendar"),
+      "Upcoming Events calendar is shown."
+    );
+
+    assert.ok(exists(".fc-view-container"), "FullCalendar is loaded.");
+  });
+
+  test("upcoming events category colors", async (assert) => {
+    await visit("/upcoming-events");
+
+    assert.strictEqual(
+      query(".fc-row tr:first-child .fc-event").style.backgroundColor,
+      "rgb(190, 10, 10)",
+      "Event item uses the proper color from category 1"
+    );
+
+    assert.strictEqual(
+      query(".fc-row tr:nth-child(2) .fc-event").style.backgroundColor,
+      "rgb(15, 120, 190)",
+      "Event item uses the proper color from category 2"
+    );
+  });
+});


### PR DESCRIPTION
We've hardcoded the events to `var(--tertiary)`. Many users have requested that events be the colour of their categories.


I attempted to add an acceptance test to assert that the colours match the category colours defined in the fixtures, but 
```
query(".fc-event-container").style.backgroundColor
```

returns `'rgb(37, 170, 226)'` value which is slightly annoying to assert against...

Category calendar now:
<img width="502" alt="Screenshot 2023-09-28 at 6 41 36 PM" src="https://github.com/discourse/discourse-calendar/assets/1555215/0588f6f0-27fc-42f5-8852-0e4391e8d1d1">

Upcoming calendar now:
<img width="791" alt="Screenshot 2023-09-28 at 6 53 56 PM" src="https://github.com/discourse/discourse-calendar/assets/1555215/67de4c9a-59b3-4938-92a3-12ed56a2f4f4">