### PR TITLE
DEV: control whitespace, remove hack

### DIFF
--- a/assets/javascripts/discourse/components/event-date.gjs
+++ b/assets/javascripts/discourse/components/event-date.gjs
@@ -7,9 +7,9 @@ export default class EventDate extends Component {
   @service siteSettings;
 
   <template>
-    {{#if this.shouldRender}}
+    {{~#if this.shouldRender~}}
       <span class="header-topic-title-suffix-outlet event-date-container">
-        {{#if this.siteSettings.use_local_event_date}}
+        {{~#if this.siteSettings.use_local_event_date~}}
           <span
             class="event-date event-local-date past"
             title={{this.dateRange}}
@@ -25,16 +25,16 @@ export default class EventDate extends Component {
             data-starts-at={{this.eventStartedAt}}
             data-ends-at={{this.eventEndedAt}}
           >
-            {{#if this.isWithinDateRange}}
+            {{~#if this.isWithinDateRange~}}
               <span class="indicator"></span>
               <span class="text">{{this.timeRemainingContent}}</span>
             {{else}}
               {{this.relativeDateContent}}
-            {{/if}}
+            {{~/if~}}
           </span>
-        {{/if}}
+        {{~/if~}}
       </span>
-    {{/if}}
+    {{~/if~}}
   </template>
 
   get shouldRender() {

--- a/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
+++ b/assets/javascripts/discourse/connectors/topic-list-after-title/event-date.hbr
@@ -1,5 +1,5 @@
-{{#if context.siteSettings.discourse_post_event_enabled}}
-    {{#if context.topic.event_starts_at}}
+{{~#if context.siteSettings.discourse_post_event_enabled~}}
+    {{~#if context.topic.event_starts_at~}}
         {{~raw "event-date-container" topic=context.topic~}}
-    {{/if}}
-{{/if}}
+    {{~/if~}}
+{{~/if~}}

--- a/assets/stylesheets/common/discourse-post-event-core-ext.scss
+++ b/assets/stylesheets/common/discourse-post-event-core-ext.scss
@@ -10,8 +10,6 @@
   .event-date-container-wrapper {
     // prevents new dot from breaking separately onto next line
     white-space: nowrap;
-    // hack to hide extra whitespace in event-relative-date
-    margin-right: -0.25em;
   }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse-calendar/commit/9ef93a836b6a84d5341d3db24d798189ad609088

We can control the whitespace here now due to https://github.com/discourse/discourse/pull/27272/files