### PR TITLE
FIX: update Malaysia holidays for 2024

### DIFF
--- a/vendor/holidays/definitions/my.yaml
+++ b/vendor/holidays/definitions/my.yaml
@@ -15,87 +15,70 @@ months:
     regions: [my]
     mday: 1
     observed: to_weekday_if_weekend(date)
-  - name: Chinese New Year
-    regions: [my]
-    mday: 23
-    observed: to_weekday_if_weekend(date)
-  - name: Chinese New Year (Day 2)
-    regions: [my]
-    mday: 24
-    year_ranges:
-      limited: [2023]
-  2:
   - name: Thaipusam
     regions: [my]
-    mday: 5
-    observed: to_weekday_if_weekend(date)
-  4:
-  - name: Nuzul Al-Quran
-    regions: [my]
-    mday: 8
+    mday: 25
     year_ranges:
-      limited: [2023]
+      limited: [2024]
+  2:
+  - name: Chinese New Year
+    regions: [my]
+    mday: 12
+    year_ranges:
+      limited: [2024]
+  4:
   - name: Hari Raya Aidilfitri
     regions: [my]
-    mday: 21
+    mday: 10
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   - name: Hari Raya Aidilfitri (Day 2)
     regions: [my]
-    mday: 24
+    mday: 11
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   5:
   - name: Labour Day
     regions: [my]
     mday: 1
   - name: Wesak Day
     regions: [my]
-    mday: 4
+    mday: 22
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   6:
   - name: Agong's Birthday
     regions: [my]
-    mday: 4
+    mday: 3
     observed: to_weekday_if_weekend(date)
   - name: Hari Raya Haji
     regions: [my]
-    mday: 29
+    mday: 17
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   7:
   - name: Awal Muharram
     regions: [my]
-    mday: 19
+    mday: 8
     year_ranges:
-      limited: [2023]
-  8:
-  - name: Independence Day
-    regions: [my]
-    mday: 31
-    observed: to_weekday_if_weekend(date)
+      limited: [2024]
   9:
   - name: Malaysia Day
     regions: [my]
     mday: 16
     observed: to_weekday_if_weekend(date)
-  - name: Prophet Muhammad's Birthday
+  - name: Malaysia Day (Day 2)
     regions: [my]
-    mday: 28
+    mday: 17
     year_ranges:
-      limited: [2023]
-  11:
-  - name: Deepavali (Observed)
+      limited: [2024]
+  10:
+  - name: Deepavali
     regions: [my]
-    mday: 13
-    observed: to_weekday_if_weekend(date)
+    mday: 31
+    year_ranges:
+      limited: [2024]
   12:
-  - name: Sultan of Selangor's Birthday
-    regions: [my]
-    mday: 11
-    year_ranges:
-      limited: [2023]
   - name: Christmas Day
     regions: [my]
     mday: 25
@@ -109,35 +92,59 @@ tests:
     expect:
       name: "New Year's Day"
   - given:
+      date: '2023-01-25'
+      regions: ["my"]
+      options: ["informal"]
+    expect:
+      name: "Thaipusam"
+  - given:
+      date: '2023-02-12'
+      regions: ["my"]
+      options: ["informal"]
+    expect:
+      name: "Chinese New Year"
+  - given:
+      date: '2023-04-10'
+      regions: ["my"]
+      options: ["informal"]
+    expect:
+      name: "Hari Raya Aidilfitri"
+  - given:
+      date: '2023-04-11'
+      regions: ["my"]
+      options: ["informal"]
+    expect:
+      name: "Hari Raya Aidilfitri (Day 2)"
+  - given:
       date: '2023-05-01'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "Labour Day"
   - given:
-      date: '2023-06-04'
+      date: '2023-05-22'
+      regions: ["my"]
+      options: ["informal"]
+    expect:
+      name: "Wesak Day"
+  - given:
+      date: '2023-06-03'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "Agong's Birthday"
   - given:
