### PR TITLE
DEV: merge discourse post event settings to calendar

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -68,14 +68,18 @@ module DiscoursePostEvent
           else
             render json:
                      failed_json.merge(
-                       errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
+                       errors: [
+                         I18n.t("discourse_calendar.discourse_post_event.errors.bulk_invite.error"),
+                       ],
                      ),
                    status: 422
           end
         rescue StandardError
           render json:
                    failed_json.merge(
-                     errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
+                     errors: [
+                       I18n.t("discourse_calendar.discourse_post_event.errors.bulk_invite.error"),
+                     ],
                    ),
                  status: 422
         end
@@ -101,7 +105,9 @@ module DiscoursePostEvent
       rescue StandardError
         render json:
                  failed_json.merge(
-                   errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
+                   errors: [
+                     I18n.t("discourse_calendar.discourse_post_event.errors.bulk_invite.error"),
+                   ],
                  ),
                status: 422
       end

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -128,7 +128,10 @@ module DiscoursePostEvent
       if self.raw_invitees && self.raw_invitees.length > 10
         errors.add(
           :base,
-          I18n.t("discourse_post_event.errors.models.event.raw_invitees_length", count: 10),
+          I18n.t(
+            "discourse_calendar.discourse_post_event.errors.models.event.raw_invitees_length",
+            count: 10,
+          ),
         )
       end
     end
@@ -138,7 +141,9 @@ module DiscoursePostEvent
       if self.raw_invitees && User.select(:id).where(username: self.raw_invitees).limit(1).count > 0
         errors.add(
           :base,
-          I18n.t("discourse_post_event.errors.models.event.raw_invitees.only_group"),
+          I18n.t(
+            "discourse_calendar.discourse_post_event.errors.models.event.raw_invitees.only_group",
+          ),
         )
       end
     end
@@ -149,7 +154,9 @@ module DiscoursePostEvent
            self.original_starts_at >= self.original_ends_at
         errors.add(
           :base,
-          I18n.t("discourse_post_event.errors.models.event.ends_at_before_starts_at"),
+          I18n.t(
+            "discourse_calendar.discourse_post_event.errors.models.event.ends_at_before_starts_at",
+          ),
         )
       end
     end
@@ -161,7 +168,10 @@ module DiscoursePostEvent
         if !allowed_custom_fields.include?(key)
           errors.add(
             :base,
-            I18n.t("discourse_post_event.errors.models.event.custom_field_is_invalid", field: key),
+            I18n.t(
+              "discourse_calendar.discourse_post_event.errors.models.event.custom_field_is_invalid",
+              field: key,
+            ),
           )
         end
       end
@@ -199,9 +209,9 @@ module DiscoursePostEvent
 
       message =
         if predefined_attendance
-          "discourse_post_event.notifications.invite_user_predefined_attendance_notification"
+          "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification"
         else
