### PR TITLE
FIX: expired events from PM not visible in upcoming events calendar

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -113,24 +113,26 @@ export default Component.extend({
             (entry) =>
               entry.type === "tag" && post.topic.tags.includes(entry.slug)
           );
-          backgroundColor = tagColorEntry ? tagColorEntry.color : null;
+          backgroundColor = tagColorEntry?.color;
         }
 
         if (!backgroundColor) {
-          const categoryColorFromMap = tagsColorsMap.find(
+          const categoryColorEntry = tagsColorsMap.find(
             (entry) =>
               entry.type === "category" &&
               entry.slug === post.topic.category_slug
-          )?.color;
-          backgroundColor =
-            categoryColorFromMap ||
-            `#${this.site.categoriesById[category_id]?.color}`;
+          );
+          backgroundColor = categoryColorEntry?.color;
         }
 
-        let borderColor, textColor;
+        const categoryColor = this.site.categoriesById[category_id]?.color;
+        if (!backgroundColor && categoryColor) {
+          backgroundColor = `#${categoryColor}`;
+        }
+
+        let classNames;
         if (moment(ends_at || starts_at).isBefore(moment())) {
-          borderColor = textColor = backgroundColor;
-          backgroundColor = "unset";
+          classNames = "fc-past-event";
         }
 
         this._calendar.addEvent({
@@ -140,8 +142,7 @@ export default Component.extend({
           allDay: !isNotFullDayEvent(moment(starts_at), moment(ends_at)),
           url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
           backgroundColor,
-          borderColor,
-          textColor,
+          classNames,
         });
       });
 

--- a/assets/stylesheets/common/upcoming-events-calendar.scss
+++ b/assets/stylesheets/common/upcoming-events-calendar.scss
@@ -118,6 +118,10 @@
     }
   }
 
+  .fc-past-event {
+    opacity: 0.3;
+  }
+
   .fc-left {
     .fc-button-group:first-child {
       margin-left: 0;


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/events-in-personal-messages-are-present-in-the-upcoming-events-page-but-not-visible/290950.

In addition to the fix, this PR changes the expired events to be displayed with 30% opacity (same as Google Calendar) instead of the previous outline approach.

![image](https://github.com/discourse/discourse-calendar/assets/3530/27778f20-9b70-446c-b7a1-b4dcf15494bb)
