### PR TITLE
UX: Allow event time to be hidden if desired

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -183,7 +183,7 @@ export default class UpcomingEventsList extends Component {
                       >
                         {{#if this.timeFormat}}
                           <div class="upcoming-events-list__event-time">
-                            {{this.timeFormat event}}
+                            {{this.formatTime event}}
                           </div>
                         {{/if}}
 

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -181,9 +181,12 @@ export default class UpcomingEventsList extends Component {
                         class="upcoming-events-list__event"
                         href={{event.post.url}}
                       >
-                        <div class="upcoming-events-list__event-time">
-                          {{this.formatTime event}}
-                        </div>
+                        {{#if this.timeFormat}}
+                          <div class="upcoming-events-list__event-time">
+                            {{this.timeFormat event}}
+                          </div>
+                        {{/if}}
+
                         <div class="upcoming-events-list__event-name">
                           {{or event.name event.post.topic.title}}
                         </div>

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -237,15 +237,13 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     await waitFor(".loading-container .spinner", { count: 0 });
 
-    assert.ok(
-      !exists(".upcoming-events-list__formatted-month"),
-      "it omits the formatted month when empty"
-    );
+    assert
+      .dom(".upcoming-events-list__formatted-month")
+      .doesNotExist("it omits the formatted month when empty");
 
-    assert.ok(
-      !exists(".upcoming-events-list__formatted-time"),
-      "it omits the formatted time when empty"
-    );
+    assert
+      .dom(".upcoming-events-list__formatted-time")
+      .doesNotExist("it omits the formatted time when empty");
   });
 
   test("with an error response", async function (assert) {

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -189,11 +189,6 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     await waitFor(".loading-container .spinner", { count: 0 });
 
-    assert.ok(
-      !exists(".upcoming-events-list__formatted-month"),
-      "it omits the formatted month when empty"
-    );
-
     assert.deepEqual(
       [...queryAll(".upcoming-events-list__formatted-day")].map(
         (el) => el.innerText
@@ -221,6 +216,35 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
       ),
       ["Awesome Event", "Another Awesome Event"],
       "it displays the event name"
+    );
+  });
+
+  test("with events, omitted formats", async function (assert) {
+    pretender.get("/discourse-post-event/events", twoEventsResponseHandler);
+    await render(<template>
+      <UpcomingEventsList @params={{hash monthFormat="" timeFormat=""}} />
+    </template>);
+
+    this.appEvents.trigger("page:changed", { url: "/" });
+
+    assert.strictEqual(
+      query(".upcoming-events-list__heading").innerText,
+      I18n.t(
+        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
+      ),
+      "it displays the title"
+    );
+
+    await waitFor(".loading-container .spinner", { count: 0 });
+
+    assert.ok(
+      !exists(".upcoming-events-list__formatted-month"),
+      "it omits the formatted month when empty"
+    );
+
+    assert.ok(
+      !exists(".upcoming-events-list__formatted-time"),
+      "it omits the formatted time when empty"
     );
   });
 

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -227,13 +227,14 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     this.appEvents.trigger("page:changed", { url: "/" });
 
-    assert.strictEqual(
-      query(".upcoming-events-list__heading").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-      ),
-      "it displays the title"
-    );
+    assert
+      .dom(".upcoming-events-list__heading")
+      .hasText(
+        I18n.t(
+          "discourse_calendar.discourse_post_event.upcoming_events_list.title"
+        ),
+        "it displays the title"
+      );
 
     await waitFor(".loading-container .spinner", { count: 0 });
 


### PR DESCRIPTION
This is already the case for `monthFormat`. A blank `timeFormat` field results in a neater-looking list, if desired:

<img width="333" alt="no_time_value" src="https://github.com/user-attachments/assets/ee7f9d09-e5d3-4de5-a15c-fcf10ba93b60">
