### PR TITLE
DEV: Adds ability to see multiday events in sidebar

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -107,9 +107,6 @@ export default class UpcomingEventsList extends Component {
   }
 
   groupByMonthAndDay(data) {
-    // this solution worked in the UI, but 5 tests fail
-    // note: does not work if no end date is added to event object
-
     return data.reduce((result, item) => {
       const startDate = moment(item.starts_at);
       const endDate = item.ends_at ? moment(item.ends_at) : null;
@@ -120,11 +117,15 @@ export default class UpcomingEventsList extends Component {
           const month = startDate.month() + 1;
           const day = startDate.date();
           const monthKey = `${year}-${month}`;
+          const today = moment();
 
-          result[monthKey] = result[monthKey] || {};
-          result[monthKey][day] = result[monthKey][day] || [];
+          // For current events, only push upcoming days
+          if (startDate.isAfter(today)) {
+            result[monthKey] = result[monthKey] || {};
+            result[monthKey][day] = result[monthKey][day] || [];
 
-          result[monthKey][day].push(item);
+            result[monthKey][day].push(item);
+          }
 
           // Move to the next day
           startDate.add(1, "day");

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -110,23 +110,26 @@ export default class UpcomingEventsList extends Component {
     return data.reduce((result, item) => {
       const startDate = moment(item.starts_at);
       const endDate = moment(item.ends_at);
-      const year = date.getFullYear();
-      const month = date.getMonth() + 1;
-      const day = date.getDate();
-      const monthKey = `${year}-${month}`;
 
-      if (startDate.isSameOrBefore(endDate, "day")) {
+      while (
+        startDate.isSameOrBefore(endDate, "day") &&
+        Object.keys(result).length <= 5 // closer, but still only seeing 1 result in the object.keys...
+      ) {
+        const year = startDate.year();
+        const month = startDate.month() + 1;
+        const day = startDate.date();
+        const monthKey = `${year}-${month}`;
+
+        result[monthKey] = result[monthKey] || {};
+        result[monthKey][day] = result[monthKey][day] || [];
+
         result[monthKey][day].push(item);
 
         // Move to the next day
         startDate.add(1, "day");
       }
 
-      result[monthKey] = result[monthKey] ?? {};
-      result[monthKey][day] = result[monthKey][day] ?? [];
-
-      result[monthKey][day].push(item);
-
+      console.log(Object.keys(result).length);
       return result;
     }, {});
   }

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -112,9 +112,9 @@ export default class UpcomingEventsList extends Component {
 
     return data.reduce((result, item) => {
       const startDate = moment(item.starts_at);
-      const endDate = moment(item.ends_at);
+      const endDate = item.ends_at ? moment(item.ends_at) : null;
 
-      if (!startDate.isSame(endDate)) {
+      if (endDate && !startDate.isSame(endDate)) {
         while (startDate.isSameOrBefore(endDate, "day")) {
           const year = startDate.year();
           const month = startDate.month() + 1;

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -108,12 +108,19 @@ export default class UpcomingEventsList extends Component {
 
   groupByMonthAndDay(data) {
     return data.reduce((result, item) => {
-      const date = new Date(item.starts_at);
+      const startDate = moment(item.starts_at);
+      const endDate = moment(item.ends_at);
       const year = date.getFullYear();
       const month = date.getMonth() + 1;
       const day = date.getDate();
-
       const monthKey = `${year}-${month}`;
+
+      if (startDate.isSameOrBefore(endDate, "day")) {
+        result[monthKey][day].push(item);
+
+        // Move to the next day
+        startDate.add(1, "day");
+      }
 
       result[monthKey] = result[monthKey] ?? {};
       result[monthKey][day] = result[monthKey][day] ?? [];
@@ -164,6 +171,7 @@ export default class UpcomingEventsList extends Component {
                   <div class="upcoming-events-list__day-section">
                     <div class="upcoming-events-list__formatted-day">
                       {{this.formatDate month day}}
+                      {{log events}}
                     </div>
 
                     {{#each events as |event|}}

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -27,6 +27,7 @@ class RouterStub extends Service {
 const today = "2100-02-01T08:00:00";
 const tomorrowAllDay = "2100-02-02T00:00:00";
 const nextMonth = "2100-03-02T08:00:00";
+const nextWeek = "2100-02-09T08:00:00";
 
 module("Integration | Component | upcoming-events-list", function (hooks) {
   setupRenderingTest(hooks);
@@ -147,16 +148,18 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
       [...queryAll(".upcoming-events-list__event-name")].map(
         (el) => el.innerText
       ),
-      ["Awesome Event", "Another Awesome Event"],
-      "it displays the multiday event on all scheduled dates"
-    );
+      [
+        "Awesome Multiday Event",
+        "Awesome Multiday Event",
+        "Awesome Multiday Event",
+        "Awesome Multiday Event",
+        "Awesome Multiday Event",
+        "Awesome Multiday Event",
+        "Awesome Multiday Event",
+        "Awesome Multiday Event",
+      ],
 
-    assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-name")].map(
-        (el) => el.innerText
-      ),
-      ["Awesome Event", "Another Awesome Event"],
-      "it displays the multiday event that has two different months"
+      "it displays the multiday event on all scheduled dates"
     );
   });
 
@@ -402,7 +405,7 @@ function multiDayEventResponseHandler({ queryParams }) {
     {
       id: 67503,
       starts_at: tomorrowAllDay,
-      ends_at: nextMonth,
+      ends_at: nextWeek,
       timezone: "Asia/Calcutta",
       post: {
         id: 67501,
@@ -413,7 +416,7 @@ function multiDayEventResponseHandler({ queryParams }) {
           title: "This is a multiday event",
         },
       },
-      name: "Awesome MultiDay Event",
+      name: "Awesome Multiday Event",
       category_id: 1,
     },
   ];

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -132,6 +132,35 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
       exists(".upcoming-events-list__view-all"),
       "it displays the view-all link"
     );
+
+    test("with multi-day events, standard formats", async function (assert) {
+      pretender.get(
+        "/discourse-post-event/events",
+        multiDayEventResponseHandler
+      );
+
+      await render(<template><UpcomingEventsList /></template>);
+
+      this.appEvents.trigger("page:changed", { url: "/" });
+
+      await waitFor(".loading-container .spinner", { count: 0 });
+
+      assert.deepEqual(
+        [...queryAll(".upcoming-events-list__event-name")].map(
+          (el) => el.innerText
+        ),
+        ["Awesome Event", "Another Awesome Event"],
+        "it displays the multiday event on all scheduled dates"
+      );
+
+      assert.deepEqual(
+        [...queryAll(".upcoming-events-list__event-name")].map(
+          (el) => el.innerText
+        ),
+        ["Awesome Event", "Another Awesome Event"],
+        "it displays the multiday event that has two different months"
+      );
+    });
   });
 
   test("with events, view-all navigation", async function (assert) {
@@ -355,6 +384,40 @@ function twoEventsResponseHandler({ queryParams }) {
       },
       name: "Another Awesome Event",
       category_id: 2,
+    },
+  ];
+
+  if (queryParams.limit) {
+    events.splice(queryParams.limit);
+  }
+
+  if (queryParams.before) {
+    events = events.filter((event) => {
+      return moment(event.starts_at).isBefore(queryParams.before);
+    });
+  }
+
+  return response({ events });
+}
+
+function multiDayEventResponseHandler({ queryParams }) {
+  let events = [
+    {
+      id: 67503,
+      starts_at: tomorrowAllDay,
+      ends_at: nextMonth,
+      timezone: "Asia/Calcutta",
+      post: {
+        id: 67501,
+        post_number: 1,
+        url: "/t/this-is-an-event/18451/1",
+        topic: {
+          id: 18449,
+          title: "This is a multiday event",
+        },
+      },
+      name: "Awesome MultiDay Event",
+      category_id: 1,
     },
   ];
 

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -132,35 +132,32 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
       exists(".upcoming-events-list__view-all"),
       "it displays the view-all link"
     );
+  });
 
-    test("with multi-day events, standard formats", async function (assert) {
-      pretender.get(
-        "/discourse-post-event/events",
-        multiDayEventResponseHandler
-      );
+  test("with multi-day events, standard formats", async function (assert) {
+    pretender.get("/discourse-post-event/events", multiDayEventResponseHandler);
 
-      await render(<template><UpcomingEventsList /></template>);
+    await render(<template><UpcomingEventsList /></template>);
 
-      this.appEvents.trigger("page:changed", { url: "/" });
+    this.appEvents.trigger("page:changed", { url: "/" });
 
-      await waitFor(".loading-container .spinner", { count: 0 });
+    await waitFor(".loading-container .spinner", { count: 0 });
 
-      assert.deepEqual(
-        [...queryAll(".upcoming-events-list__event-name")].map(
-          (el) => el.innerText
-        ),
-        ["Awesome Event", "Another Awesome Event"],
-        "it displays the multiday event on all scheduled dates"
-      );
+    assert.deepEqual(
+      [...queryAll(".upcoming-events-list__event-name")].map(
+        (el) => el.innerText
+      ),
+      ["Awesome Event", "Another Awesome Event"],
+      "it displays the multiday event on all scheduled dates"
+    );
 
-      assert.deepEqual(
-        [...queryAll(".upcoming-events-list__event-name")].map(
-          (el) => el.innerText
-        ),
-        ["Awesome Event", "Another Awesome Event"],
-        "it displays the multiday event that has two different months"
-      );
-    });
+    assert.deepEqual(
+      [...queryAll(".upcoming-events-list__event-name")].map(
+        (el) => el.innerText
+      ),
+      ["Awesome Event", "Another Awesome Event"],
+      "it displays the multiday event that has two different months"
+    );
   });
 
   test("with events, view-all navigation", async function (assert) {


### PR DESCRIPTION
(This PR refers to the [interactivity](https://meta.discourse.org/t/discourse-calendar-and-event/97376#p-473517-integrations-with-other-plugins-7) between the discourse-calendar plugin and the right-sidebar-blocks component.)

As of now, only the first day of an event gets listed in the Upcoming Events sidebar. So if the event is from `10-22-2024 to 10-26-2024,` only the 22nd would have the event on it. On the 23rd, you wouldn't know the event was still happening.

Before:
![Screenshot 2024-10-28 at 1 47 38 PM](https://github.com/user-attachments/assets/6602b3c7-e5ba-4541-b326-70046ce021af)
(Note that this screenshot was taken on October 28th, and the event's start date shows up)

After:
![Screenshot 2024-10-28 at 1 36 43 PM](https://github.com/user-attachments/assets/0a1fe1d5-60d1-4d50-9b05-2af828b147cd)
(Taken on the same day, so only the remaining event days show up)

I tested this with both single-day events and multi-day events. We might need to add a limit on the number of results we get back. (If someone throws in a month-long event, it'll get real hairy real quick.) I have some ideas, but I'm not positive of the best place to put that limiter. Ideas welcome!