### PR TITLE
DEV: Replace deprecated min_trust_to_create_post

### DIFF
--- a/spec/integration/post_spec.rb
+++ b/spec/integration/post_spec.rb
@@ -11,7 +11,7 @@ describe Post do
     SiteSetting.discourse_post_event_enabled = true
   end
 
-  let(:user) { Fabricate(:user, admin: true) }
+  let(:user) { Fabricate(:user, admin: true, refresh_auto_groups: true) }
 
   context "with a public event" do
     let(:post_1) { Fabricate(:post) }
@@ -304,7 +304,7 @@ describe Post do
         end
 
         context "when the acting user has rights to create events" do
-          let(:user_with_rights) { Fabricate(:user) }
+          let(:user_with_rights) { Fabricate(:user, refresh_auto_groups: true) }
           let(:group) { Fabricate(:group, users: [user_with_rights]) }
 
           before { SiteSetting.discourse_post_event_allowed_on_groups = group.id.to_s }
@@ -326,7 +326,7 @@ describe Post do
         end
 
         context "when the acting user doesn’t have rights to create events" do
-          let(:user_without_rights) { Fabricate(:user) }
+          let(:user_without_rights) { Fabricate(:user, refresh_auto_groups: true) }
           let(:group) { Fabricate(:group, users: [user]) }
 
           before { SiteSetting.discourse_post_event_allowed_on_groups = group.id.to_s }

--- a/spec/integration/topic_spec.rb
+++ b/spec/integration/topic_spec.rb
@@ -12,7 +12,7 @@ describe Topic do
     SiteSetting.discourse_post_event_enabled = true
   end
 
-  let(:user) { Fabricate(:user) }
+  let(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   context "when a topic is created" do
     context "with a date in title" do


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/24740, `min_trust_to_create_topic` site setting was replaced by `create_topic_allowed_groups`. This PR replaces the former, deprecated one, with the latter.