### PR TITLE
DEV: Fix some TL group loading for admins in tests

### DIFF
--- a/spec/models/calendar_event_spec.rb
+++ b/spec/models/calendar_event_spec.rb
@@ -129,8 +129,7 @@ describe CalendarEvent do
     end
 
     it "includes group timezones detail" do
-      Fabricate(:admin)
-      Group.refresh_automatic_groups!(:admins)
+      Fabricate(:admin, refresh_auto_groups: true)
 
       timezones_post =
         create_post(

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -19,7 +19,7 @@ describe PostSerializer do
   end
 
   it "includes group timezones" do
-    Fabricate(:admin)
+    Fabricate(:admin, refresh_auto_groups: true)
 
     calendar_post =
       create_post(


### PR DESCRIPTION
### What is this change?

We're changing how TL auto-groups are handled in core tests. These changes are needed to keep the `discourse-calendar` plugin tests passing.