### PR TITLE
DEV: Update QUnit acceptance test to not rely on legacy nav menu

### DIFF
--- a/test/javascripts/acceptance/sidebar-upcoming-events-item-test.js
+++ b/test/javascripts/acceptance/sidebar-upcoming-events-item-test.js
@@ -4,17 +4,25 @@ import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Discourse Calendar - hamburger action shown", function (needs) {
   needs.user();
+
   needs.settings({
     calendar_enabled: true,
     discourse_post_event_enabled: true,
     sidebar_show_upcoming_events: true,
-    navigation_menu: "legacy",
   });
 
   test("upcoming events hamburger action shown", async function (assert) {
     await visit("/");
-    await click(".hamburger-dropdown");
-    assert.ok(exists(".widget-link[title='Upcoming events']"));
+
+    await click(
+      ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
+    );
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='upcoming-events']"
+      )
+      .exists();
   });
 });
 


### PR DESCRIPTION
Why this change?

The legacy navigation menu has been deprecated for quite awhile and will
soon be removed.

What does this change do?

Update the tests to test against the `sidebar` navigation menu instead
which is the default for a new Discourse install.