### PR TITLE
UX: fix past events bg color

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -130,7 +130,7 @@ export default Component.extend({
         let borderColor, textColor;
         if (moment(ends_at || starts_at).isBefore(moment())) {
           borderColor = textColor = backgroundColor;
-          backgroundColor = undefined;
+          backgroundColor = "unset";
         }
 
         this._calendar.addEvent({

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -220,7 +220,7 @@ function initializeDiscourseCalendar(api) {
               let borderColor, textColor;
               if (moment(ends_at || starts_at).isBefore(moment())) {
                 borderColor = textColor = backgroundColor;
-                backgroundColor = undefined;
+                backgroundColor = "unset";
               }
 
               fullCalendar.addEvent({


### PR DESCRIPTION
It should override the background color, unsetting it, to properly show an outline (color + border with equal colors).

![image](https://github.com/discourse/discourse-calendar/assets/3530/4d8002b9-005e-4845-b578-96ca4c4f2926)
