### PR TITLE
DEV: Prefer Category.findById over categoryById

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import { schedule } from "@ember/runloop";
 import { Promise } from "rsvp";
 import loadScript from "discourse/lib/load-script";
+import Category from "discourse/models/category";
 import getURL from "discourse-common/lib/get-url";
 import { formatEventName } from "../helpers/format-event-name";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
@@ -125,7 +126,7 @@ export default Component.extend({
           backgroundColor = categoryColorEntry?.color;
         }
 
-        const categoryColor = this.site.categoriesById[category_id]?.color;
+        const categoryColor = Category.findById(category_id)?.color;
         if (!backgroundColor && categoryColor) {
           backgroundColor = `#${categoryColor}`;
         }

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -214,7 +214,7 @@ function initializeDiscourseCalendar(api) {
                 )?.color;
                 backgroundColor =
                   categoryColorFromMap ||
-                  `#${site.categoriesById[category_id]?.color}`;
+                  `#${Category.findById(category_id)?.color}`;
               }
 
               let borderColor, textColor;


### PR DESCRIPTION
Category.findById should be used over site.categoryById map because that is an implementation detail that might be removed in the future.