### PR TITLE
UX: use past event class name on the category calendar

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -217,10 +217,9 @@ function initializeDiscourseCalendar(api) {
                   `#${Category.findById(category_id)?.color}`;
               }
 
-              let borderColor, textColor;
+              let classNames;
               if (moment(ends_at || starts_at).isBefore(moment())) {
-                borderColor = textColor = backgroundColor;
-                backgroundColor = "unset";
+                classNames = "fc-past-event";
               }
 
               fullCalendar.addEvent({
@@ -230,8 +229,7 @@ function initializeDiscourseCalendar(api) {
                 allDay: !isNotFullDayEvent(moment(starts_at), moment(ends_at)),
                 url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
                 backgroundColor,
-                borderColor,
-                textColor,
+                classNames,
               });
             });
 


### PR DESCRIPTION
Same strategy from the `/upcoming-events` calendar:

https://github.com/discourse/discourse-calendar/blob/ad6feb27175a8af15e24d59808875637ff277593/assets/javascripts/discourse/components/upcoming-events-calendar.js#L134-L137

![image](https://github.com/discourse/discourse-calendar/assets/3530/dc72f514-6c2a-445c-9fb0-67b5963c0369)
