### PR TITLE
FIX: Remove note from `sidebar show upcoming events` description

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -53,7 +53,7 @@ en:
     sort_categories_by_event_start_date_enabled: "Enable the sorting of category topics by event start date."
     disable_resorting_on_categories_enabled: "Allow categories to disable the ability for users to sort on the event category."
     calendar_automatic_holidays_enabled: "Automatically set holiday status based on a users region (note: you can disable specific automatic holidays in plugin settings)"
-    sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'. Requires `post event enabled`"
+    sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'."
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."


### PR DESCRIPTION
As the `sidebar show upcoming events` setting was previously grouped within the Calendar settings group a note to ensure 'post event' was enabled was added. Once grouped with the Event settings, this became superfluous.