### PR TITLE
DEV: Replace deprecated queue_jobs site setting in tests

### DIFF
--- a/spec/integration/invitee_spec.rb
+++ b/spec/integration/invitee_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe DiscoursePostEvent::Invitee do
   before do
     freeze_time
-    SiteSetting.queue_jobs = false
+    Jobs.run_immediately!
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
   end

--- a/spec/integration/topic_spec.rb
+++ b/spec/integration/topic_spec.rb
@@ -7,7 +7,7 @@ describe Topic do
 
   before do
     freeze_time
-    SiteSetting.queue_jobs = false
+    Jobs.run_immediately!
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
   end

--- a/spec/requests/invitees_controller_spec.rb
+++ b/spec/requests/invitees_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 module DiscoursePostEvent
   describe InviteesController do
     before do
-      SiteSetting.queue_jobs = false
+      Jobs.run_immediately!
       SiteSetting.calendar_enabled = true
       SiteSetting.discourse_post_event_enabled = true
       sign_in(user)


### PR DESCRIPTION
### What is this change?

The `#queue_jobs=` method on site settings has been [deprecated](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) and replaced by `Jobs.run_later!` and `Jobs.run_immediately!`. This PR replaces usages in this plugin so we can remove the fallback in core.

The fallback used in core for reference:

https://github.com/discourse/discourse/blob/main/app/models/site_setting.rb#L109-L115