### PR TITLE
Add upcoming Saudi holidays (Eid Al Adha)

### DIFF
--- a/vendor/holidays/definitions/sa.yaml
+++ b/vendor/holidays/definitions/sa.yaml
@@ -56,45 +56,24 @@ months:
   6:
   - name: Day of Arafah
     regions: [sa]
-    mday: 27
+    mday: 15
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   - name: Day 1 of Eid Al Adha
     regions: [sa]
-    mday: 28
+    mday: 16
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   - name: Day 2 of Eid Al Adha
     regions: [sa]
-    mday: 29
+    mday: 17
     year_ranges:
-      limited: [2023]
+      limited: [2024]
   - name: Day 3 of Eid Al Adha
     regions: [sa]
-    mday: 30
+    mday: 18
     year_ranges:
-      limited: [2023]
-  7:
-  - name: Day of Arafah
-    regions: [sa]
-    mday: 8
-    year_ranges:
-      limited: [2022]
-  - name: Day 1 of Eid Al Adha
-    regions: [sa]
-    mday: 9
-    year_ranges:
-      limited: [2022]
-  - name: Day 2 of Eid Al Adha
-    regions: [sa]
-    mday: 10
-    year_ranges:
-      limited: [2022]
-  - name: Day 3 of Eid Al Adha
-    regions: [sa]
-    mday: 11
-    year_ranges:
-      limited: [2022]
+      limited: [2024]
   9:
   - name: Saudi National Day
     regions: [sa]

--- a/vendor/holidays/lib/generated_definitions/sa.rb
+++ b/vendor/holidays/lib/generated_definitions/sa.rb
@@ -22,14 +22,10 @@ module Holidays
       5 => [{:mday => 2, :year_ranges => { :limited => [2022] },:name => "Festival of Breaking the Fast", :regions => [:sa]},
             {:mday => 3, :year_ranges => { :limited => [2022] },:name => "Second Day of the Festival of Breaking the Fast", :regions => [:sa]},
             {:mday => 4, :year_ranges => { :limited => [2022] },:name => "Third Day of the Festival of Breaking the Fast", :regions => [:sa]}],
-      6 => [{:mday => 27, :year_ranges => { :limited => [2023] },:name => "Day of Arafah", :regions => [:sa]},
-            {:mday => 28, :year_ranges => { :limited => [2023] },:name => "Day 1 of Eid Al Adha", :regions => [:sa]},
-            {:mday => 29, :year_ranges => { :limited => [2023] },:name => "Day 2 of Eid Al Adha", :regions => [:sa]},
-            {:mday => 30, :year_ranges => { :limited => [2023] },:name => "Day 3 of Eid Al Adha", :regions => [:sa]}],
-      7 => [{:mday => 8, :year_ranges => { :limited => [2022] },:name => "Day of Arafah", :regions => [:sa]},
-            {:mday => 9, :year_ranges => { :limited => [2022] },:name => "Day 1 of Eid Al Adha", :regions => [:sa]},
-            {:mday => 10, :year_ranges => { :limited => [2022] },:name => "Day 2 of Eid Al Adha", :regions => [:sa]},
-            {:mday => 11, :year_ranges => { :limited => [2022] },:name => "Day 3 of Eid Al Adha", :regions => [:sa]}],
+      6 => [{:mday => 15, :year_ranges => { :limited => [2024] },:name => "Day of Arafah", :regions => [:sa]},
+            {:mday => 16, :year_ranges => { :limited => [2024] },:name => "Day 1 of Eid Al Adha", :regions => [:sa]},
+            {:mday => 17, :year_ranges => { :limited => [2024] },:name => "Day 2 of Eid Al Adha", :regions => [:sa]},
+            {:mday => 18, :year_ranges => { :limited => [2024] },:name => "Day 3 of Eid Al Adha", :regions => [:sa]}],
       9 => [{:mday => 23, :name => "Saudi National Day", :regions => [:sa]}]
       }
     end


### PR DESCRIPTION
The 15th of June to the 18th of June of 2024 is a public holiday in Saudi Arabia as per https://holidayapi.com/countries/sa/2024.