### PR TITLE
UX: Update mobile event styling

### DIFF
--- a/assets/stylesheets/mobile/discourse-post-event.scss
+++ b/assets/stylesheets/mobile/discourse-post-event.scss
@@ -6,7 +6,7 @@
   .event-header,
   .event-actions,
   .event-dates {
-    padding: 0 0.5em;
+    padding: 0 0.3em;
   }
 
   .event-dates {
@@ -20,6 +20,11 @@
       width: 100%;
       display: flex;
       justify-content: space-between;
+
+      button {
+        padding: 0 0.6em;
+        height: 2.5em;
+      }
     }
   }
 
@@ -27,14 +32,20 @@
     font-size: var(--font-down-1);
   }
 
-  .event-invitees .event-invitees-avatars .topic-invitee-avatar .avatar-flair {
-    background: none;
-    border-radius: 50%;
-    height: 12px;
-    width: 12px;
-    border: none;
-    right: -2px;
-    bottom: -2px;
+  .event-invitees {
+    .show-all span {
+      width: max-content;
+    }
+
+    .event-invitees-avatars .topic-invitee-avatar .avatar-flair {
+      background: none;
+      border-radius: 50%;
+      height: 12px;
+      width: 12px;
+      border: none;
+      right: -2px;
+      bottom: -2px;
+    }
   }
 
   .creators {


### PR DESCRIPTION
- Ensure event status buttons don't overflow
- Ensure `show all` button does not wrap

# Mobile - Large
![image](https://github.com/discourse/discourse-calendar/assets/50783505/743ad5b0-d8ab-40c0-ad1f-8487b5c5fbb8)

# Mobile - Small
![image](https://github.com/discourse/discourse-calendar/assets/50783505/ec9e12eb-e32c-44b1-8a41-48e93afddba0)

# Before - Mobile - Small
![image](https://github.com/discourse/discourse-calendar/assets/50783505/adb39103-cc26-48b7-884c-07750a9eb22f)
