### PR TITLE
UX: prioritize events with high participant counts

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -372,7 +372,14 @@ function initializeDiscourseCalendar(api) {
         center: "title",
         right: "month,basicWeek,listNextYear",
       },
-      eventOrder: ["start", _orderByTz, "-duration", "allDay", "title"],
+      eventOrder: [
+        "start",
+        _orderByTz,
+        "-participantCount",
+        "-duration",
+        "allDay",
+        "title",
+      ],
       datesRender: (info) => {
         if (showAddToCalendar) {
           _insertAddToCalendarLinks(info);
@@ -584,6 +591,7 @@ function initializeDiscourseCalendar(api) {
     }
     event.extendedProps.htmlContent = escape(popupText);
     event.title = event.title.replace(/<img[^>]*>/g, "");
+    event.participantCount = 1;
     calendar.addEvent(event);
   }
 
@@ -634,6 +642,8 @@ function initializeDiscourseCalendar(api) {
           event.extendedProps.htmlContent = localEventNames[0];
         }
       }
+
+      event.participantCount = users.length;
 
       calendar.addEvent(event);
     });


### PR DESCRIPTION
This adds another priority: participant count, so events with multiple participants aren't buried under single-participant events in cases where there's a long list of multi-day events.

This is particularly useful for an employee leave/holiday calendar with automatic holidays enabled. Currently if there are many individuals with multi-day leave, this can bury a holiday even if it has many more participants. 

Before (multi-day events above multi-participant events):
![image](https://github.com/user-attachments/assets/894bcf52-db45-4251-8b2d-e8ef5279e6fe)


After (multi-participant events get priority, then multi-day events):
![image](https://github.com/user-attachments/assets/b47013af-8590-4475-b10f-e9ec6fbc4ddb)
