### PR TITLE
UX: use json_schema setting color format

### DIFF
--- a/lib/discourse_calendar/site_settings/map_event_tag_colors_json_schema.rb
+++ b/lib/discourse_calendar/site_settings/map_event_tag_colors_json_schema.rb
@@ -22,8 +22,9 @@ module DiscourseCalendar
               },
               color: {
                 type: "string",
+                format: "color",
+                default: "#FFFFFF",
                 description: "Color associated with the tag or category",
-                pattern: "^#(?:[0-9a-fA-F]{3}){1,2}$",
               },
             },
             required: %w[slug type color],


### PR DESCRIPTION
json_schema supports a color format, which is more user friendly... the format error message is unintelligible to most people:

![image](https://github.com/discourse/discourse-calendar/assets/1681963/1006ae54-169d-4f3d-8cdd-307d85b6672d)

It appears that we can just drop this in for free: 

![image](https://github.com/discourse/discourse-calendar/assets/1681963/1a406f04-2221-449a-9eba-08c67e35722d)

![image](https://github.com/discourse/discourse-calendar/assets/1681963/1d92639d-7c00-4afd-8819-ed52718a507c)


![image](https://github.com/discourse/discourse-calendar/assets/1681963/badaf3a9-8aee-4d33-8274-046f6e7df204)


`input type="color"` is supported by all the browsers we support
