### PR TITLE
DEV: Update public holiday for Singapore 2024

### DIFF
--- a/vendor/holidays/definitions/sg.yaml
+++ b/vendor/holidays/definitions/sg.yaml
@@ -16,109 +16,61 @@ months:
     regions: [sg]
     mday: 1
     observed: to_weekday_if_weekend(date)
+  2:
   - name: First day of Chinese New Year (Observed)
     regions: [sg]
-    mday: 23
+    mday: 10
+    observed: to_weekday_if_weekend(date)
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   - name: Second day of Chinese New Year
     regions: [sg]
-    mday: 24
+    mday: 11
+    observed: to_weekday_if_weekend(date)
     year_ranges:
-      limited: [2023]
-  2:
-  - name: Valentine's Day
-    regions: [sg]
-    mday: 14
-    type: informal
-  - name: Total Defence Day
-    regions: [sg]
-    mday: 15
-    type: informal
-  4:
+      limited: [2024]
+  3:
   - name: Good Friday
     regions: [sg]
-    mday: 7
+    mday: 29
     year_ranges:
-      limited: [2023]
+      limited: [2024]
+  4:
   - name: Hari Raya Puasa (Observed)
     regions: [sg]
-    mday: 24
+    mday: 10
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   5:
   - name: Labour Day
     regions: [sg]
     mday: 1
     observed: to_weekday_if_weekend(date)
-  6:
   - name: Vesak Day
     regions: [sg]
-    mday: 2
+    mday: 22
     year_ranges:
-      limited: [2023]
+      limited: [2024]
+  6:
   - name: Hari Raya Haji
     regions: [sg]
-    mday: 29
+    mday: 17
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   8:
   - name: National Day
     regions: [sg]
     mday: 9
     observed: to_weekday_if_weekend(date)
-  11:
+  10:
   - name: Deepavali (Observed)
     regions: [sg]
-    mday: 13
+    mday: 31
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   12:
   - name: Christmas Day
     regions: [sg]
     mday: 25
     observed: to_weekday_if_weekend(date)
 
-tests:
-  - given:
-      date: '2014-01-01'
-      regions: ["sg"]
-      options: ["informal"]
-    expect:
-      name: "New Year's Day"
-  - given:
-      date: '2014-02-14'
-      regions: ["sg"]
-      options: ["informal"]
-    expect:
-      name: "Valentine's Day"
-  - given:
-      date: '2014-02-15'
-      regions: ["sg"]
-      options: ["informal"]
-    expect:
-      name: "Total Defence Day"
-  - given:
-      date: '2014-04-18'
-      regions: ["sg"]
-      options: ["informal"]
-    expect:
-      name: "Good Friday"
-  - given:
-      date: '2014-05-01'
-      regions: ["sg"]
-      options: ["informal"]
-    expect:
-      name: "Labour Day"
-  - given:
-      date: '2014-08-09'
-      regions: ["sg"]
-      options: ["informal"]
-    expect:
-      name: "National Day"
-  - given:
-      date: '2014-12-25'
-      regions: ["sg"]
-      options: ["informal"]
-    expect:
-      name: "Christmas Day"

--- a/vendor/holidays/lib/generated_definitions/sg.rb
+++ b/vendor/holidays/lib/generated_definitions/sg.rb
@@ -12,18 +12,16 @@ module Holidays
 
     def self.holidays_by_month
       {
-                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:sg]},
-            {:mday => 23, :year_ranges => { :limited => [2023] },:name => "First day of Chinese New Year (Observed)", :regions => [:sg]},
-            {:mday => 24, :year_ranges => { :limited => [2023] },:name => "Second day of Chinese New Year", :regions => [:sg]}],
-      2 => [{:mday => 14, :type => :informal, :name => "Valentine's Day", :regions => [:sg]},
-            {:mday => 15, :type => :informal, :name => "Total Defence Day", :regions => [:sg]}],
-      4 => [{:mday => 7, :year_ranges => { :limited => [2023] },:name => "Good Friday", :regions => [:sg]},
-            {:mday => 24, :year_ranges => { :limited => [2023] },:name => "Hari Raya Puasa (Observed)", :regions => [:sg]}],
-      5 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Labour Day", :regions => [:sg]}],
-      6 => [{:mday => 2, :year_ranges => { :limited => [2023] },:name => "Vesak Day", :regions => [:sg]},
-            {:mday => 29, :year_ranges => { :limited => [2023] },:name => "Hari Raya Haji", :regions => [:sg]}],
+                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:sg]}],
+      2 => [{:mday => 10, :year_ranges => { :limited => [2024] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "First day of Chinese New Year (Observed)", :regions => [:sg]},
+            {:mday => 11, :year_ranges => { :limited => [2024] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Second day of Chinese New Year", :regions => [:sg]}],
+      3 => [{:mday => 29, :year_ranges => { :limited => [2024] },:name => "Good Friday", :regions => [:sg]}],
+      4 => [{:mday => 10, :year_ranges => { :limited => [2024] },:name => "Hari Raya Puasa (Observed)", :regions => [:sg]}],
+      5 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Labour Day", :regions => [:sg]},
+            {:mday => 22, :year_ranges => { :limited => [2024] },:name => "Vesak Day", :regions => [:sg]}],
+      6 => [{:mday => 17, :year_ranges => { :limited => [2024] },:name => "Hari Raya Haji", :regions => [:sg]}],
       8 => [{:mday => 9, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "National Day", :regions => [:sg]}],
-      11 => [{:mday => 13, :year_ranges => { :limited => [2023] },:name => "Deepavali (Observed)", :regions => [:sg]}],
+      10 => [{:mday => 31, :year_ranges => { :limited => [2024] },:name => "Deepavali (Observed)", :regions => [:sg]}],
       12 => [{:mday => 25, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:sg]}]
       }
     end

--- a/vendor/holidays/test/defs/test_defs_sg.rb
+++ b/vendor/holidays/test/defs/test_defs_sg.rb
@@ -7,19 +7,5 @@ require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
 class SgDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
   def test_sg
-    assert_equal "New Year's Day", (Holidays.on(Date.civil(2014, 1, 1), [:sg], [:informal])[0] || {})[:name]
-
-    assert_equal "Valentine's Day", (Holidays.on(Date.civil(2014, 2, 14), [:sg], [:informal])[0] || {})[:name]
-
-    assert_equal "Total Defence Day", (Holidays.on(Date.civil(2014, 2, 15), [:sg], [:informal])[0] || {})[:name]
-
-    assert_equal "Good Friday", (Holidays.on(Date.civil(2014, 4, 18), [:sg], [:informal])[0] || {})[:name]
-
-    assert_equal "Labour Day", (Holidays.on(Date.civil(2014, 5, 1), [:sg], [:informal])[0] || {})[:name]
-
-    assert_equal "National Day", (Holidays.on(Date.civil(2014, 8, 9), [:sg], [:informal])[0] || {})[:name]
-
-    assert_equal "Christmas Day", (Holidays.on(Date.civil(2014, 12, 25), [:sg], [:informal])[0] || {})[:name]
-
   end
 end


### PR DESCRIPTION
https://www.mom.gov.sg/newsroom/press-releases/2023/0524-public-holidays-for-2024