### PR TITLE
FIX: regional public holidays day early

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -721,6 +721,11 @@ function initializeDiscourseCalendar(api) {
     (post.calendar_details || []).forEach((detail) => {
       switch (detail.type) {
         case "grouped":
+          if (fullDay && detail.timezone) {
+            detail.from = moment
+              .tz(detail.from, detail.timezone)
+              .format("YYYY-MM-DD");
+          }
           groupedEvents.push(detail);
           break;
         case "standalone":

--- a/jobs/scheduled/create_holiday_events.rb
+++ b/jobs/scheduled/create_holiday_events.rb
@@ -75,14 +75,18 @@ module Jobs
                   holiday[:date]
                 end
 
-              CalendarEvent.find_or_create_by(
-                topic_id: topic_id,
-                user_id: user_id,
-                username: usernames[user_id],
-                description: holiday[:name],
-                start_date: date,
-                region: region,
-              )
+              event =
+                CalendarEvent.find_or_initialize_by(
+                  topic_id: topic_id,
+                  user_id: user_id,
+                  username: usernames[user_id],
+                  description: holiday[:name],
+                  start_date: date,
+                  region: region,
+                )
+
+              event.timezone = tz.name if tz
+              event.save!
             end
           end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -371,7 +371,13 @@ after_initialize do
         else
           identifier = "#{event.region.split("_").first}-#{event.start_date.strftime("%j")}"
 
-          grouped[identifier] ||= { type: :grouped, from: event.start_date, name: [], users: [] }
+          grouped[identifier] ||= {
+            type: :grouped,
+            from: event.start_date,
+            timezone: event.timezone,
+            name: [],
+            users: [],
+          }
 
           user = User.find_by_username(event.username)
 

--- a/test/javascripts/acceptance/topic-calendar-holidays-test.js
+++ b/test/javascripts/acceptance/topic-calendar-holidays-test.js
@@ -1,6 +1,7 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance, fakeTime } from "discourse/tests/helpers/qunit-helpers";
+import { cloneJSON } from "discourse-common/lib/object";
 import eventTopicFixture from "../helpers/event-topic-fixture";
 
 acceptance("Discourse Calendar - Topic Calendar Holidays", function (needs) {
@@ -17,7 +18,9 @@ acceptance("Discourse Calendar - Topic Calendar Holidays", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    eventTopicFixture.post_stream.posts[0].calendar_details = [
+    const clonedEventTopicFixture = cloneJSON(eventTopicFixture);
+
+    clonedEventTopicFixture.post_stream.posts[0].calendar_details = [
       {
         type: "grouped",
         from: "2023-12-25T05:00:00.000Z",
@@ -32,7 +35,7 @@ acceptance("Discourse Calendar - Topic Calendar Holidays", function (needs) {
       },
     ];
     server.get("/t/252.json", () => {
-      return helper.response(eventTopicFixture);
+      return helper.response(clonedEventTopicFixture);
     });
   });
 

--- a/test/javascripts/acceptance/topic-calendar-holidays-test.js
+++ b/test/javascripts/acceptance/topic-calendar-holidays-test.js
@@ -1,0 +1,49 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance, fakeTime } from "discourse/tests/helpers/qunit-helpers";
+import eventTopicFixture from "../helpers/event-topic-fixture";
+
+acceptance("Discourse Calendar - Topic Calendar Holidays", function (needs) {
+  needs.hooks.beforeEach(function () {
+    this.clock = fakeTime("2023-12-10T00:00:00", "America/Los_Angeles", true);
+  });
+
+  needs.hooks.afterEach(function () {
+    this.clock.restore();
+  });
+
+  needs.settings({
+    calendar_enabled: true,
+  });
+
+  needs.pretender((server, helper) => {
+    eventTopicFixture.post_stream.posts[0].calendar_details = [
+      {
+        type: "grouped",
+        from: "2023-12-25T05:00:00.000Z",
+        timezone: "Europe/Rome",
+        name: "Natale",
+        users: [
+          {
+            username: "gmt+1_user",
+            timezone: "Europe/Rome",
+          },
+        ],
+      },
+    ];
+    server.get("/t/252.json", () => {
+      return helper.response(eventTopicFixture);
+    });
+  });
+
+  test("renders calendar holidays with fullDay='true'", async (assert) => {
+    await visit("/t/-/252");
+
+    assert
+      .dom(".fc-week:nth-child(5) .fc-content-skeleton tbody td:first-child")
+      .hasClass(
+        "fc-event-container",
+        "Italian Christmas Day is displayed on Monday 2023-12-25"
+      );
+  });
+});


### PR DESCRIPTION
When a public holiday is created, it is created in a specific user time zone.

https://github.com/discourse/discourse-calendar/blob/main/jobs/scheduled/create_holiday_events.rb#L71

When calendar is set as fullDay, we would like to display Christmas always 25th of December.

To achieve that, we need to have information about timezone, parse date in that timezone, and leave only year, month and day.

I added a test case to cover one bug scenario. User from Los Angeles have seen that user from Italy was celebrating Christmas Day on 24th of December instead of 25th.