-      date: '2023-06-29'
+      date: '2024-06-17'
       regions: ["my"]
       options: ["observed"]
     expect:
       name: "Hari Raya Haji"
   - given:
-      date: '2023-07-19'
+      date: '2024-07-08'
       regions: ["my"]
       options: ["informal"]
     expect:
       name: "Awal Muharram"
-  - given:
-      date: '2023-08-31'
-      regions: ["my"]
-      options: ["informal"]
-    expect:
-      name: "Independence Day"
   - given:
       date: '2023-09-16'
       regions: ["my"]
@@ -145,17 +152,17 @@ tests:
     expect:
       name: "Malaysia Day"
   - given:
-      date: '2023-09-28'
+      date: '2023-09-17'
       regions: ["my"]
       options: ["informal"]
     expect:
-      name: "Prophet Muhammad's Birthday"
+      name: "Malaysia Day (Day 2)"
   - given:
-      date: '2023-11-13'
+      date: '2023-10-31'
       regions: ["my"]
       options: ["observed"]
     expect:
-      name: "Deepavali (Observed)"
+      name: "Deepavali"
   - given:
       date: '2023-12-25'
       regions: ["my"]

--- a/vendor/holidays/lib/generated_definitions/my.rb
+++ b/vendor/holidays/lib/generated_definitions/my.rb
@@ -13,23 +13,19 @@ module Holidays
     def self.holidays_by_month
       {
                 1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:my]},
-            {:mday => 23, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Chinese New Year", :regions => [:my]},
-            {:mday => 24, :year_ranges => { :limited => [2023] },:name => "Chinese New Year (Day 2)", :regions => [:my]}],
-      2 => [{:mday => 5, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Thaipusam", :regions => [:my]}],
-      4 => [{:mday => 8, :year_ranges => { :limited => [2023] },:name => "Nuzul Al-Quran", :regions => [:my]},
-            {:mday => 21, :year_ranges => { :limited => [2023] },:name => "Hari Raya Aidilfitri", :regions => [:my]},
-            {:mday => 24, :year_ranges => { :limited => [2023] },:name => "Hari Raya Aidilfitri (Day 2)", :regions => [:my]}],
+            {:mday => 25, :year_ranges => { :limited => [2024] },:name => "Thaipusam", :regions => [:my]}],
+      2 => [{:mday => 12, :year_ranges => { :limited => [2024] },:name => "Chinese New Year", :regions => [:my]}],
+      4 => [{:mday => 10, :year_ranges => { :limited => [2024] },:name => "Hari Raya Aidilfitri", :regions => [:my]},
+            {:mday => 11, :year_ranges => { :limited => [2024] },:name => "Hari Raya Aidilfitri (Day 2)", :regions => [:my]}],
       5 => [{:mday => 1, :name => "Labour Day", :regions => [:my]},
-            {:mday => 4, :year_ranges => { :limited => [2023] },:name => "Wesak Day", :regions => [:my]}],
-      6 => [{:mday => 4, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Agong's Birthday", :regions => [:my]},
-            {:mday => 29, :year_ranges => { :limited => [2023] },:name => "Hari Raya Haji", :regions => [:my]}],
-      7 => [{:mday => 19, :year_ranges => { :limited => [2023] },:name => "Awal Muharram", :regions => [:my]}],
-      8 => [{:mday => 31, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Independence Day", :regions => [:my]}],
+            {:mday => 22, :year_ranges => { :limited => [2024] },:name => "Wesak Day", :regions => [:my]}],
+      6 => [{:mday => 3, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Agong's Birthday", :regions => [:my]},
+            {:mday => 17, :year_ranges => { :limited => [2024] },:name => "Hari Raya Haji", :regions => [:my]}],
+      7 => [{:mday => 8, :year_ranges => { :limited => [2024] },:name => "Awal Muharram", :regions => [:my]}],
       9 => [{:mday => 16, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Malaysia Day", :regions => [:my]},
-            {:mday => 28, :year_ranges => { :limited => [2023] },:name => "Prophet Muhammad's Birthday", :regions => [:my]}],
-      11 => [{:mday => 13, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Deepavali (Observed)", :regions => [:my]}],
-      12 => [{:mday => 11, :year_ranges => { :limited => [2023] },:name => "Sultan of Selangor's Birthday", :regions => [:my]},
-            {:mday => 25, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:my]}]
+            {:mday => 17, :year_ranges => { :limited => [2024] },:name => "Malaysia Day (Day 2)", :regions => [:my]}],
+      10 => [{:mday => 31, :year_ranges => { :limited => [2024] },:name => "Deepavali", :regions => [:my]}],
+      12 => [{:mday => 25, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:my]}]
       }
     end
 

--- a/vendor/holidays/test/defs/test_defs_my.rb
+++ b/vendor/holidays/test/defs/test_defs_my.rb
@@ -9,21 +9,29 @@ class MyDefinitionTests < Test::Unit::TestCase  # :nodoc:
   def test_my
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2023, 1, 1), [:my], [:informal])[0] || {})[:name]
 
