### PR TITLE
UX: always wrap new dot and date onto same line

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
+++ b/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
@@ -1,5 +1,5 @@
 {{#if context.siteSettings.discourse_post_event_enabled}}
     {{#if context.topic.event_starts_at}}
-        {{~raw "event-date-container" topic=context.topic}}
+        {{~raw "event-date-container" topic=context.topic~}}
     {{/if}}
 {{/if}}

--- a/assets/stylesheets/common/discourse-post-event-core-ext.scss
+++ b/assets/stylesheets/common/discourse-post-event-core-ext.scss
@@ -6,6 +6,13 @@
   }
 }
 
+.link-top-line {
+  .event-date-container-wrapper {
+    // prevents new dot from breaking separately onto next line
+    white-space: nowrap;
+  }
+}
+
 .link-top-line,
 .header-title {
   .event-date {
@@ -17,6 +24,7 @@
     padding: 0 0.25em;
     border-radius: 3px;
     pointer-events: auto; // needed to show title attribute on hover
+    vertical-align: text-bottom;
 
     .indicator {
       display: flex;


### PR DESCRIPTION
before:

![image](https://github.com/discourse/discourse-calendar/assets/1681963/b9983016-aac3-42c6-b66b-164ff29fc0eb)


after:

![image](https://github.com/discourse/discourse-calendar/assets/1681963/4db5ffd1-25a3-46d9-a43f-5693d5ecb35d)
