### PR TITLE
FIX: include year in holiday identifier to differentiate yearly recurring events.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -365,6 +365,7 @@ after_initialize do
 
     CalendarEvent
       .where(topic_id: object.topic_id)
+      .where("post_id IS NOT NULL OR start_date >= ?", 6.months.ago)
       .order(:start_date, :end_date)
       .each do |event|
         if event.post_id
@@ -380,7 +381,7 @@ after_initialize do
             timezone: event.timezone,
           }
         else
-          identifier = "#{event.region.split("_").first}-#{event.start_date.strftime("%j")}"
+          identifier = "#{event.region.split("_").first}-#{event.start_date.strftime("%Y-%j")}"
 
           grouped[identifier] ||= {
             type: :grouped,

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -11,6 +11,7 @@ describe PostSerializer do
   it "includes calendar events" do
     calendar_post = create_post(raw: "[calendar]\n[/calendar]")
 
+    freeze_time Date.new(2018, 5, 1)
     post = create_post(topic: calendar_post.topic, raw: 'Rome [date="2018-06-05" time="10:20:00"]')
 
     json = PostSerializer.new(calendar_post, scope: Guardian.new).as_json
@@ -48,11 +49,13 @@ describe PostSerializer do
     ::DiscourseCalendar::CreateHolidayEvents.new.execute({})
 
     json = PostSerializer.new(post.reload, scope: Guardian.new).as_json
-    expect(json[:post][:calendar_details].map { |x| x[:name] }).to contain_exactly(
-      "Día del Veterano y de los Caídos en la Guerra de Malvinas, Viernes Santo",
-      "Día de la Revolución de Mayo",
-      "Feriado puente turístico",
-      "Día de la Independencia",
+    expect(
+      json[:post][:calendar_details].map { |x| { x[:from].year => x[:name] } },
+    ).to contain_exactly(
+      { 2021 => "Día del Veterano y de los Caídos en la Guerra de Malvinas, Viernes Santo" },
+      { 2021 => "Día de la Revolución de Mayo" },
+      { 2021 => "Feriado puente turístico" },
+      { 2021 => "Día de la Independencia" },
     )
     expect(json[:post][:calendar_details].map { |x| x[:users] }).to all (
           contain_exactly(
@@ -60,5 +63,17 @@ describe PostSerializer do
             { username: user2.username, timezone: "America/Buenos_Aires" },
           )
         )
+
+    freeze_time Date.new(2022, 4, 1)
+    ::DiscourseCalendar::CreateHolidayEvents.new.execute({})
+
+    json = PostSerializer.new(post.reload, scope: Guardian.new).as_json
+    expect(json[:post][:calendar_details].map { |x| { x[:from].year => x[:name] } }).to include(
+      { 2022 => "Viernes Santo" },
+      { 2022 => "Día de la Revolución de Mayo" },
+      { 2022 => "Día de la Bandera" },
+      { 2022 => "Feriado puente turístico" },
+      { 2022 => "Paso a la Inmortalidad del General José de San Martín" },
+    )
   end
 end


### PR DESCRIPTION
We must include the year identifier since now we can use same topic to track holidays for multiple years. Also, we don't need to load old public holiday events for more than 6 months.