### PR TITLE
FIX: Show sub category events

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -110,7 +110,7 @@ module DiscoursePostEvent
     private
 
     def filtered_events_params
-      params.permit(:post_id, :category_id)
+      params.permit(:post_id, :category_id, :include_subcategories)
     end
   end
 end

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -144,21 +144,22 @@ function initializeDiscourseCalendar(api) {
             }
           );
           const loadEvents = ajax(
-            `/discourse-post-event/events.json?category_id=${browsedCategory.id}`
+            `/discourse-post-event/events.json?category_id=${browsedCategory.id}&include_subcategories=true`
           );
 
           Promise.all([loadEvents]).then((results) => {
             const events = results[0];
 
             events[Object.keys(events)[0]].forEach((event) => {
-              const { starts_at, ends_at, post } = event;
+              const { starts_at, ends_at, post, category_id } = event;
+              const backgroundColor = `#${site.categoriesById[category_id]?.color}`;
               fullCalendar.addEvent({
                 title: formatEventName(event),
                 start: starts_at,
                 end: ends_at || starts_at,
                 allDay: !isNotFullDayEvent(moment(starts_at), moment(ends_at)),
                 url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
-                backgroundColor: `#${browsedCategory.color}`,
+                backgroundColor,
               });
             });
 

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -210,17 +210,42 @@ module DiscoursePostEvent
         end
 
         context "when filtering by category" do
-          it "can filter the event by category" do
-            category = Fabricate(:category)
-            topic = Fabricate(:topic, category: category)
-            event_2 = Fabricate(:event, post: Fabricate(:post, post_number: 1, topic: topic))
+          fab!(:category) { Fabricate(:category) }
+          fab!(:subcategory) do
+            Fabricate(:category, parent_category: category, name: "category subcategory")
+          end
+          fab!(:event_1) do
+            Fabricate(
+              :event,
+              post: Fabricate(:post, post_number: 1, topic: Fabricate(:topic, category: category)),
+            )
+          end
+          fab!(:event_2) do
+            Fabricate(
+              :event,
+              post:
+                Fabricate(:post, post_number: 1, topic: Fabricate(:topic, category: subcategory)),
+            )
+          end
 
+          it "can filter the event by category" do
             get "/discourse-post-event/events.json?category_id=#{category.id}"
 
             expect(response.status).to eq(200)
             events = response.parsed_body["events"]
             expect(events.length).to eq(1)
-            expect(events[0]["id"]).to eq(event_2.id)
+            expect(events[0]["id"]).to eq(event_1.id)
+          end
+
+          it "includes subcategory events when param provided" do
+            get "/discourse-post-event/events.json?category_id=#{category.id}&include_subcategories=true"
+
+            expect(response.status).to eq(200)
+            events = response.parsed_body["events"]
+            expect(events.length).to eq(2)
+            expect(events).to match_array(
+              [hash_including("id" => event_1.id), hash_including("id" => event_2.id)],
+            )
           end
         end
       end


### PR DESCRIPTION
Currently on any category page e.g. /c/general/1, sub category events are not shown on the parent calendar. This fix shows sub categories on the parent category's calendar.

<img width="1091" alt="Screenshot 2023-11-10 at 2 13 11 PM" src="https://github.com/discourse/discourse-calendar/assets/1555215/1d92d125-9d49-4519-8a3d-3c4c727fe1cc">

