### PR TITLE
FIX: fallback category color if there's no category

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -42,7 +42,8 @@ export default Component.extend({
 
       (this.events || []).forEach((event) => {
         const { starts_at, ends_at, post, category_id } = event;
-        const backgroundColor = `#${this.site.categoriesById[category_id].color}`;
+        const categoryColor = this.site.categoriesById[category_id]?.color;
+        const backgroundColor = categoryColor ? `#${categoryColor}` : undefined;
         this._calendar.addEvent({
           title: formatEventName(event),
           start: starts_at,

--- a/assets/stylesheets/common/upcoming-events-calendar.scss
+++ b/assets/stylesheets/common/upcoming-events-calendar.scss
@@ -98,6 +98,7 @@
   .fc-event,
   .fc-event-dot {
     color: var(--secondary);
+    background-color: var(--tertiary);
     border: 1px solid transparent;
 
     .fc-time {


### PR DESCRIPTION
Fallback to a default color if there's no category_id.

A user may manually copy the event from a topic or convert one to a PM, leaving the event without a category.