### PR TITLE
DEV: Add upcoming Eid-Ul-Fitr holiday for Ghana

### DIFF
--- a/vendor/holidays/definitions/gh.yaml
+++ b/vendor/holidays/definitions/gh.yaml
@@ -33,9 +33,7 @@ months:
   4:
   - name: Eid-ul-Fitr
     regions: [gh]
-    mday: 22
-    year_ranges:
-      limited: [2023]
+    function: eid_ul_fitr(year)
     observed: to_monday_if_weekend(date)
   5:
   - name: May Day (Workers' Day)
@@ -83,6 +81,16 @@ months:
     mday: 26
     observed: to_weekday_if_boxing_weekend(date)
 
+methods:
+  eid_ul_fitr:
+    arguments: year
+    ruby: |
+      eid_ul_fitr_dates = {
+        '2023' => Date.civil(2023, 4, 22),
+        '2024' => Date.civil(2024, 4, 11)
+      }
+      eid_ul_fitr_dates[year.to_s]
+
 tests:
   - given:
       date: "2022-04-15"
@@ -112,7 +120,7 @@ tests:
     expect:
       name: "Independence Day"
   - given:
-      date: "2023-04-24"
+      date: ["2023-04-24", "2024-04-11"]
       regions: ["gh"]
       options: ["observed"]
     expect:

--- a/vendor/holidays/lib/generated_definitions/gh.rb
+++ b/vendor/holidays/lib/generated_definitions/gh.rb
@@ -17,7 +17,7 @@ module Holidays
       1 => [{:mday => 1, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:gh]},
             {:mday => 7, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Constitution Day", :regions => [:gh]}],
       3 => [{:mday => 6, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Independence Day", :regions => [:gh]}],
-      4 => [{:mday => 22, :year_ranges => { :limited => [2023] },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Eid-ul-Fitr", :regions => [:gh]}],
+      4 => [{:function => "eid_ul_fitr(year)", :function_arguments => [:year], :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Eid-ul-Fitr", :regions => [:gh]}],
       5 => [{:mday => 1, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "May Day (Workers' Day)", :regions => [:gh]},
             {:mday => 25, :type => :informal, :name => "African Union Day", :regions => [:gh]}],
       6 => [{:mday => 28, :year_ranges => { :limited => [2023] },:name => "Eid-ul-Adha", :regions => [:gh]}],
@@ -32,7 +32,15 @@ module Holidays
 
     def self.custom_methods
       {
-          
+          "eid_ul_fitr(year)" => Proc.new { |year|
+eid_ul_fitr_dates = {
+  '2023' => Date.civil(2023, 4, 22),
+  '2024' => Date.civil(2024, 4, 11)
+}
+eid_ul_fitr_dates[year.to_s]
+},
+
+
       }
     end
   end

--- a/vendor/holidays/test/defs/test_defs_gh.rb
+++ b/vendor/holidays/test/defs/test_defs_gh.rb
@@ -18,6 +18,7 @@ class GhDefinitionTests < Test::Unit::TestCase  # :nodoc:
     assert_equal "Independence Day", (Holidays.on(Date.civil(2022, 3, 7), [:gh], [:observed])[0] || {})[:name]
 
     assert_equal "Eid-ul-Fitr", (Holidays.on(Date.civil(2023, 4, 24), [:gh], [:observed])[0] || {})[:name]
+assert_equal "Eid-ul-Fitr", (Holidays.on(Date.civil(2024, 4, 11), [:gh], [:observed])[0] || {})[:name]
 
     assert_equal "May Day (Workers' Day)", (Holidays.on(Date.civil(2022, 5, 1), [:gh])[0] || {})[:name]
 


### PR DESCRIPTION
Switched to using a function for Eid-Ul-Fitr to make future updates seamless.

See https://www.mint.gov.gh/declaration-of-thursday-11th-april-2024-as-a-statutory-public-holiday/