### PR TITLE
DEV: Remove use of private routeAction function

### DIFF
--- a/assets/javascripts/discourse/widgets/discourse-post-event.js
+++ b/assets/javascripts/discourse/widgets/discourse-post-event.js
@@ -1,5 +1,5 @@
+import getOwner from "@ember/application";
 import EmberObject from "@ember/object";
-import { routeAction } from "discourse/helpers/route-action";
 import { exportEntity } from "discourse/lib/export-csv";
 import { cook, emojiUnescape } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";
@@ -159,13 +159,13 @@ export default createWidget("discourse-post-event", {
   },
 
   sendPMToCreator() {
-    const router = this.register.lookup("service:router")._router;
-    routeAction(
-      "composePrivateMessage",
-      router,
-      EmberObject.create(this.state.eventModel.creator),
-      EmberObject.create(this.state.eventModel.post)
-    ).call();
+    getOwner(this)
+      .lookup("route:application")
+      .send(
+        "composePrivateMessage",
+        EmberObject.create(this.state.eventModel.creator),
+        EmberObject.create(this.state.eventModel.post)
+      );
   },
 
   addToCalendar() {


### PR DESCRIPTION
We know exactly which route this action exists on, so it's cleaner to lookup the route directly. (routeAction iterates through all active routes). Ideally this should be possible via a function on the composer service, but that would require a larger core change.

Ref https://github.com/discourse/discourse/pull/24946