### PR TITLE
Update map_event_tag_colors_json_schema.rb

### DIFF
--- a/lib/discourse_calendar/site_settings/map_event_tag_colors_json_schema.rb
+++ b/lib/discourse_calendar/site_settings/map_event_tag_colors_json_schema.rb
@@ -22,7 +22,7 @@ module DiscourseCalendar
               },
               color: {
                 type: "string",
-                description: "Color associated with the tag or category",
+                description: "Hex code of color associated with the tag or category",
                 pattern: "^#(?:[0-9a-fA-F]{3}){1,2}$",
               },
             },


### PR DESCRIPTION
Clarified that only hex codes are supported as  color