### PR TITLE
DEV: Add upcoming Eid-Ul-Adha holiday for Ghana

### DIFF
--- a/vendor/holidays/definitions/gh.yaml
+++ b/vendor/holidays/definitions/gh.yaml
@@ -47,9 +47,8 @@ months:
   6:
   - name: Eid-ul-Adha
     regions: [gh]
-    mday: 28
-    year_ranges:
-      limited: [2023]
+    function: eid_ul_adha(year)
+    observed: to_monday_if_weekend(date)
   7:
   - name: Republic Day
     regions: [gh]
@@ -90,6 +89,14 @@ methods:
         '2024' => Date.civil(2024, 4, 11)
       }
       eid_ul_fitr_dates[year.to_s]
+  eid_ul_adha:
+    arguments: year
+    ruby: |
+      eid_ul_adha_dates = {
+        '2023' => Date.civil(2024, 6, 28)
+        '2024' => Date.civil(2024, 6, 16)
+      }
+      eid_ul_adha_dates[year.to_s]
 
 tests:
   - given:
@@ -137,7 +144,7 @@ tests:
     expect:
       name: "African Union Day"
   - given:
-      date: "2023-06-28"
+      date: ["2023-06-28","2024-06-17" ]
       regions: ["gh"]
       options: ["observed"]
     expect:

--- a/vendor/holidays/lib/generated_definitions/gh.rb
+++ b/vendor/holidays/lib/generated_definitions/gh.rb
@@ -20,7 +20,7 @@ module Holidays
       4 => [{:function => "eid_ul_fitr(year)", :function_arguments => [:year], :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Eid-ul-Fitr", :regions => [:gh]}],
       5 => [{:mday => 1, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "May Day (Workers' Day)", :regions => [:gh]},
             {:mday => 25, :type => :informal, :name => "African Union Day", :regions => [:gh]}],
-      6 => [{:mday => 28, :year_ranges => { :limited => [2023] },:name => "Eid-ul-Adha", :regions => [:gh]}],
+      6 => [{:function => "eid_ul_adha(year)", :function_arguments => [:year], :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Eid-ul-Adha", :regions => [:gh]}],
       7 => [{:mday => 1, :type => :informal, :name => "Republic Day", :regions => [:gh]}],
       8 => [{:mday => 4, :year_ranges => { :from => 2019 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Founders' Day", :regions => [:gh]}],
       9 => [{:mday => 21, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Kwame Nkrumah Memorial Day", :regions => [:gh]}],
@@ -38,6 +38,14 @@ eid_ul_fitr_dates = {
   '2024' => Date.civil(2024, 4, 11)
 }
 eid_ul_fitr_dates[year.to_s]
+},
+
+"eid_ul_adha(year)" => Proc.new { |year|
+eid_ul_adha_dates = {
+  '2023' => Date.civil(2024, 6, 28)
+  '2024' => Date.civil(2024, 6, 16)
+}
+eid_ul_adha_dates[year.to_s]
 },
 
 

--- a/vendor/holidays/test/defs/test_defs_gh.rb
+++ b/vendor/holidays/test/defs/test_defs_gh.rb
@@ -25,6 +25,7 @@ assert_equal "Eid-ul-Fitr", (Holidays.on(Date.civil(2024, 4, 11), [:gh], [:obser
     assert_equal "African Union Day", (Holidays.on(Date.civil(2022, 5, 25), [:gh], [:informal])[0] || {})[:name]
 
     assert_equal "Eid-ul-Adha", (Holidays.on(Date.civil(2023, 6, 28), [:gh], [:observed])[0] || {})[:name]
+assert_equal "Eid-ul-Adha", (Holidays.on(Date.civil(2024, 6, 17), [:gh], [:observed])[0] || {})[:name]
 
     assert_equal "Republic Day", (Holidays.on(Date.civil(2022, 7, 1), [:gh], [:informal])[0] || {})[:name]
 


### PR DESCRIPTION
See https://www.mint.gov.gh/declaration-of-monday-17th-june-2024-as-a-public-holiday/