### PR TITLE
UX: fix extra space and wrapping in topic lists

### DIFF
--- a/assets/stylesheets/common/discourse-post-event-core-ext.scss
+++ b/assets/stylesheets/common/discourse-post-event-core-ext.scss
@@ -6,10 +6,12 @@
   }
 }
 
-.link-top-line {
+.main-link {
   .event-date-container-wrapper {
     // prevents new dot from breaking separately onto next line
     white-space: nowrap;
+    // hack to hide extra whitespace in event-relative-date
+    margin-right: -0.25em;
   }
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/discourse/discourse-calendar/pull/577 that also improves this on mobile, and adds a hack to hide an extra whitespace. 

/t/128649