### PR TITLE
DEV: Exclude system users when serializing group timezones

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -425,6 +425,7 @@ after_initialize do
     if group_names.present?
       users =
         User
+          .human_users
           .joins(:groups, :user_option)
           .where("groups.name": group_names)
           .select("users.*", "groups.name AS group_name", "user_options.timezone")

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -20,7 +20,6 @@ describe PostSerializer do
 
   it "includes group timezones" do
     Fabricate(:admin)
-    Group.refresh_automatic_groups!(:admins)
 
     calendar_post =
       create_post(


### PR DESCRIPTION
### What is this change?

The `post_serializer_spec` was calling `Group.refresh_automatic_groups!(:admins)`, relying on that call booting system users from the group.

This change makes it so the implementation excludes any system users instead.