### PR TITLE
FIX: only render event-date-container for topics with event date

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
+++ b/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
@@ -1,1 +1,7 @@
-{{~raw "event-date-container" topic=context.topic}}
+{{#if context.siteSettings.discourse_post_event_enabled}}
+    {{#if context.topic.event_starts_at}}
+        {{#if context.topic.event_ends_at}}
+            {{~raw "event-date-container" topic=context.topic}}
+        {{/if}}
+    {{/if}}
+{{/if}}


### PR DESCRIPTION
### Context
Previous implementation of event-date for topics (https://github.com/discourse/discourse-calendar/pull/474) introduced visual bugs for topics that did not have events, as we would render the `event-date-container-wrapper` for those topics as well. This would add an extra space between the title and other badge elements. 

The fix replicates logic of the component `event-date`'s shouldRender in the raw template used for the `topic-list-after-title` connector to ensure the `event-date-container-wrapper` element does not render.