### PR TITLE
FIX: fix i18n in upcoming-events

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -7,6 +7,22 @@ import getURL from "discourse-common/lib/get-url";
 import { formatEventName } from "../helpers/format-event-name";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 import { buildPopover, destroyPopover } from "../lib/popover";
+import I18n from "I18n";
+
+function getCurrentBcp47Locale() {
+  return I18n.currentLocale().replace("_", "-");
+}
+
+function getCalendarButtonsText() {
+  return {
+    today: I18n.t("discourse_calendar.toolbar_button.today"),
+    month: I18n.t("discourse_calendar.toolbar_button.month"),
+    week: I18n.t("discourse_calendar.toolbar_button.week"),
+    day: I18n.t("discourse_calendar.toolbar_button.day"),
+    list: I18n.t("discourse_calendar.toolbar_button.list"),
+  };
+}
+
 
 export default Component.extend({
   tagName: "",
@@ -95,6 +111,8 @@ export default Component.extend({
         eventMouseLeave: function () {
           destroyPopover();
         },
+        locale: getCurrentBcp47Locale(),
+        buttonText: getCalendarButtonsText(),
       });
       this._calendar = fullCalendar;
 

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -4,10 +4,10 @@ import { Promise } from "rsvp";
 import loadScript from "discourse/lib/load-script";
 import Category from "discourse/models/category";
 import getURL from "discourse-common/lib/get-url";
+import I18n from "I18n";
 import { formatEventName } from "../helpers/format-event-name";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 import { buildPopover, destroyPopover } from "../lib/popover";
-import I18n from "I18n";
 
 function getCurrentBcp47Locale() {
   return I18n.currentLocale().replace("_", "-");


### PR DESCRIPTION
See https://meta.discourse.org/t/broken-no-i18n-in-calendar-plugin-upcoming-events-route/313745

This is a somewhat dirty fix, simply copying the functionality from `discourse-calendar.js` over to `upcoming-events-calendar.js`, but should at least solve the problem.