### PR TITLE
UX: Add I18n translations for upcoming events

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -5,6 +5,10 @@ import loadScript from "discourse/lib/load-script";
 import Category from "discourse/models/category";
 import getURL from "discourse-common/lib/get-url";
 import { formatEventName } from "../helpers/format-event-name";
+import {
+  getCalendarButtonsText,
+  getCurrentBcp47Locale,
+} from "../lib/calendar-locale";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 import { buildPopover, destroyPopover } from "../lib/popover";
 
@@ -59,6 +63,8 @@ export default Component.extend({
 
     this._loadCalendar().then(() => {
       const fullCalendar = new window.FullCalendar.Calendar(calendarNode, {
+        locale: getCurrentBcp47Locale(),
+        buttonText: getCalendarButtonsText(),
         eventClick: function () {
           destroyPopover();
         },

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -12,6 +12,10 @@ import getURL from "discourse-common/lib/get-url";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "I18n";
 import { formatEventName } from "../helpers/format-event-name";
+import {
+  getCalendarButtonsText,
+  getCurrentBcp47Locale,
+} from "../lib/calendar-locale";
 import { colorToHex, contrastColor, stringToColor } from "../lib/colors";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 import { buildPopover, destroyPopover } from "../lib/popover";
@@ -20,20 +24,6 @@ function loadFullCalendar() {
   return loadScript(
     "/plugins/discourse-calendar/javascripts/fullcalendar-with-moment-timezone.min.js"
   );
-}
-
-function getCurrentBcp47Locale() {
-  return I18n.currentLocale().replace("_", "-");
-}
-
-function getCalendarButtonsText() {
-  return {
-    today: I18n.t("discourse_calendar.toolbar_button.today"),
-    month: I18n.t("discourse_calendar.toolbar_button.month"),
-    week: I18n.t("discourse_calendar.toolbar_button.week"),
-    day: I18n.t("discourse_calendar.toolbar_button.day"),
-    list: I18n.t("discourse_calendar.toolbar_button.list"),
-  };
 }
 
 function initializeDiscourseCalendar(api) {

--- a/assets/javascripts/discourse/lib/calendar-locale.js
+++ b/assets/javascripts/discourse/lib/calendar-locale.js
@@ -1,0 +1,15 @@
+import I18n from "I18n";
+
+export function getCurrentBcp47Locale() {
+  return I18n.currentLocale().replace("_", "-");
+}
+
+export function getCalendarButtonsText() {
+  return {
+    today: I18n.t("discourse_calendar.toolbar_button.today"),
+    month: I18n.t("discourse_calendar.toolbar_button.month"),
+    week: I18n.t("discourse_calendar.toolbar_button.week"),
+    day: I18n.t("discourse_calendar.toolbar_button.day"),
+    list: I18n.t("discourse_calendar.toolbar_button.list"),
+  };
+}


### PR DESCRIPTION
Our old implementation was missing I18n for calendars in upcoming-events, this commit fixes it.

Related meta topic: https://meta.discourse.org/t/broken-no-i18n-in-calendar-plugin-upcoming-events-route/313745/2

## Screenshot

before:
![image](https://github.com/user-attachments/assets/70cfda54-dbb4-49a0-a059-e292954029cd)

after:
![image](https://github.com/user-attachments/assets/d3b6cfbf-6dc3-4066-93c4-a35f70a57557)
