### PR TITLE
DEV: update regions js and missing uae translation

### DIFF
--- a/assets/javascripts/discourse/lib/regions.js
+++ b/assets/javascripts/discourse/lib/regions.js
@@ -2,6 +2,7 @@
 // Update it by running `rake javascript:update_constants`
 
 export const HOLIDAY_REGIONS = [
+  "ae",
   "ar",
   "at",
   "au",
@@ -381,6 +382,7 @@ export const TIME_ZONE_TO_REGION = {
   "Asia/Bangkok": "th",
   "Asia/Barnaul": "ru",
   "Asia/Chita": "ru",
+  "Asia/Dubai": "ae",
   "Asia/Hong_Kong": "hk",
   "Asia/Irkutsk": "ru",
   "Asia/Jakarta": "id",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -38,6 +38,7 @@ en:
         none: "None"
         use_current_region: "Use Current Region"
         names:
+          ae: "United Arab Emirates"
           ar: "Argentina"
           at: "Austria"
           au_act: "Australia (au_act)"


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse-calendar/pull/568

Adding the required region.js addition for UAE `ae` by running `bin/rails javascript:update_constants` in Discourse root.