### PR TITLE
FIX: support endless events in topic list

### DIFF
--- a/assets/javascripts/discourse/components/event-date.gjs
+++ b/assets/javascripts/discourse/components/event-date.gjs
@@ -40,8 +40,7 @@ export default class EventDate extends Component {
   get shouldRender() {
     return (
       this.siteSettings.discourse_post_event_enabled &&
-      this.args.topic.event_starts_at &&
-      this.args.topic.event_ends_at
+      this.args.topic.event_starts_at
     );
   }
 
@@ -50,11 +49,13 @@ export default class EventDate extends Component {
   }
 
   get eventEndedAt() {
-    return this._parsedDate(this.args.topic.event_ends_at);
+    return this.args.topic.event_ends_at
+      ? this._parsedDate(this.args.topic.event_ends_at)
+      : this.eventStartedAt;
   }
 
   get dateRange() {
-    return this.eventEndedAt
+    return this.args.topic.event_ends_at
       ? `${this._formattedDate(this.eventStartedAt)} → ${this._formattedDate(
           this.eventEndedAt
         )}`

--- a/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
+++ b/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
@@ -1,7 +1,5 @@
 {{#if context.siteSettings.discourse_post_event_enabled}}
     {{#if context.topic.event_starts_at}}
-        {{#if context.topic.event_ends_at}}
-            {{~raw "event-date-container" topic=context.topic}}
-        {{/if}}
+        {{~raw "event-date-container" topic=context.topic}}
     {{/if}}
 {{/if}}

--- a/test/javascripts/acceptance/topic-title-decorator-test.js
+++ b/test/javascripts/acceptance/topic-title-decorator-test.js
@@ -2,7 +2,7 @@ import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import sinon from "sinon";
 import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
-import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance("Discourse Calendar - Event Title Decorator", function (needs) {
@@ -15,8 +15,12 @@ acceptance("Discourse Calendar - Event Title Decorator", function (needs) {
   needs.pretender((server, helper) => {
     server.get("/latest.json", () => {
       const topicList = cloneJSON(discoveryFixtures["/latest.json"]);
+
+      // both start and end dates
       topicList.topic_list.topics[0].event_starts_at = "2022-01-10 19:00:00";
       topicList.topic_list.topics[0].event_ends_at = "2022-01-10 20:00:00";
+      // just a start date
+      topicList.topic_list.topics[1].event_starts_at = "2022-01-11 15:00:00";
 
       return helper.response(topicList);
     });
@@ -29,15 +33,23 @@ acceptance("Discourse Calendar - Event Title Decorator", function (needs) {
 
     await visit("/latest");
 
-    const firstTopic = query(".topic-list-item:first-child .link-top-line");
-    assert.dom(".event-date.past", firstTopic).exists();
-    assert.dom(".event-date", firstTopic).hasAttribute("data-starts-at");
-    assert.dom(".event-date", firstTopic).hasAttribute("data-ends-at");
+    const topics = queryAll(".topic-list-item");
+
+    assert.dom(".event-date.past", topics[0]).exists();
+    assert.dom(".event-date", topics[0]).hasAttribute("data-starts-at");
+    assert.dom(".event-date", topics[0]).hasAttribute("data-ends-at");
     assert
-      .dom(".event-date", firstTopic)
+      .dom(".event-date", topics[0])
       .hasAttribute(
         "title",
         "January 10, 2022 7:00 PM → January 10, 2022 8:00 PM"
       );
+
+    assert.dom(".event-date.past", topics[1]).exists();
+    assert.dom(".event-date", topics[1]).hasAttribute("data-starts-at");
+    assert.dom(".event-date", topics[1]).hasAttribute("data-ends-at");
+    assert
+      .dom(".event-date", topics[1])
+      .hasAttribute("title", "January 11, 2022 3:00 PM");
   });
 });


### PR DESCRIPTION
Uses the start date when an event doesn't have an end date so that we always show the date in the topic title in topic lists.

Cf. https://meta.discourse.org/t/post-event-date-not-always-displayed-on-topic-title/258816

Inspired by https://github.com/discourse/discourse-calendar/pull/501