### PR TITLE
UX: Remove 'experimental' from discourse_post_event_enabled

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -30,7 +30,7 @@ en:
 
   site_settings:
     calendar_enabled: "Enable the discourse-calendar plugin. This will add support for a [calendar][/calendar] tag in the first post of a topic."
-    discourse_post_event_enabled: "[experimental] Enables to attach an event to a post. Note: also needs `calendar enabled` to be enabled."
+    discourse_post_event_enabled: "Enables the Event features. Note: also needs `calendar enabled` to be enabled."
     displayed_invitees_limit: "Limits the numbers of invitees displayed on an event."
     display_post_event_date_on_topic_title: "Displays the date of the event after the topic title."
     use_local_event_date: "Use local date after topic title instead of relative time."


### PR DESCRIPTION
Removes 'experimental' from the `discourse_post_event_enabled` plugin setting