### PR TITLE
FEATURE: closed events

### DIFF
--- a/app/serializers/discourse_post_event/event_serializer.rb
+++ b/app/serializers/discourse_post_event/event_serializer.rb
@@ -2,33 +2,34 @@
 
 module DiscoursePostEvent
   class EventSerializer < ApplicationSerializer
-    attributes :id
-    attributes :creator
-    attributes :sample_invitees
-    attributes :watching_invitee
-    attributes :starts_at
-    attributes :ends_at
-    attributes :timezone
-    attributes :stats
-    attributes :status
-    attributes :raw_invitees
-    attributes :post
-    attributes :name
     attributes :can_act_on_discourse_post_event
     attributes :can_update_attendance
+    attributes :category_id
+    attributes :creator
+    attributes :custom_fields
+    attributes :ends_at
+    attributes :id
+    attributes :is_closed
     attributes :is_expired
     attributes :is_ongoing
-    attributes :should_display_invitees
-    attributes :url
-    attributes :custom_fields
-    attributes :is_public
     attributes :is_private
+    attributes :is_public
     attributes :is_standalone
-    attributes :reminders
-    attributes :recurrence
     attributes :minimal
-    attributes :category_id
+    attributes :name
+    attributes :post
+    attributes :raw_invitees
+    attributes :recurrence
     attributes :recurrence_rule
+    attributes :reminders
+    attributes :sample_invitees
+    attributes :should_display_invitees
+    attributes :starts_at
+    attributes :stats
+    attributes :status
+    attributes :timezone
+    attributes :url
+    attributes :watching_invitee
 
     def can_act_on_discourse_post_event
       scope.can_act_on_discourse_post_event?(object)
@@ -55,15 +56,19 @@ module DiscoursePostEvent
     end
 
     def is_public
-      object.status === Event.statuses[:public]
+      object.public?
     end
 
     def is_private
-      object.status === Event.statuses[:private]
+      object.private?
     end
 
     def is_standalone
-      object.status === Event.statuses[:standalone]
+      object.standalone?
+    end
+
+    def is_closed
+      object.closed
     end
 
     def status

