### PR TITLE
FIX: Move `sidebar_show_upcoming_events` into Event settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,9 +47,6 @@ discourse_calendar:
     default: 2
     client: true
   calendar_automatic_holidays_enabled: true
-  sidebar_show_upcoming_events:
-    default: true
-    client: true
   enable_timezone_offset_for_calendar_events:
     default: false
     client: true
@@ -104,4 +101,7 @@ discourse_post_event:
     client: true
   disable_resorting_on_categories_enabled:
     default: false
+    client: true
+  sidebar_show_upcoming_events:
+    default: true
     client: true


### PR DESCRIPTION
Currently the `sidebar_show_upcoming_events` is displaying in the Calendar group and not the Event group. This commit moves it into the correct group