### PR TITLE
DEV: Tweak event text colors

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -601,7 +601,7 @@ function initializeDiscourseCalendar(api) {
 
       event.title = detail.username;
       event.backgroundColor = colorToHex(color);
-      event.textColor = colorToHex(contrastColor(color));
+      event.textColor = contrastColor(color);
     }
 
     let popupText = detail.message.slice(0, 100);

--- a/assets/javascripts/discourse/lib/colors.js
+++ b/assets/javascripts/discourse/lib/colors.js
@@ -24,11 +24,5 @@ export function colorToHex(color) {
 
 export function contrastColor(color) {
   const luminance = 0.2126 * color[0] + 0.7152 * color[1] + 0.0722 * color[2];
-  const multiplier = luminance >= 128 ? 0.25 : 4.0;
-
-  return [
-    Math.min(Math.max(multiplier * color[0], 0), 255),
-    Math.min(Math.max(multiplier * color[1], 0), 255),
-    Math.min(Math.max(multiplier * color[2], 0), 255),
-  ];
+  return luminance / 255 >= 0.5 ? "#000d" : "#fffd";
 }


### PR DESCRIPTION
…to increase contrast

Before / After

<img width="97" alt="Screenshot 2024-05-21 at 01 29 11" src="https://github.com/discourse/discourse-calendar/assets/66961/8cf545d6-227f-458e-b1b3-40f6de1dfdf3"> <img width="97" alt="Screenshot 2024-05-21 at 01 37 09" src="https://github.com/discourse/discourse-calendar/assets/66961/f13a92e4-56e0-4665-bfc3-0c2f83b38179">
<img width="98" alt="Screenshot 2024-05-21 at 01 39 13" src="https://github.com/discourse/discourse-calendar/assets/66961/d14bb6b2-9f2c-46e6-a0e9-9f27483686c8"> <img width="98" alt="Screenshot 2024-05-21 at 01 39 58" src="https://github.com/discourse/discourse-calendar/assets/66961/ff3a65d1-c1c7-4ed3-b4ec-202cff4ca384">