--- a/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -5,6 +5,10 @@ export function buildParams(startsAt, endsAt, eventModel, siteSettings) {
 
   params.start = moment(startsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
 
+  if (eventModel.closed) {
+    params.closed = "true";
+  }
+
   if (eventModel.status) {
     params.status = eventModel.status;
   }

--- a/assets/javascripts/discourse/widgets/discourse-post-event-dates.js
+++ b/assets/javascripts/discourse/widgets/discourse-post-event-dates.js
@@ -15,27 +15,28 @@ export default createWidget("discourse-post-event-dates", {
     });
   },
 
-  html(attrs) {
+  html({ localDates, eventModel }) {
     const content = [
       iconNode("clock"),
-      h("span.date", new RawHtml({ html: `<span>${attrs.localDates}</span>` })),
+      h("span.date", new RawHtml({ html: `<span>${localDates}</span>` })),
     ];
 
     if (
-      attrs.eventModel.is_expired &&
-      attrs.eventModel.status !== "standalone"
+      eventModel.is_expired &&
+      !eventModel.is_closed &&
+      !eventModel.is_standalone
     ) {
       let participants;
       const label = I18n.t(
         "discourse_calendar.discourse_post_event.event_ui.participants",
         {
-          count: attrs.eventModel.stats.going,
+          count: eventModel.stats.going,
         }
       );
-      if (attrs.eventModel.stats.going > 0) {
+      if (eventModel.stats.going > 0) {
         participants = this.attach("link", {
           action: "showAllParticipatingInvitees",
-          actionParam: attrs.eventModel.id,
+          actionParam: eventModel.id,
           contents: () => label,
         });
       } else {

--- a/assets/javascripts/discourse/widgets/more-dropdown.js
+++ b/assets/javascripts/discourse/widgets/more-dropdown.js
@@ -36,10 +36,11 @@ export default createWidget("more-dropdown", {
     }
   },
 
-  _buildContent(attrs) {
+  _buildContent({ canActOnEvent, isPublicEvent, eventModel }) {
     const content = [];
+    const expiredOrClosed = eventModel.is_expired || eventModel.is_closed;
 
-    if (!attrs.eventModel.is_expired) {
+    if (!expiredOrClosed) {
       content.push({
         id: "addToCalendar",
         icon: "file",
@@ -54,30 +55,30 @@ export default createWidget("more-dropdown", {
         icon: "envelope",
         translatedLabel: I18n.t(
           "discourse_calendar.discourse_post_event.event_ui.send_pm_to_creator",
-          { username: attrs.eventModel.creator.username }
+          { username: eventModel.creator.username }
         ),
       });
     }
 
-    if (!attrs.is_expired && attrs.canActOnEvent && attrs.isPublicEvent) {
+    if (!expiredOrClosed && canActOnEvent && isPublicEvent) {
       content.push({
         id: "inviteUserOrGroup",
         icon: "user-plus",
         label: "discourse_calendar.discourse_post_event.event_ui.invite",
-        param: attrs.eventModel.id,
+        param: eventModel.id,
       });
     }
 
-    if (attrs.eventModel.watching_invitee && attrs.isPublicEvent) {
+    if (eventModel.watching_invitee && isPublicEvent) {
       content.push({
         id: "leaveEvent",
         icon: "times",
         label: "discourse_calendar.discourse_post_event.event_ui.leave",
-        param: attrs.eventModel.id,
+        param: eventModel.id,
       });
     }
 
-    if (attrs.eventModel.recurrence) {
+    if (!eventModel.is_closed && eventModel.recurrence) {
       content.push({
         id: "upcomingEvents",
         icon: "far-calendar-plus",
@@ -85,40 +86,50 @@ export default createWidget("more-dropdown", {
       });
     }
 
-    if (attrs.canActOnEvent) {
+    if (canActOnEvent) {
       content.push("separator");
 
       content.push({
         icon: "file-csv",
         id: "exportPostEvent",
         label: "discourse_calendar.discourse_post_event.event_ui.export_event",
-        param: attrs.eventModel.id,
+        param: eventModel.id,
       });
 
-      if (!attrs.eventModel.is_expired && !attrs.eventModel.is_standalone) {
+      if (!expiredOrClosed && !eventModel.is_standalone) {
         content.push({
           icon: "file-upload",
           id: "bulkInvite",
           label: "discourse_calendar.discourse_post_event.event_ui.bulk_invite",
-          param: attrs.eventModel,
+          param: eventModel,
         });
       }
 
-      content.push({
-        icon: "pencil-alt",
-        id: "editPostEvent",
-        label: "discourse_calendar.discourse_post_event.event_ui.edit_event",
-        param: attrs.eventModel.id,
-      });
-
-      if (!attrs.eventModel.is_expired) {
+      if (eventModel.is_closed) {
         content.push({
-          icon: "times",
-          id: "closeEvent",
-          label: "discourse_calendar.discourse_post_event.event_ui.close_event",
-          class: "danger",
-          param: attrs.eventModel,
+          icon: "unlock",
+          id: "openEvent",
+          label: "discourse_calendar.discourse_post_event.event_ui.open_event",
+          param: eventModel,
         });
+      } else {
+        content.push({
+          icon: "pencil-alt",
+          id: "editPostEvent",
+          label: "discourse_calendar.discourse_post_event.event_ui.edit_event",
+          param: eventModel.id,
+        });
+
+        if (!eventModel.is_expired) {
+          content.push({
+            icon: "times",
+            id: "closeEvent",
+            label:
+              "discourse_calendar.discourse_post_event.event_ui.close_event",
+            class: "danger",
+            param: eventModel,
+          });
+        }
       }
     }
 

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -133,7 +133,8 @@ $interested: #fb985d;
       }
 
       .status {
-        &.expired {
+        &.expired,
+        &.closed {
           color: var(--danger-medium);
         }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -337,6 +337,7 @@ en:
               interested: "Interested"
           event:
             expired: "Expired"
+            closed: "Closed"
             status:
               standalone:
                 title: "Standalone"
@@ -361,6 +362,7 @@ en:
           created_by: "Created by"
           bulk_invite: "Bulk Invite"
           close_event: "Close event"
+          open_event: "Open event"
         invitees_modal:
           title_invited: "List of RSVPed users"
           title_participated: "List of users who participated"
@@ -389,6 +391,7 @@ en:
           update_event_title: "Edit Event"
           confirm_delete: "Are you sure you want to delete this event?"
           confirm_close: "Are you sure you want to close this event?"
+          confirm_open: "Are you sure you want to open this event?"
           create: "Create"
           update: "Save"
           attach: "Create event"
@@ -466,6 +469,8 @@ en:
       preview:
         more_than_one_event: "You can’t have more than one event."
       edit_reason: "Event updated"
+      edit_reason_closed: "Event closed"
+      edit_reason_opened: "Event opened"
       topic_title:
         starts_at: "Event will start: %{date}"
         ended_at: "Event ended: %{date}"

--- a/db/migrate/20240513140542_add_closed_to_discourse_post_event.rb
+++ b/db/migrate/20240513140542_add_closed_to_discourse_post_event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddClosedToDiscoursePostEvent < ActiveRecord::Migration[7.0]
+  def change
+    add_column :discourse_post_event_events, :closed, :boolean, default: false, null: false
+  end
+end

--- a/lib/discourse_post_event/event_parser.rb
+++ b/lib/discourse_post_event/event_parser.rb
@@ -13,6 +13,7 @@ module DiscoursePostEvent
       :recurrence,
       :timezone,
       :minimal,
+      :closed,
     ]
 
     def self.extract_events(post)

--- a/spec/models/discourse_post_event/event_spec.rb
+++ b/spec/models/discourse_post_event/event_spec.rb
@@ -272,10 +272,10 @@ describe DiscoursePostEvent::Event do
 
     context "without ends_at date" do
       context "when starts_at < current date" do
-        it "is not ongoing" do
+        it "is ongoing" do
           post_event = Event.create!(original_starts_at: 2.hours.ago, post: first_post)
 
-          expect(post_event.ongoing?).to be(false)
+          expect(post_event.ongoing?).to be(true)
         end
       end
 
@@ -288,10 +288,10 @@ describe DiscoursePostEvent::Event do
       end
 
       context "when starts_at > current date" do
-        it "is ongoing" do
+        it "is not ongoing" do
           post_event = Event.create!(original_starts_at: 1.hours.from_now, post: first_post)
 
-          expect(post_event.ongoing?).to be(true)
+          expect(post_event.ongoing?).to be(false)
         end
       end
     end

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe "Post event", type: :system do
+  fab!(:admin)
+  let(:composer) { PageObjects::Components::Composer.new }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    sign_in(admin)
+    visit "/new-topic"
+  end
+
+  it "can create, close, and open an event" do
+    title = "My upcoming l33t event"
+    tomorrow = (Time.zone.now + 1.day).strftime("%Y-%m-%d")
+
+    composer.fill_title(title)
+
+    composer.fill_content <<~MD
+      [event start="#{tomorrow} 13:37" status="public"]
+      [/event]
+    MD
+
+    composer.submit
+
+    expect(page).to have_content(title)
+
+    page.find("#more-dropdown").click
+    page.find(".item-closeEvent").click
+    page.find("#dialog-holder .btn-primary").click
+
+    expect(page).to have_css(".discourse-post-event .status-and-creators .status.closed")
+
+    page.find("#more-dropdown").click
+    page.find(".item-openEvent").click
+    page.find("#dialog-holder .btn-primary").click
+
+    expect(page).to have_css(".discourse-post-event .status-and-creators .status.public")
+  end
+end


### PR DESCRIPTION
Adds support for "closed" events instead of just relying on the start & end dates.

An event will be "expired" when it happened in the past.

An event might now also be "closed", if for whatever reasons, the author decides to "cancel" it.

Context - https://meta.discourse.org/t/when-closing-event-it-moves-it-to-todays-date-time/307292