### PR TITLE
FIX: skip html escaping event urls

### DIFF
--- a/lib/discourse_post_event/event_parser.rb
+++ b/lib/discourse_post_event/event_parser.rb
@@ -41,7 +41,7 @@ module DiscoursePostEvent
 
             if value && valid_options.include?(name)
               event ||= {}
-              event[name.sub("data-", "").to_sym] = if name == "data-name"
+              event[name.sub("data-", "").to_sym] = if %w[data-name data-url].include?(name)
                 value
               else
                 CGI.escapeHTML(value)

--- a/spec/lib/discourse_post_event/event_parser_spec.rb
+++ b/spec/lib/discourse_post_event/event_parser_spec.rb
@@ -100,6 +100,16 @@ describe DiscoursePostEvent::EventParser do
     expect(events[0][:name]).to eq("bar <script> baz")
   end
 
+  it "doesn't escape urls" do
+    post_event = build_post user, <<~TXT
+        [event start="2020" url="https://example.com/?q=foo&all=true"]
+        [/event]
+      TXT
+
+    events = parser.extract_events(post_event)
+    expect(events[0][:url]).to eq("https://example.com/?q=foo&all=true")
+  end
+
   context "with custom fields" do
     before { SiteSetting.discourse_post_event_allowed_custom_fields = "foo-bar|bar" }
 


### PR DESCRIPTION
Event URLs are used on `a` `href`s and shouldn't be HTML-escaped.