### PR TITLE
FIX: Move misplaced error translation

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -77,9 +77,10 @@ en:
         models:
           event:
             only_one_event: "A post can only have one event."
-            only_group: "An event accepts only group names."
             must_be_in_first_post: "An event can only be in the first post of a topic."
             raw_invitees_length: "An event is limited to %{count} users/groups."
+            raw_invitees:
+              only_group: "An event accepts only group names."
             ends_at_before_starts_at: "An event can't end before it starts."
             start_must_be_present_and_a_valid_date: "An event requires a valid start date."
             end_must_be_a_valid_date: "End date must be a valid date."


### PR DESCRIPTION
### What is this fix?

I am trying to enable `i18n.raise_on_missing_translations` in core. It caught a misplaced translation in this plugin. The key and the error message are there, but not nested in the right place.

**Before:**

```
Run options: include {:locations=>{"./plugins/discourse-calendar/spec/integration/post_spec.rb"=>[509]}}

Randomized with seed 20522
F

Failures:

  1) Post with a private event when updating raw_invitees doesn’t accept usernames
     Failure/Error:
       expect { event_1.update_with_params!(raw_invitees: [lurker_1.username]) }.to raise_error(
         ActiveRecord::RecordInvalid,
       )
     
       expected ActiveRecord::RecordInvalid, got #<I18n::MissingTranslationData: Translation missing: en.discourse_calendar.discourse_post_event.errors.models.event.raw_invitees.only_group> with backtrace:
         # ./lib/freedom_patches/translate_accelerator.rb:150:in `translate_no_override'
         # ./lib/freedom_patches/translate_accelerator.rb:227:in `translate'
         # /Users/drenmi/Workspace/Discourse/discourse-calendar/app/models/discourse_post_event/event.rb:144:in `raw_invitees_are_groups'
         # /Users/drenmi/Workspace/Discourse/discourse-calendar/app/models/discourse_post_event/event.rb:355:in `update_with_params!'
         # ./plugins/discourse-calendar/spec/integration/post_spec.rb:510:in `block (5 levels) in <main>'
         # ./plugins/discourse-calendar/spec/integration/post_spec.rb:510:in `block (4 levels) in <main>'
         # ./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'
     # ./plugins/discourse-calendar/spec/integration/post_spec.rb:510:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'

Finished in 1.53 seconds (files took 2.79 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./plugins/discourse-calendar/spec/integration/post_spec.rb:509 # Post with a private event when updating raw_invitees doesn’t accept usernames

Randomized with seed 20522
```

**After:**

```
Run options: include {:locations=>{"./plugins/discourse-calendar/spec/integration/post_spec.rb"=>[509]}}

Randomized with seed 43832
.

Finished in 1.59 seconds (files took 2.84 seconds to load)
1 example, 0 failures
```