### PR TITLE
DEV: Extract common calendar options

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -5,8 +5,8 @@ import loadScript from "discourse/lib/load-script";
 import Category from "discourse/models/category";
 import getURL from "discourse-common/lib/get-url";
 import { formatEventName } from "../helpers/format-event-name";
+import fullCalendarDefaultOptions from "../lib/full-calendar-default-options";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
-import fullCalendarDefaultOptions from "./full-calendar-default-options";
 
 export default Component.extend({
   tagName: "",

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -11,9 +11,9 @@ import Category from "discourse/models/category";
 import getURL from "discourse-common/lib/get-url";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "I18n";
-import fullCalendarDefaultOptions from "../components/full-calendar-default-options";
 import { formatEventName } from "../helpers/format-event-name";
 import { colorToHex, contrastColor, stringToColor } from "../lib/colors";
+import fullCalendarDefaultOptions from "../lib/full-calendar-default-options";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 import { buildPopover, destroyPopover } from "../lib/popover";
 

--- a/assets/javascripts/discourse/lib/calendar-locale.js
+++ b/assets/javascripts/discourse/lib/calendar-locale.js
@@ -1,7 +1,7 @@
 import I18n from "I18n";
 
 export function getCurrentBcp47Locale() {
-  return I18n.currentLocale().replace("_", "-");
+  return I18n.currentLocale().replace("_", "-").toLowerCase();
 }
 
 export function getCalendarButtonsText() {

--- a/assets/javascripts/discourse/lib/full-calendar-default-options.js
+++ b/assets/javascripts/discourse/lib/full-calendar-default-options.js
@@ -1,8 +1,8 @@
 import {
   getCalendarButtonsText,
   getCurrentBcp47Locale,
-} from "../lib/calendar-locale";
-import { buildPopover, destroyPopover } from "../lib/popover";
+} from "./calendar-locale";
+import { buildPopover, destroyPopover } from "./popover";
 
 export default function fullCalendarDefaultOptions() {
   return {


### PR DESCRIPTION
We use the FullCalendar library for this plugin, but certain fixed options are repeated across files. This change consolidates these options, and should introduce consistency.

This also includes a more compatible setting for the locale (referring to example: https://github.com/fullcalendar/fullcalendar/blob/v4.0.0-alpha.3/locales/en-gb.js, "en_GB" -> "en-gb") but it doesn't seem to set the first day correctly. This change also allows for a future improvement which allows correctly* setting of the first day of the week, outside of FullCalendar's default which doesn't seem to reflect correctly.

A future change would include updating us to fullcalendar v6.