### PR TITLE
FIX: events endpoint extension

### DIFF
--- a/assets/javascripts/discourse/adapters/discourse-post-event-event.js
+++ b/assets/javascripts/discourse/adapters/discourse-post-event-event.js
@@ -6,7 +6,7 @@ export default DiscoursePostEventAdapter.extend({
     const path =
       this.basePath(store, type, findArgs) +
       underscore(store.pluralize(this.apiNameFor(type)));
-    return this.appendQueryParams(path, findArgs, ".json");
+    return this.appendQueryParams(path, findArgs);
   },
 
   apiNameFor() {

--- a/assets/javascripts/discourse/adapters/discourse-post-event-event.js
+++ b/assets/javascripts/discourse/adapters/discourse-post-event-event.js
@@ -6,7 +6,7 @@ export default DiscoursePostEventAdapter.extend({
     const path =
       this.basePath(store, type, findArgs) +
       underscore(store.pluralize(this.apiNameFor(type)));
-    return this.appendQueryParams(`${path}.json`, findArgs);
+    return this.appendQueryParams(path, findArgs, ".json");
   },
 
   apiNameFor() {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -184,7 +184,7 @@ function initializeDiscourseCalendar(api) {
           if (siteSettings.include_expired_events_on_calendar) {
             params.include_expired = true;
           }
-          const loadEvents = ajax(`/discourse-post-event/events.json`, {
+          const loadEvents = ajax(`/discourse-post-event/events`, {
             data: params,
           });
 

--- a/test/javascripts/acceptance/category-events-calendar-outlet-test.js
+++ b/test/javascripts/acceptance/category-events-calendar-outlet-test.js
@@ -3,7 +3,7 @@ import { test } from "qunit";
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 
 const eventsPretender = (server, helper) => {
-  server.get("/discourse-post-event/events.json", () => {
+  server.get("/discourse-post-event/events", () => {
     return helper.response({
       events: [
         {

--- a/test/javascripts/acceptance/category-events-calendar-test.js
+++ b/test/javascripts/acceptance/category-events-calendar-test.js
@@ -25,7 +25,7 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/discourse-post-event/events.json", () => {
+    server.get("/discourse-post-event/events", () => {
       return helper.response({
         events: [
           {

--- a/test/javascripts/acceptance/upcoming-events-calendar-test.js
+++ b/test/javascripts/acceptance/upcoming-events-calendar-test.js
@@ -33,7 +33,7 @@ acceptance("Discourse Calendar - Upcoming Events Calendar", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/discourse-post-event/events.json", () => {
+    server.get("/discourse-post-event/events", () => {
       return helper.response({
         events: [
           {


### PR DESCRIPTION
~~Uses the extension parameter of [`appendQueryParams`](https://github.com/discourse/discourse/blob/48193767bf753bedf9483b4a0c3b2f9760745df3/app/assets/javascripts/discourse/app/adapters/rest.js#L47) instead of appending it manually.~~

Removes all `.json` extension occurrences from all `/discourse-post-event/events` calls.