-          "discourse_post_event.notifications.invite_user_notification"
+          "discourse_calendar.discourse_post_event.notifications.invite_user_notification"
         end
 
       attrs = {

--- a/assets/javascripts/discourse/components/bulk-invite-sample-csv-file.hbs
+++ b/assets/javascripts/discourse/components/bulk-invite-sample-csv-file.hbs
@@ -1,4 +1,4 @@
 <DButton
-  @label="discourse_post_event.bulk_invite_modal.download_sample_csv"
+  @label="discourse_calendar.discourse_post_event.bulk_invite_modal.download_sample_csv"
   @action={{action "downloadSampleCsv"}}
 />

--- a/assets/javascripts/discourse/components/event-date.gjs
+++ b/assets/javascripts/discourse/components/event-date.gjs
@@ -92,9 +92,12 @@ export default class EventDate extends Component {
   }
 
   get timeRemainingContent() {
-    return I18n.t("discourse_post_event.topic_title.ends_in_duration", {
-      duration: this.eventEndedAt.from(moment()),
-    });
+    return I18n.t(
+      "discourse_calendar.discourse_post_event.topic_title.ends_in_duration",
+      {
+        duration: this.eventEndedAt.from(moment()),
+      }
+    );
   }
 
   _parsedDate(date) {

--- a/assets/javascripts/discourse/components/modal/post-event-builder.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.hbs
@@ -1,7 +1,7 @@
 <DModal
   @title={{i18n
     (concat
-      "discourse_post_event.builder_modal."
+      "discourse_calendar.discourse_post_event.builder_modal."
       (if @model.event.isNew "create_event_title" "update_event_title")
     )
   }}
@@ -23,41 +23,43 @@
 
         <EventField
           @class="name"
-          @label="discourse_post_event.builder_modal.name.label"
+          @label="discourse_calendar.discourse_post_event.builder_modal.name.label"
         >
           <Input
             @value={{@model.event.name}}
             placeholder={{i18n
-              "discourse_post_event.builder_modal.name.placeholder"
+              "discourse_calendar.discourse_post_event.builder_modal.name.placeholder"
             }}
           />
         </EventField>
 
         <EventField
           @class="url"
-          @label="discourse_post_event.builder_modal.url.label"
+          @label="discourse_calendar.discourse_post_event.builder_modal.url.label"
         >
           <Input
             @value={{@model.event.url}}
             placeholder={{i18n
-              "discourse_post_event.builder_modal.url.placeholder"
+              "discourse_calendar.discourse_post_event.builder_modal.url.placeholder"
             }}
           />
         </EventField>
 
         <EventField
           @class="timezone"
-          @label="discourse_post_event.builder_modal.timezone.label"
+          @label="discourse_calendar.discourse_post_event.builder_modal.timezone.label"
         >
           <TimezoneInput
             @value={{@model.event.timezone}}
             @onChange={{this.setNewTimezone}}
             @class="input-xxlarge"
-            @none="discourse_post_event.builder_modal.timezone.remove_timezone"
+            @none="discourse_calendar.discourse_post_event.builder_modal.timezone.remove_timezone"
           />
         </EventField>
 
-        <EventField @label="discourse_post_event.builder_modal.status.label">
+        <EventField
+          @label="discourse_calendar.discourse_post_event.builder_modal.status.label"
+        >
           <label class="radio-label">
             <RadioButton
               @name="status"
@@ -67,11 +69,13 @@
             />
             <span class="message">
               <span class="title">
-                {{i18n "discourse_post_event.models.event.status.public.title"}}
+                {{i18n
+                  "discourse_calendar.discourse_post_event.models.event.status.public.title"
+                }}
               </span>
               <span class="description">
                 {{i18n
-                  "discourse_post_event.models.event.status.public.description"
+                  "discourse_calendar.discourse_post_event.models.event.status.public.description"
                 }}
               </span>
             </span>
@@ -86,12 +90,12 @@
             <span class="message">
               <span class="title">
                 {{i18n
-                  "discourse_post_event.models.event.status.private.title"
+                  "discourse_calendar.discourse_post_event.models.event.status.private.title"
                 }}
               </span>
               <span class="description">
                 {{i18n
-                  "discourse_post_event.models.event.status.private.description"
+                  "discourse_calendar.discourse_post_event.models.event.status.private.description"
                 }}
               </span>
             </span>
@@ -106,12 +110,12 @@
             <span class="message">
               <span class="title">
                 {{i18n
-                  "discourse_post_event.models.event.status.standalone.title"
+                  "discourse_calendar.discourse_post_event.models.event.status.standalone.title"
                 }}
               </span>
               <span class="description">
                 {{i18n
-                  "discourse_post_event.models.event.status.standalone.description"
+                  "discourse_calendar.discourse_post_event.models.event.status.standalone.description"
                 }}
               </span>
             </span>
@@ -120,7 +124,7 @@
 
         <EventField
           @enabled={{eq @model.event.status "private"}}
-          @label="discourse_post_event.builder_modal.invitees.label"
+          @label="discourse_calendar.discourse_post_event.builder_modal.invitees.label"
         >
           <GroupSelector
             @fullWidthWrap={{true}}
@@ -133,7 +137,7 @@
 
         <EventField
           @class="reminders"
-          @label="discourse_post_event.builder_modal.reminders.label"
+          @label="discourse_calendar.discourse_post_event.builder_modal.reminders.label"
         >
           <div class="reminders-list">
             {{#each @model.event.reminders as |reminder|}}
@@ -151,7 +155,7 @@
                   min={{0}}
                   @value={{reminder.value}}
                   placeholder={{i18n
-                    "discourse_post_event.builder_modal.name.placeholder"
+                    "discourse_calendar.discourse_post_event.builder_modal.name.placeholder"
                   }}
                 />
 
@@ -185,34 +189,34 @@
             class="add-reminder"
             @disabled={{this.addReminderDisabled}}
             @icon="plus"
-            @label="discourse_post_event.builder_modal.add_reminder"
+            @label="discourse_calendar.discourse_post_event.builder_modal.add_reminder"
             @action={{@model.addReminder}}
           />
         </EventField>
 
         <EventField
           @class="recurrence"
-          @label="discourse_post_event.builder_modal.recurrence.label"
+          @label="discourse_calendar.discourse_post_event.builder_modal.recurrence.label"
         >
           <ComboBox
             @class="available-recurrences"
             @value={{@model.event.recurrence}}
             @content={{this.availableRecurrences}}
             @options={{hash
-              none="discourse_post_event.builder_modal.recurrence.none"
+              none="discourse_calendar.discourse_post_event.builder_modal.recurrence.none"
             }}
           />
         </EventField>
 
         <EventField
           @class="minimal-event"
-          @label="discourse_post_event.builder_modal.minimal.label"
+          @label="discourse_calendar.discourse_post_event.builder_modal.minimal.label"
         >
           <label class="checkbox-label">
             <Input @type="checkbox" @checked={{@model.event.minimal}} />
             <span class="message">
               {{i18n
-                "discourse_post_event.builder_modal.minimal.checkbox_label"
+                "discourse_calendar.discourse_post_event.builder_modal.minimal.checkbox_label"
               }}
             </span>
           </label>
@@ -220,11 +224,11 @@
 
         {{#if this.allowedCustomFields.length}}
           <EventField
-            @label="discourse_post_event.builder_modal.custom_fields.label"
+            @label="discourse_calendar.discourse_post_event.builder_modal.custom_fields.label"
           >
             <p class="event-field-description">
               {{i18n
-                "discourse_post_event.builder_modal.custom_fields.description"
+                "discourse_calendar.discourse_post_event.builder_modal.custom_fields.description"
               }}
             </p>
             {{#each this.allowedCustomFields as |allowedCustomField|}}
@@ -237,7 +241,7 @@
                   (get @model.event.custom_fields allowedCustomField)
                 }}
                 placeholder={{i18n
-                  "discourse_post_event.builder_modal.custom_fields.placeholder"
+                  "discourse_calendar.discourse_post_event.builder_modal.custom_fields.placeholder"
                 }}
                 {{on "input" (fn this.setCustomField allowedCustomField)}}
               />
@@ -252,7 +256,7 @@
       <DButton
         @type="button"
         class="btn-primary"
-        @label="discourse_post_event.builder_modal.create"
+        @label="discourse_calendar.discourse_post_event.builder_modal.create"
         @icon="calendar-day"
         @action={{this.createEvent}}
       />
@@ -260,7 +264,7 @@
       <DButton
         @type="button"
         class="btn-primary"
-        @label="discourse_post_event.builder_modal.update"
+        @label="discourse_calendar.discourse_post_event.builder_modal.update"
         @icon="calendar-day"
         @action={{this.updateEvent}}
       />

--- a/assets/javascripts/discourse/components/modal/post-event-bulk-invite.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-bulk-invite.hbs
@@ -1,6 +1,8 @@
 <DModal
   @closeModal={{@closeModal}}
-  @title={{i18n "discourse_post_event.bulk_invite_modal.title"}}
+  @title={{i18n
+    "discourse_calendar.discourse_post_event.bulk_invite_modal.title"
+  }}
   class="post-event-bulk-invite"
   @flash={{this.flash}}
 >
@@ -9,12 +11,14 @@
       <p class="bulk-event-help">
         {{i18n
           (concat
-            "discourse_post_event.bulk_invite_modal.description_"
+            "discourse_calendar.discourse_post_event.bulk_invite_modal.description_"
             @model.event.status
           )
         }}
       </p>
-      <h3>{{i18n "discourse_post_event.bulk_invite_modal.inline_title"}}</h3>
+      <h3>{{i18n
+          "discourse_calendar.discourse_post_event.bulk_invite_modal.inline_title"
+        }}</h3>
 
       <div class="bulk-invite-rows">
         {{#each this.bulkInvites as |bulkInvite|}}
@@ -25,7 +29,7 @@
                 @single={{true}}
                 @groupFinder={{this.groupFinder}}
                 @groupNames={{bulkInvite.identifier}}
-                @placeholderKey="discourse_post_event.bulk_invite_modal.group_selector_placeholder"
+                @placeholderKey="discourse_calendar.discourse_post_event.bulk_invite_modal.group_selector_placeholder"
                 @onChangeCallback={{fn
                   this.updateBulkGroupInviteIdentifier
                   bulkInvite
@@ -39,7 +43,7 @@
                 @onChange={{fn this.updateInviteIdentifier bulkInvite}}
                 @options={{hash
                   maximum=1
-                  filterPlaceholder="discourse_post_event.bulk_invite_modal.user_selector_placeholder"
+                  filterPlaceholder="discourse_calendar.discourse_post_event.bulk_invite_modal.user_selector_placeholder"
                 }}
               />
             {{/if}}
@@ -65,7 +69,7 @@
       <div class="bulk-invite-actions">
         <DButton
           class="send-bulk-invites btn-primary"
-          @label="discourse_post_event.bulk_invite_modal.send_bulk_invites"
+          @label="discourse_calendar.discourse_post_event.bulk_invite_modal.send_bulk_invites"
           @action={{this.sendBulkInvites}}
           @disabled={{this.bulkInviteDisabled}}
         />
@@ -78,7 +82,9 @@
     </div>
 
     <div class="csv-bulk-invites">
-      <h3>{{i18n "discourse_post_event.bulk_invite_modal.csv_title"}}</h3>
+      <h3>{{i18n
+          "discourse_calendar.discourse_post_event.bulk_invite_modal.csv_title"
+        }}</h3>
 
       <div class="bulk-invite-actions">
         <BulkInviteSampleCsvFile />
@@ -90,7 +96,7 @@
             @model.event.id
             "/csv-bulk-invite"
           }}
-          @i18nPrefix="discourse_post_event.bulk_invite_modal"
+          @i18nPrefix="discourse_calendar.discourse_post_event.bulk_invite_modal"
           @uploadDone={{this.uploadDone}}
         />
       </div>

--- a/assets/javascripts/discourse/components/modal/post-event-bulk-invite.js
+++ b/assets/javascripts/discourse/components/modal/post-event-bulk-invite.js
@@ -22,19 +22,27 @@ export default class PostEventBulkInvite extends Component {
   get bulkInviteStatuses() {
     return [
       {
-        label: I18n.t("discourse_post_event.models.invitee.status.unknown"),
+        label: I18n.t(
+          "discourse_calendar.discourse_post_event.models.invitee.status.unknown"
+        ),
         name: "unknown",
       },
       {
-        label: I18n.t("discourse_post_event.models.invitee.status.going"),
+        label: I18n.t(
+          "discourse_calendar.discourse_post_event.models.invitee.status.going"
+        ),
         name: "going",
       },
       {
-        label: I18n.t("discourse_post_event.models.invitee.status.not_going"),
+        label: I18n.t(
+          "discourse_calendar.discourse_post_event.models.invitee.status.not_going"
+        ),
         name: "not_going",
       },
       {
-        label: I18n.t("discourse_post_event.models.invitee.status.interested"),
+        label: I18n.t(
+          "discourse_calendar.discourse_post_event.models.invitee.status.interested"
+        ),
         name: "interested",
       },
     ];
@@ -97,7 +105,9 @@ export default class PostEventBulkInvite extends Component {
   @action
   async uploadDone() {
     await this.dialog.alert(
-      I18n.t("discourse_post_event.bulk_invite_modal.success")
+      I18n.t(
+        "discourse_calendar.discourse_post_event.bulk_invite_modal.success"
+      )
     );
     this.args.closeModal();
   }

--- a/assets/javascripts/discourse/components/modal/post-event-invite-user-or-group.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-invite-user-or-group.hbs
@@ -1,5 +1,7 @@
 <DModal
-  @title={{i18n "discourse_post_event.invite_user_or_group.title"}}
+  @title={{i18n
+    "discourse_calendar.discourse_post_event.invite_user_or_group.title"
+  }}
   @closeModal={{@closeModal}}
   @flash={{this.flash}}
 >
@@ -22,7 +24,7 @@
     <DButton
       @type="button"
       class="btn-primary"
-      @label="discourse_post_event.invite_user_or_group.invite"
+      @label="discourse_calendar.discourse_post_event.invite_user_or_group.invite"
       @action={{this.invite}}
     />
   </:footer>

--- a/assets/javascripts/discourse/components/modal/post-event-invitees.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-invitees.hbs
@@ -12,7 +12,7 @@
       {{on "input" this.onFilterChanged}}
       class="filter"
       placeholder={{i18n
-        "discourse_post_event.invitees_modal.filter_placeholder"
+        "discourse_calendar.discourse_post_event.invitees_modal.filter_placeholder"
       }}
     />
     <ToggleInvitees @viewType={{this.type}} @toggle={{this.toggleType}} />
@@ -33,7 +33,9 @@
         </ul>
       {{else}}
         <p class="no-users">
-          {{i18n "discourse_post_event.models.invitee.no_users"}}
+          {{i18n
+            "discourse_calendar.discourse_post_event.models.invitee.no_users"
+          }}
         </p>
       {{/if}}
     </ConditionalLoadingSpinner>

--- a/assets/javascripts/discourse/components/modal/post-event-invitees.js
+++ b/assets/javascripts/discourse/components/modal/post-event-invitees.js
@@ -20,7 +20,7 @@ export default class PostEventInvitees extends Component {
 
   get title() {
     return I18n.t(
-      `discourse_post_event.invitees_modal.${
+      `discourse_calendar.discourse_post_event.invitees_modal.${
         this.args.model.title || "title_invited"
       }`
     );

--- a/assets/javascripts/discourse/components/toggle-invitees.hbs
+++ b/assets/javascripts/discourse/components/toggle-invitees.hbs
@@ -1,6 +1,6 @@
 <div class="invitees-type-filter">
   <DButton
-    @label="discourse_post_event.models.invitee.status.going"
+    @label="discourse_calendar.discourse_post_event.models.invitee.status.going"
     class={{concat-class
       "btn toggle-going"
       (if (eq @viewType "going") "btn-danger" "btn-default")
@@ -9,7 +9,7 @@
   />
 
   <DButton
-    @label="discourse_post_event.models.invitee.status.interested"
+    @label="discourse_calendar.discourse_post_event.models.invitee.status.interested"
     class={{concat-class
       "btn toggle-interested"
       (if (eq @viewType "interested") "btn-danger" "btn-default")
@@ -18,7 +18,7 @@
   />
 
   <DButton
-    @label="discourse_post_event.models.invitee.status.not_going"
+    @label="discourse_calendar.discourse_post_event.models.invitee.status.not_going"
     class={{concat-class
       "btn toggle-not-going"
       (if (eq @viewType "not_going") "btn-danger" "btn-default")

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -26,10 +26,18 @@ export default class UpcomingEventsList extends Component {
   dateFormat = this.args.params?.dateFormat ?? DEFAULT_DATE_FORMAT;
   timeFormat = this.args.params?.timeFormat ?? DEFAULT_TIME_FORMAT;
 
-  title = I18n.t("discourse_post_event.upcoming_events_list.title");
-  emptyMessage = I18n.t("discourse_post_event.upcoming_events_list.empty");
-  allDayLabel = I18n.t("discourse_post_event.upcoming_events_list.all_day");
-  errorMessage = I18n.t("discourse_post_event.upcoming_events_list.error");
+  title = I18n.t(
+    "discourse_calendar.discourse_post_event.upcoming_events_list.title"
+  );
+  emptyMessage = I18n.t(
+    "discourse_calendar.discourse_post_event.upcoming_events_list.empty"
+  );
+  allDayLabel = I18n.t(
+    "discourse_calendar.discourse_post_event.upcoming_events_list.all_day"
+  );
+  errorMessage = I18n.t(
+    "discourse_calendar.discourse_post_event.upcoming_events_list.error"
+  );
 
   constructor() {
     super(...arguments);
@@ -135,7 +143,7 @@ export default class UpcomingEventsList extends Component {
             </div>
             <DButton
               @action={{this.updateEventsByMonth}}
-              @label="discourse_post_event.upcoming_events_list.try_again"
+              @label="discourse_calendar.discourse_post_event.upcoming_events_list.try_again"
               class="btn-link upcoming-events-list__try-again"
             />
           {{/if}}

--- a/assets/javascripts/discourse/initializers/add-event-ui-builder.js
+++ b/assets/javascripts/discourse/initializers/add-event-ui-builder.js
@@ -44,7 +44,7 @@ function initializeEventBuilder(api) {
     },
     group: "insertions",
     icon: "calendar-day",
-    label: "discourse_post_event.builder_modal.attach",
+    label: "discourse_calendar.discourse_post_event.builder_modal.attach",
     condition: (composer) => {
       if (!currentUser || !currentUser.can_create_discourse_post_event) {
         return false;

--- a/assets/javascripts/discourse/initializers/add-hamburger-menu-action.js
+++ b/assets/javascripts/discourse/initializers/add-hamburger-menu-action.js
@@ -5,7 +5,7 @@ function initializeHamburgerMenu(api) {
     return {
       icon: "calendar-day",
       route: "discourse-post-event-upcoming-events",
-      label: "discourse_post_event.upcoming_events.title",
+      label: "discourse_calendar.discourse_post_event.upcoming_events.title",
     };
   });
 }

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -286,7 +286,7 @@ function initializeDiscourseCalendar(api) {
           get label() {
             if (
               this.notification.data.message ===
-              "discourse_post_event.notifications.invite_user_predefined_attendance_notification"
+              "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification"
             ) {
               return I18n.t(this.notification.data.message, {
                 username: this.username,

--- a/assets/javascripts/discourse/initializers/discourse-post-event-decorator.js
+++ b/assets/javascripts/discourse/initializers/discourse-post-event-decorator.js
@@ -16,7 +16,7 @@ function _validEventPreview(eventContainer) {
   eventContainer.innerHTML = "";
   eventContainer.classList.add("discourse-post-event-preview");
 
-  const statusLocaleKey = `discourse_post_event.models.event.status.${
+  const statusLocaleKey = `discourse_calendar.discourse_post_event.models.event.status.${
     eventContainer.dataset.status || "public"
   }.title`;
   if (I18n.lookup(statusLocaleKey, { locale: "en" })) {
@@ -64,7 +64,7 @@ function _invalidEventPreview(eventContainer) {
   );
   eventContainer.classList.remove("discourse-post-event");
   eventContainer.innerText = I18n.t(
-    "discourse_post_event.preview.more_than_one_event"
+    "discourse_calendar.discourse_post_event.preview.more_than_one_event"
   );
 }
 

--- a/assets/javascripts/discourse/lib/event-relative-date.js
+++ b/assets/javascripts/discourse/lib/event-relative-date.js
@@ -8,9 +8,12 @@ function _computeCurrentEvent(container, endsAt) {
 
   const text = document.createElement("span");
   text.classList.add("text");
-  text.innerText = I18n.t("discourse_post_event.topic_title.ends_in_duration", {
-    duration: endsAt.from(moment()),
-  });
+  text.innerText = I18n.t(
+    "discourse_calendar.discourse_post_event.topic_title.ends_in_duration",
+    {
+      duration: endsAt.from(moment()),
+    }
+  );
   container.appendChild(text);
 }
 

--- a/assets/javascripts/discourse/widgets/discourse-post-event-dates.js
+++ b/assets/javascripts/discourse/widgets/discourse-post-event-dates.js
@@ -26,9 +26,12 @@ export default createWidget("discourse-post-event-dates", {
       attrs.eventModel.status !== "standalone"
     ) {
       let participants;
-      const label = I18n.t("discourse_post_event.event_ui.participants", {
-        count: attrs.eventModel.stats.going,
-      });
+      const label = I18n.t(
+        "discourse_calendar.discourse_post_event.event_ui.participants",
+        {
+          count: attrs.eventModel.stats.going,
+        }
+      );
       if (attrs.eventModel.stats.going > 0) {
         participants = this.attach("link", {
           action: "showAllParticipatingInvitees",

--- a/assets/javascripts/discourse/widgets/discourse-post-event-invitee.js
+++ b/assets/javascripts/discourse/widgets/discourse-post-event-invitee.js
@@ -52,7 +52,7 @@ export default createWidget("discourse-post-event-invitee", {
       avatarContent.push(
         this.attach("avatar-flair", {
           flair_name: I18n.t(
-            `discourse_post_event.models.invitee.status.${attrs.invitee.status}`
+            `discourse_calendar.discourse_post_event.models.invitee.status.${attrs.invitee.status}`
           ),
           flair_url: statusIcon,
         })

--- a/assets/javascripts/discourse/widgets/discourse-post-event-invitees.js
+++ b/assets/javascripts/discourse/widgets/discourse-post-event-invitees.js
@@ -13,9 +13,9 @@ export default createWidget("discourse-post-event-invitees", {
   template: hbs`
     <div class="header">
       <div class="event-invitees-status">
-        <span>{{attrs.eventModel.stats.going}} {{i18n "discourse_post_event.models.invitee.status.going"}} -</span>
-        <span>{{attrs.eventModel.stats.interested}} {{i18n "discourse_post_event.models.invitee.status.interested"}} -</span>
-        <span>{{attrs.eventModel.stats.not_going}} {{i18n "discourse_post_event.models.invitee.status.not_going"}}</span>
+        <span>{{attrs.eventModel.stats.going}} {{i18n "discourse_calendar.discourse_post_event.models.invitee.status.going"}} -</span>
+        <span>{{attrs.eventModel.stats.interested}} {{i18n "discourse_calendar.discourse_post_event.models.invitee.status.interested"}} -</span>
+        <span>{{attrs.eventModel.stats.not_going}} {{i18n "discourse_calendar.discourse_post_event.models.invitee.status.not_going"}}</span>
         {{#if transformed.isPrivateEvent}}
           <span class="invited">- on {{attrs.eventModel.stats.invited}} users invited</span>
         {{/if}}
@@ -25,7 +25,7 @@ export default createWidget("discourse-post-event-invitees", {
         widget="button"
         attrs=(hash
           className="show-all btn-small"
-          label="discourse_post_event.event_ui.show_all"
+          label="discourse_calendar.discourse_post_event.event_ui.show_all"
           action="showAllInvitees"
           actionParam=(hash postId=attrs.eventModel.id)
         )

--- a/assets/javascripts/discourse/widgets/discourse-post-event.js
+++ b/assets/javascripts/discourse/widgets/discourse-post-event.js
@@ -76,7 +76,9 @@ export default createWidget("discourse-post-event", {
 
   closeEvent(eventModel) {
     this.dialog.yesNoConfirm({
-      message: I18n.t("discourse_post_event.builder_modal.confirm_close"),
+      message: I18n.t(
+        "discourse_calendar.discourse_post_event.builder_modal.confirm_close"
+      ),
       didConfirm: () => {
         return this.store.find("post", eventModel.id).then((post) => {
           const raw = post.raw;
@@ -94,7 +96,9 @@ export default createWidget("discourse-post-event", {
           if (newRaw) {
             const props = {
               raw: newRaw,
-              edit_reason: I18n.t("discourse_post_event.edit_reason"),
+              edit_reason: I18n.t(
+                "discourse_calendar.discourse_post_event.edit_reason"
+              ),
             };
 
             return cook(newRaw).then((cooked) => {
@@ -205,10 +209,10 @@ export default createWidget("discourse-post-event", {
 
     return {
       eventStatusLabel: I18n.t(
-        `discourse_post_event.models.event.status.${eventModel.status}.title`
+        `discourse_calendar.discourse_post_event.models.event.status.${eventModel.status}.title`
       ),
       eventStatusDescription: I18n.t(
-        `discourse_post_event.models.event.status.${eventModel.status}.description`
+        `discourse_calendar.discourse_post_event.models.event.status.${eventModel.status}.description`
       ),
       startsAtMonth: moment(eventModel.starts_at).format("MMM"),
       startsAtDay: moment(eventModel.starts_at).format("D"),
@@ -243,7 +247,7 @@ export default createWidget("discourse-post-event", {
             {{#unless transformed.isStandaloneEvent}}
               {{#if state.eventModel.is_expired}}
                 <span class="status expired">
-                  {{i18n "discourse_post_event.models.event.expired"}}
+                  {{i18n "discourse_calendar.discourse_post_event.models.event.expired"}}
                 </span>
               {{else}}
                 <span class={{transformed.statusClass}} title={{transformed.eventStatusDescription}}>
@@ -253,7 +257,7 @@ export default createWidget("discourse-post-event", {
               <span class="separator">·</span>
             {{/unless}}
             <span class="creators">
-              <span class="created-by">{{i18n "discourse_post_event.event_ui.created_by"}}</span>
+              <span class="created-by">{{i18n "discourse_calendar.discourse_post_event.event_ui.created_by"}}</span>
               {{attach widget="discourse-post-event-creator" attrs=(hash user=state.eventModel.creator)}}
             </span>
           </div>

--- a/assets/javascripts/discourse/widgets/event-invitation-notification-item.js
+++ b/assets/javascripts/discourse/widgets/event-invitation-notification-item.js
@@ -29,7 +29,7 @@ createWidgetFrom(
       let translationKey = data.message;
       if (
         translationKey ===
-        "discourse_post_event.notifications.invite_user_predefined_attendance_notification"
+        "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification"
       ) {
         translationKey += "_html";
       }

--- a/assets/javascripts/discourse/widgets/going-button.js
+++ b/assets/javascripts/discourse/widgets/going-button.js
@@ -11,7 +11,7 @@ export default createWidget("going-button", {
   template: hbs`
     {{d-icon "check"}}
     <span class="label">
-      {{i18n "discourse_post_event.models.invitee.status.going"}}
+      {{i18n "discourse_calendar.discourse_post_event.models.invitee.status.going"}}
     </span>
   `,
 });

--- a/assets/javascripts/discourse/widgets/interested-button.js
+++ b/assets/javascripts/discourse/widgets/interested-button.js
@@ -11,7 +11,7 @@ export default createWidget("interested-button", {
   template: hbs`
     {{d-icon "star"}}
     <span class="label">
-      {{i18n "discourse_post_event.models.invitee.status.interested"}}
+      {{i18n "discourse_calendar.discourse_post_event.models.invitee.status.interested"}}
     </span>
   `,
 });

--- a/assets/javascripts/discourse/widgets/more-dropdown.js
+++ b/assets/javascripts/discourse/widgets/more-dropdown.js
@@ -43,7 +43,8 @@ export default createWidget("more-dropdown", {
       content.push({
         id: "addToCalendar",
         icon: "file",
-        label: "discourse_post_event.event_ui.add_to_calendar",
+        label:
+          "discourse_calendar.discourse_post_event.event_ui.add_to_calendar",
       });
     }
 
@@ -52,7 +53,7 @@ export default createWidget("more-dropdown", {
         id: "sendPMToCreator",
         icon: "envelope",
         translatedLabel: I18n.t(
-          "discourse_post_event.event_ui.send_pm_to_creator",
+          "discourse_calendar.discourse_post_event.event_ui.send_pm_to_creator",
           { username: attrs.eventModel.creator.username }
         ),
       });
@@ -62,7 +63,7 @@ export default createWidget("more-dropdown", {
       content.push({
         id: "inviteUserOrGroup",
         icon: "user-plus",
-        label: "discourse_post_event.event_ui.invite",
+        label: "discourse_calendar.discourse_post_event.event_ui.invite",
         param: attrs.eventModel.id,
       });
     }
@@ -71,7 +72,7 @@ export default createWidget("more-dropdown", {
       content.push({
         id: "leaveEvent",
         icon: "times",
-        label: "discourse_post_event.event_ui.leave",
+        label: "discourse_calendar.discourse_post_event.event_ui.leave",
         param: attrs.eventModel.id,
       });
     }
@@ -90,7 +91,7 @@ export default createWidget("more-dropdown", {
       content.push({
         icon: "file-csv",
         id: "exportPostEvent",
-        label: "discourse_post_event.event_ui.export_event",
+        label: "discourse_calendar.discourse_post_event.event_ui.export_event",
         param: attrs.eventModel.id,
       });
 
@@ -98,7 +99,7 @@ export default createWidget("more-dropdown", {
         content.push({
           icon: "file-upload",
           id: "bulkInvite",
-          label: "discourse_post_event.event_ui.bulk_invite",
+          label: "discourse_calendar.discourse_post_event.event_ui.bulk_invite",
           param: attrs.eventModel,
         });
       }
@@ -106,7 +107,7 @@ export default createWidget("more-dropdown", {
       content.push({
         icon: "pencil-alt",
         id: "editPostEvent",
-        label: "discourse_post_event.event_ui.edit_event",
+        label: "discourse_calendar.discourse_post_event.event_ui.edit_event",
         param: attrs.eventModel.id,
       });
 
@@ -114,7 +115,7 @@ export default createWidget("more-dropdown", {
         content.push({
           icon: "times",
           id: "closeEvent",
-          label: "discourse_post_event.event_ui.close_event",
+          label: "discourse_calendar.discourse_post_event.event_ui.close_event",
           class: "danger",
           param: attrs.eventModel,
         });

--- a/assets/javascripts/discourse/widgets/not-going-button.js
+++ b/assets/javascripts/discourse/widgets/not-going-button.js
@@ -11,7 +11,7 @@ export default createWidget("not-going-button", {
   template: hbs`
     {{d-icon "times"}}
     <span class="label">
-      {{i18n "discourse_post_event.models.invitee.status.not_going"}}
+      {{i18n "discourse_calendar.discourse_post_event.models.invitee.status.not_going"}}
     </span>
   `,
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -305,6 +305,145 @@ en:
         week: "Week"
         day: "Day"
         list: "List"
+      discourse_post_event:
+        notifications:
+          invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to"
+          before_event_reminder: "An event is about to start"
+          after_event_reminder: "An event has ended"
+          ongoing_event_reminder: "An event is ongoing"
+          # TODO: delete the following keys (until ongoing_event_reminder_html)
+          # when event-invitation and event-reminder notification item widgets
+          # are removed
+          invite_user_notification: "%{username} %{description}"
+          invite_user_predefined_attendance_notification_html: "%{username} has automatically set your attendance and invited you to %{description}"
+          before_event_reminder_html: "An event is about to start %{description}"
+          after_event_reminder_html: "An event has ended %{description}"
+          ongoing_event_reminder_html: "An event is ongoing  %{description}"
+        preview:
+          more_than_one_event: "You can’t have more than one event."
+        edit_reason: "Event updated"
+        topic_title:
+          starts_at: "Event will start: %{date}"
+          ended_at: "Event ended: %{date}"
+          ends_in_duration: "Ends %{duration}"
+        models:
+          invitee:
+            no_users: "There are no users of this type."
+            status:
+              unknown: "Not interested"
+              going: "Going"
+              not_going: "Not Going"
+              interested: "Interested"
+          event:
+            expired: "Expired"
+            status:
+              standalone:
+                title: "Standalone"
+                description: "A standalone event can't be joined."
+              public:
+                title: "Public"
+                description: "A public event can be joined by anyone."
+              private:
+                title: "Private"
+                description: "A private event can only be joined by invited users."
+        event_ui:
+          show_all: "Show all"
+          participants:
+            one: "%{count} user participated."
+            other: "%{count} users participated."
+          invite: "Notify user"
+          add_to_calendar: "Add to calendar"
+          send_pm_to_creator: "Send PM to %{username}"
+          leave: "Leave event"
+          edit_event: "Edit event"
+          export_event: "Export event"
+          created_by: "Created by"
+          bulk_invite: "Bulk Invite"
+          close_event: "Close event"
+        invitees_modal:
+          title_invited: "List of RSVPed users"
+          title_participated: "List of users who participated"
+          filter_placeholder: "Filter users"
+        bulk_invite_modal:
+          confirm: "confirm"
+          text: "Upload CSV file"
+          title: "Bulk Invite"
+          success: "File uploaded successfully, you will be notified via message when the process is complete."
+          error: "Sorry, file should be CSV format."
+          confirmation_message: "You’re about to notify everyone in the uploaded file."
+          description_public: "Public events only accept usernames for bulk invites."
+          description_private: "Private events only accept group names for bulk invites."
+          download_sample_csv: "Download a sample CSV file"
+          send_bulk_invites: "Send invites"
+          group_selector_placeholder: "Choose a group..."
+          user_selector_placeholder: "Choose user..."
+          inline_title: "Inline bulk invite"
+          csv_title: "CSV bulk invite"
+        builder_modal:
+          custom_fields:
+            label: "Custom Fields"
+            placeholder: "Optional"
+            description: "Allowed custom fields are defined in site settings. Custom fields are used to transmit data to other plugins."
+          create_event_title: "Create Event"
+          update_event_title: "Edit Event"
+          confirm_delete: "Are you sure you want to delete this event?"
+          confirm_close: "Are you sure you want to close this event?"
+          create: "Create"
+          update: "Save"
+          attach: "Create event"
+          add_reminder: "Add reminder"
+          timezone:
+            label: Timezone
+            remove_timezone: No timezone (UTC)
+          reminders:
+            label: "Reminders"
+            types:
+              bump_topic: "auto-bump topic"
+              notification: "notify participants"
+            units:
+              minutes: "minutes"
+              hours: "hours"
+              days: "days"
+              weeks: "weeks"
+            periods:
+              before: "before"
+              after: "after"
+          recurrence:
+            label: "Recurrence"
+            none: "No recurrence"
+            every_day: "Every day"
+            every_month: "Every month at this weekday"
+            every_weekday: "Every weekday"
+            every_week: "Every week at this weekday"
+            every_two_weeks: "Every two weeks at this weekday"
+            every_four_weeks: "Every four weeks at this weekday"
+          minimal:
+            label: "Minimal event"
+            checkbox_label: "Hide Going/Not going buttons and invitees status"
+          url:
+            label: "URL"
+            placeholder: "Optional"
+          name:
+            label: "Event name"
+            placeholder: "Optional, defaults to topic title"
+          invitees:
+            label: "Invited groups"
+          status:
+            label: "Status"
+        invite_user_or_group:
+          title: "Notify user(s) or group(s)"
+          invite: "Send"
+        upcoming_events:
+          title: "Upcoming events"
+          creator: "Creator"
+          status: "Status"
+          starts_at: "Starts at"
+        upcoming_events_list:
+          title: "Upcoming events"
+          empty: "No upcoming events"
+          all_day: "All-day"
+          error: "Failed to retrieve events"
+          try_again: "Try again"
     group_timezones:
       search: "Search..."
       group_availability: "%{group} availability"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -64,33 +64,33 @@ en:
     event_expired: "Event expired"
     holiday_status:
       description: "On holiday"
+    discourse_post_event:
+      notifications:
+        before_event_reminder: "%{title} is about to start."
+        after_event_reminder: "%{title} has ended."
+        ongoing_event_reminder: "%{title} is ongoing."
+      errors:
+        bulk_invite:
+          max_invitees: "First %{max_invittes} invitees have been created. Try splitting the file in smaller parts."
+          error: "There was an error uploading that file. Please try again later."
+        models:
+          event:
+            only_one_event: "A post can only have one event."
+            only_group: "An event accepts only group names."
+            must_be_in_first_post: "An event can only be in the first post of a topic."
+            raw_invitees_length: "An event is limited to %{count} users/groups."
+            ends_at_before_starts_at: "An event can't end before it starts."
+            start_must_be_present_and_a_valid_date: "An event requires a valid start date."
+            end_must_be_a_valid_date: "End date must be a valid date."
+            invalid_recurrence: "Recurrence must be one of: every_month, every_week, every_two_weeks, every_four_weeks, every_day, every_weekday."
+            invalid_timezone: "Timezone not recognized."
+            acting_user_not_allowed_to_create_event: "Current user is not allowed to create events."
+            acting_user_not_allowed_to_act_on_this_event: "Current user is not allowed to act on this event."
+            invalid_allowed_groups: "Invalid allowed groups."
+            acting_user_not_allowed_to_invite_these_groups: "Current user is not allowed to invite these groups."
+            custom_field_is_invalid: "The custom field `%{field}` is not allowed."
+            name:
+              length: "Event name length must be between %{minimum} and %{maximum} characters."
   discourse_push_notifications:
     popup:
       event_reminder: "Event Reminder"
-  discourse_post_event:
-    notifications:
-      before_event_reminder: "%{title} is about to start."
-      after_event_reminder: "%{title} has ended."
-      ongoing_event_reminder: "%{title} is ongoing."
-    errors:
-      bulk_invite:
-        max_invitees: "First %{max_invittes} invitees have been created. Try splitting the file in smaller parts."
-        error: "There was an error uploading that file. Please try again later."
-      models:
-        event:
-          only_one_event: "A post can only have one event."
-          only_group: "An event accepts only group names."
-          must_be_in_first_post: "An event can only be in the first post of a topic."
-          raw_invitees_length: "An event is limited to %{count} users/groups."
-          ends_at_before_starts_at: "An event can't end before it starts."
-          start_must_be_present_and_a_valid_date: "An event requires a valid start date."
-          end_must_be_a_valid_date: "End date must be a valid date."
-          invalid_recurrence: "Recurrence must be one of: every_month, every_week, every_two_weeks, every_four_weeks, every_day, every_weekday."
-          invalid_timezone: "Timezone not recognized."
-          acting_user_not_allowed_to_create_event: "Current user is not allowed to create events."
-          acting_user_not_allowed_to_act_on_this_event: "Current user is not allowed to act on this event."
-          invalid_allowed_groups: "Invalid allowed groups."
-          acting_user_not_allowed_to_invite_these_groups: "Current user is not allowed to invite these groups."
-          custom_field_is_invalid: "The custom field `%{field}` is not allowed."
-          name:
-            length: "Event name length must be between %{minimum} and %{maximum} characters."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,8 +59,6 @@ discourse_calendar:
     default: false
     client: true
     hidden: true
-
-discourse_post_event:
   discourse_post_event_enabled:
     default: false
     client: true

--- a/jobs/regular/discourse_post_event/send_reminder.rb
+++ b/jobs/regular/discourse_post_event/send_reminder.rb
@@ -66,7 +66,8 @@ module Jobs
           data: {
             topic_title: event.name || event.post.topic.title,
             display_username: invitee.user.username,
-            message: "discourse_post_event.notifications.#{prefix}_event_reminder",
+            message:
+              "discourse_calendar.discourse_post_event.notifications.#{prefix}_event_reminder",
           }.to_json,
         }
 
@@ -79,7 +80,7 @@ module Jobs
           notification_type: Notification.types[:event_reminder] || Notification.types[:custom],
           excerpt:
             I18n.t(
-              "discourse_post_event.notifications.#{prefix}_event_reminder",
+              "discourse_calendar.discourse_post_event.notifications.#{prefix}_event_reminder",
               title: event.name || event.post.topic.title,
               locale: invitee.user.effective_locale,
             ),

--- a/lib/discourse_post_event/event_validator.rb
+++ b/lib/discourse_post_event/event_validator.rb
@@ -21,14 +21,19 @@ module DiscoursePostEvent
       return false if extracted_events.count == 0
 
       if extracted_events.count > 1
-        @post.errors.add(:base, I18n.t("discourse_post_event.errors.models.event.only_one_event"))
+        @post.errors.add(
+          :base,
+          I18n.t("discourse_calendar.discourse_post_event.errors.models.event.only_one_event"),
+        )
         return false
       end
 
       if !@post.is_first_post?
         @post.errors.add(
           :base,
-          I18n.t("discourse_post_event.errors.models.event.must_be_in_first_post"),
+          I18n.t(
+            "discourse_calendar.discourse_post_event.errors.models.event.must_be_in_first_post",
+          ),
         )
         return false
       end
@@ -42,7 +47,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_post_event.errors.models.event.acting_user_not_allowed_to_act_on_this_event",
+              "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_act_on_this_event",
             ),
           )
           return false
@@ -52,7 +57,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
+              "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
             ),
           )
           return false
@@ -69,7 +74,9 @@ module DiscoursePostEvent
            ).nil?
         @post.errors.add(
           :base,
-          I18n.t("discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date"),
+          I18n.t(
+            "discourse_calendar.discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date",
+          ),
         )
         return false
       end
@@ -84,7 +91,9 @@ module DiscoursePostEvent
            ).nil?
         @post.errors.add(
           :base,
-          I18n.t("discourse_post_event.errors.models.event.end_must_be_a_valid_date"),
+          I18n.t(
+            "discourse_calendar.discourse_post_event.errors.models.event.end_must_be_a_valid_date",
+          ),
         )
         return false
       end
@@ -93,7 +102,9 @@ module DiscoursePostEvent
         if Time.parse(extracted_event[:start]) > Time.parse(extracted_event[:end])
           @post.errors.add(
             :base,
-            I18n.t("discourse_post_event.errors.models.event.ends_at_before_starts_at"),
+            I18n.t(
+              "discourse_calendar.discourse_post_event.errors.models.event.ends_at_before_starts_at",
+            ),
           )
           return false
         end
@@ -104,7 +115,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_post_event.errors.models.event.name.length",
+              "discourse_calendar.discourse_post_event.errors.models.event.name.length",
               minimum: Event::MIN_NAME_LENGTH,
               maximum: Event::MAX_NAME_LENGTH,
             ),
@@ -117,7 +128,9 @@ module DiscoursePostEvent
         if !VALID_RECURRENCES.include?(extracted_event[:recurrence].to_s)
           @post.errors.add(
             :base,
-            I18n.t("discourse_post_event.errors.models.event.invalid_recurrence"),
+            I18n.t(
+              "discourse_calendar.discourse_post_event.errors.models.event.invalid_recurrence",
+            ),
           )
         end
       end
@@ -127,7 +140,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_post_event.errors.models.event.invalid_timezone",
+              "discourse_calendar.discourse_post_event.errors.models.event.invalid_timezone",
               timezone: extracted_event[:timezone],
             ),
           )
@@ -156,7 +169,9 @@ module DiscoursePostEvent
           if !group || !guardian.can_see_group?(group)
             @post.errors.add(
               :base,
-              I18n.t("discourse_post_event.errors.models.event.invalid_allowed_groups"),
+              I18n.t(
+                "discourse_calendar.discourse_post_event.errors.models.event.invalid_allowed_groups",
+              ),
             )
             return false
           end
@@ -165,7 +180,7 @@ module DiscoursePostEvent
             @post.errors.add(
               :base,
               I18n.t(
-                "discourse_post_event.errors.models.event.acting_user_not_allowed_to_invite_these_groups",
+                "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_invite_these_groups",
               ),
             )
             return false

--- a/spec/integration/post_spec.rb
+++ b/spec/integration/post_spec.rb
@@ -343,7 +343,7 @@ describe Post do
             end.to(
               raise_error(ActiveRecord::RecordNotSaved).with_message(
                 I18n.t(
-                  "discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
+                  "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
                 ),
               ),
             )
@@ -363,7 +363,7 @@ describe Post do
             end.to(
               raise_error(ActiveRecord::RecordNotSaved).with_message(
                 I18n.t(
-                  "discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date",
+                  "discourse_calendar.discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date",
                 ),
               ),
             )
@@ -373,7 +373,9 @@ describe Post do
         context "when recurrence is invalid" do
           it "raises an error" do
             expect { create_post_with_event(user, 'recurrence="foo"') }.to raise_error(
-              I18n.t("discourse_post_event.errors.models.event.invalid_recurrence"),
+              I18n.t(
+                "discourse_calendar.discourse_post_event.errors.models.event.invalid_recurrence",
+              ),
             )
           end
         end
@@ -399,7 +401,9 @@ describe Post do
               )
             end.to(
               raise_error(ActiveRecord::RecordNotSaved).with_message(
-                I18n.t("discourse_post_event.errors.models.event.end_must_be_a_valid_date"),
+                I18n.t(
+                  "discourse_calendar.discourse_post_event.errors.models.event.end_must_be_a_valid_date",
+                ),
               ),
             )
           end
@@ -416,7 +420,7 @@ describe Post do
                 [/event]
               TXT
             raise_error(ActiveRecord::RecordNotSaved).with_message(
-              I18n.t("discourse_post_event.errors.models.event.only_one_event"),
+              I18n.t("discourse_calendar.discourse_post_event.errors.models.event.only_one_event"),
             ),
           )
         end
@@ -776,7 +780,9 @@ describe Post do
           title: "Beach party",
           raw: "[event start='2022-07-24 14:01' timezone='Westeros/Winterfell']\n[/event]",
         )
-      }.to raise_error(I18n.t("discourse_post_event.errors.models.event.invalid_timezone"))
+      }.to raise_error(
+        I18n.t("discourse_calendar.discourse_post_event.errors.models.event.invalid_timezone"),
+      )
     end
 
     it "handles simple weekly recurrence correctly" do

--- a/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
+++ b/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
@@ -249,7 +249,8 @@ describe Jobs::DiscoursePostEventSendReminder do
             data: {
               topic_title: event_1.name || post_1.topic.title,
               display_username: going_user.username,
-              message: "discourse_post_event.notifications.before_event_reminder",
+              message:
+                "discourse_calendar.discourse_post_event.notifications.before_event_reminder",
             }.to_json,
           )
 
@@ -264,8 +265,8 @@ describe Jobs::DiscoursePostEventSendReminder do
             ).pluck("data::json ->> 'message'")
 
           expect(messages).to contain_exactly(
-            "discourse_post_event.notifications.before_event_reminder",
-            "discourse_post_event.notifications.ongoing_event_reminder",
+            "discourse_calendar.discourse_post_event.notifications.before_event_reminder",
+            "discourse_calendar.discourse_post_event.notifications.ongoing_event_reminder",
           )
         end
 

--- a/test/javascripts/acceptance/notifications-test.js
+++ b/test/javascripts/acceptance/notifications-test.js
@@ -26,7 +26,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Monthly Hangout #3",
               display_username: "fun-haver",
               message:
-                "discourse_post_event.notifications.before_event_reminder",
+                "discourse_calendar.discourse_post_event.notifications.before_event_reminder",
             },
           },
           {
@@ -44,7 +44,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Fancy title and pants",
               display_username: "fancy-pants-wearer",
               message:
-                "discourse_post_event.notifications.ongoing_event_reminder",
+                "discourse_calendar.discourse_post_event.notifications.ongoing_event_reminder",
             },
           },
           {
@@ -62,7 +62,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Topic with event and after_event reminder",
               display_username: "attender-no193",
               message:
-                "discourse_post_event.notifications.after_event_reminder",
+                "discourse_calendar.discourse_post_event.notifications.after_event_reminder",
             },
           },
           {
@@ -80,7 +80,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Tuesdays are for Among Us",
               display_username: "imposter",
               message:
-                "discourse_post_event.notifications.invite_user_notification",
+                "discourse_calendar.discourse_post_event.notifications.invite_user_notification",
             },
           },
           {
@@ -98,7 +98,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Asia Pacific team call",
               display_username: "apacer",
               message:
-                "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
+                "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification",
             },
           },
         ],
@@ -118,7 +118,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[0].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_post_event.notifications.before_event_reminder"
+        "discourse_calendar.discourse_post_event.notifications.before_event_reminder"
       )} Monthly Hangout #3`,
       "before event reminder notification has the right content"
     );
@@ -133,7 +133,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_post_event.notifications.ongoing_event_reminder"
+        "discourse_calendar.discourse_post_event.notifications.ongoing_event_reminder"
       )} Fancy title and pants`,
       "ongoing event reminder notification has the right content"
     );
@@ -148,7 +148,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_post_event.notifications.after_event_reminder"
+        "discourse_calendar.discourse_post_event.notifications.after_event_reminder"
       )} Topic with event and after_event reminder`,
       "after event reminder notification has the right content"
     );
@@ -178,7 +178,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[4].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
+        "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification",
         { username: "apacer" }
       )} Asia Pacific team call`,
       "event invitation with predefined attendance notification has the right content"

--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -24,7 +24,7 @@ acceptance("Post event - composer", function (needs) {
     await click(".toolbar-popup-menu-options .dropdown-select-box-header");
     await click(
       `.toolbar-popup-menu-options *[data-name='${I18n.t(
-        "discourse_post_event.builder_modal.attach"
+        "discourse_calendar.discourse_post_event.builder_modal.attach"
       )}']`
     );
 
@@ -94,7 +94,7 @@ acceptance("Post event - composer", function (needs) {
       await click(".toolbar-popup-menu-options .dropdown-select-box-header");
       await click(
         `.toolbar-popup-menu-options *[data-name='${I18n.t(
-          "discourse_post_event.builder_modal.attach"
+          "discourse_calendar.discourse_post_event.builder_modal.attach"
         )}']`
       );
 

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -56,7 +56,9 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t("discourse_post_event.upcoming_events_list.title"),
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
+      ),
       "it displays the title"
     );
 
@@ -64,7 +66,9 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__empty-message").innerText,
-      I18n.t("discourse_post_event.upcoming_events_list.empty"),
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.empty"
+      ),
       "it displays the empty list message"
     );
   });
@@ -78,7 +82,9 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t("discourse_post_event.upcoming_events_list.title"),
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
+      ),
       "it displays the title"
     );
 
@@ -111,7 +117,9 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
         (el) => el.innerText
       ),
       [
-        I18n.t("discourse_post_event.upcoming_events_list.all_day"),
+        I18n.t(
+          "discourse_calendar.discourse_post_event.upcoming_events_list.all_day"
+        ),
         moment(nextMonth).format(DEFAULT_TIME_FORMAT),
       ],
       "it displays the formatted time"
@@ -139,7 +147,9 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t("discourse_post_event.upcoming_events_list.title"),
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
+      ),
       "it displays the title"
     );
 
@@ -163,7 +173,9 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
         (el) => el.innerText
       ),
       [
-        I18n.t("discourse_post_event.upcoming_events_list.all_day"),
+        I18n.t(
+          "discourse_calendar.discourse_post_event.upcoming_events_list.all_day"
+        ),
         moment(nextMonth).format("LLL"),
       ],
       "it displays the formatted time"
@@ -189,7 +201,9 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t("discourse_post_event.upcoming_events_list.title"),
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
+      ),
       "it displays the title"
     );
 
@@ -197,13 +211,17 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__error-message").innerText,
-      I18n.t("discourse_post_event.upcoming_events_list.error"),
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.error"
+      ),
       "it displays the error message"
     );
 
     assert.strictEqual(
       query(".upcoming-events-list__try-again").innerText,
-      I18n.t("discourse_post_event.upcoming_events_list.try_again"),
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.try_again"
+      ),
       "it displays the try again button"
     );
   });


### PR DESCRIPTION
Before, site settings were divided into `discourse calendar` and `discourse events`.

This PR is merging them. Also, translation were moved under `discourse_calendar` key.