### PR TITLE
UX: fix group timezone layout in Safari

### DIFF
--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -197,10 +197,9 @@ a.holiday {
 }
 
 .group-timezones {
-  display: flex;
+  display: grid;
   width: 100%;
   box-sizing: border-box;
-  flex-direction: column;
 
   &[data-size="auto"],
   &.auto {
@@ -383,8 +382,9 @@ a.holiday {
         &.on-holiday::after {
           content: "📅";
           position: absolute;
-          bottom: -8px;
-          left: 14px;
+          bottom: -0.15em;
+          left: 1em;
+          font-size: var(--font-down-2);
         }
       }
     }


### PR DESCRIPTION
Something about Safari really doesn't like that this grid is wrapped with flex, and it makes the rows very tall — using grid as the wrapper instead fixes this.

I also adjusted the calendar icons to be a little smaller to avoid causing horizontal overflow. 

Before:
![image](https://github.com/user-attachments/assets/60b8c936-ecaf-44e6-9268-8eba3bff3ee3)


After:
![image](https://github.com/user-attachments/assets/aae9eda3-e310-41e9-ab58-65a48bb34bb3)
