### PR TITLE
DEV: optional include_details param for events' list

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -5,10 +5,13 @@ module DiscoursePostEvent
     def index
       @events = DiscoursePostEvent::EventFinder.search(current_user, filtered_events_params)
 
+      # The detailed serializer is currently not used anywhere in the frontend, but available via API
+      serializer = params[:include_details] == "true" ? EventSerializer : EventSummarySerializer
+
       render json:
                ActiveModel::ArraySerializer.new(
                  @events,
-                 each_serializer: EventSummarySerializer,
+                 each_serializer: serializer,
                  scope: guardian,
                ).as_json
     end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -247,6 +247,26 @@ module DiscoursePostEvent
               [hash_including("id" => event_1.id), hash_including("id" => event_2.id)],
             )
           end
+
+          it "includes events' details when param provided" do
+            get "/discourse-post-event/events.json?category_id=#{category.id}&include_subcategories=true&include_details=true"
+
+            expect(response.status).to eq(200)
+            events = response.parsed_body["events"]
+            expect(events.length).to eq(2)
+            expect(events[0].keys).to include(
+              "creator",
+              "sample_invitees",
+              "watching_invitee",
+              "stats",
+              "status",
+              "can_update_attendance",
+              "should_display_invitees",
+              "is_public",
+              "is_private",
+              "is_standalone",
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Optional query param to support the detailed serializer that we replaced in https://github.com/discourse/discourse-calendar/pull/484