### PR TITLE
Show topic title suffix even when missing an ending

### DIFF
--- a/assets/javascripts/discourse/components/event-date.gjs
+++ b/assets/javascripts/discourse/components/event-date.gjs
@@ -40,8 +40,7 @@ export default class EventDate extends Component {
   get shouldRender() {
     return (
       this.siteSettings.discourse_post_event_enabled &&
-      this.args.topic.event_starts_at &&
-      this.args.topic.event_ends_at
+      this.args.topic.event_starts_at
     );
   }
 
@@ -50,7 +49,7 @@ export default class EventDate extends Component {
   }
 
   get eventEndedAt() {
-    return this._parsedDate(this.args.topic.event_ends_at);
+    return this.args.topic.event_ends_at ? this._parsedDate(this.args.topic.event_ends_at) : this.eventStartedAt();
   }
 
   get dateRange() {


### PR DESCRIPTION
Addresses https://meta.discourse.org/t/post-event-date-not-always-displayed-on-topic-title/258816/ by using the start datetime. This won't ever show the event as being "in progress", but seems like a reasonable limitation.