+    assert_equal "Thaipusam", (Holidays.on(Date.civil(2023, 1, 25), [:my], [:informal])[0] || {})[:name]
+
+    assert_equal "Chinese New Year", (Holidays.on(Date.civil(2023, 2, 12), [:my], [:informal])[0] || {})[:name]
+
+    assert_equal "Hari Raya Aidilfitri", (Holidays.on(Date.civil(2023, 4, 10), [:my], [:informal])[0] || {})[:name]
+
+    assert_equal "Hari Raya Aidilfitri (Day 2)", (Holidays.on(Date.civil(2023, 4, 11), [:my], [:informal])[0] || {})[:name]
+
     assert_equal "Labour Day", (Holidays.on(Date.civil(2023, 5, 1), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Agong's Birthday", (Holidays.on(Date.civil(2023, 6, 4), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Wesak Day", (Holidays.on(Date.civil(2023, 5, 22), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Hari Raya Haji", (Holidays.on(Date.civil(2023, 6, 29), [:my], [:observed])[0] || {})[:name]
+    assert_equal "Agong's Birthday", (Holidays.on(Date.civil(2023, 6, 3), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Awal Muharram", (Holidays.on(Date.civil(2023, 7, 19), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Hari Raya Haji", (Holidays.on(Date.civil(2024, 6, 17), [:my], [:observed])[0] || {})[:name]
 
-    assert_equal "Independence Day", (Holidays.on(Date.civil(2023, 8, 31), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Awal Muharram", (Holidays.on(Date.civil(2024, 7, 8), [:my], [:informal])[0] || {})[:name]
 
     assert_equal "Malaysia Day", (Holidays.on(Date.civil(2023, 9, 16), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Prophet Muhammad's Birthday", (Holidays.on(Date.civil(2023, 9, 28), [:my], [:informal])[0] || {})[:name]
+    assert_equal "Malaysia Day (Day 2)", (Holidays.on(Date.civil(2023, 9, 17), [:my], [:informal])[0] || {})[:name]
 
-    assert_equal "Deepavali (Observed)", (Holidays.on(Date.civil(2023, 11, 13), [:my], [:observed])[0] || {})[:name]
+    assert_equal "Deepavali", (Holidays.on(Date.civil(2023, 10, 31), [:my], [:observed])[0] || {})[:name]
 
     assert_equal "Christmas Day", (Holidays.on(Date.civil(2023, 12, 25), [:my], [:informal])[0] || {})[:name]
 


### PR DESCRIPTION
Adds and updates various national holidays that are based on the Lunar calendar.

Source:
https://publicholidays.com.my/kuala-lumpur/2024-dates/