### PR TITLE
DEV: Skip flaky test

### DIFF
--- a/test/javascripts/acceptance/topic-calendar-events-test.js
+++ b/test/javascripts/acceptance/topic-calendar-events-test.js
@@ -1,6 +1,6 @@
 import { acceptance, fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
-import { test } from "qunit";
+import { skip } from "qunit";
 import getEventByText from "../helpers/get-event-by-text";
 import eventTopicFixture from "../helpers/event-topic-fixture";
 
@@ -23,7 +23,7 @@ acceptance("Discourse Calendar - Topic Calendar Events", function (needs) {
     });
   });
 
-  test("renders calendar events with fullDay='false'", async (assert) => {
+  skip("renders calendar events with fullDay='false'", async (assert) => {
     await visit("/t/-/252");
 
     assert.dom(getEventByText("Event 1")).exists();


### PR DESCRIPTION
This is still problematic. The cause of the flakiness is in Discourse core, but skipping this test for now while we continue digging into the problem.