### PR TITLE
FIX: shows category calendar on hot/latest

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -66,7 +66,9 @@ function initializeDiscourseCalendar(api) {
       return;
     }
 
-    const browsedCategory = Category.findBySlugPathWithID(route.params.category_slug_path_with_id);
+    const browsedCategory = Category.findBySlugPathWithID(
+      route.params.category_slug_path_with_id
+    );
     if (!browsedCategory) {
       return;
     }

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -39,6 +39,8 @@ function initializeDiscourseCalendar(api) {
   const site = api.container.lookup("service:site");
   const isMobileView = site && site.mobileView;
 
+  const router = api.container.lookup("service:router");
+
   let selector = `.${outletName}-outlet`;
   if (outletName === "before-topic-list-body") {
     selector = `.topic-list:not(.shared-drafts) .${outletName}-outlet`;
@@ -59,7 +61,12 @@ function initializeDiscourseCalendar(api) {
       categoryEventNode.innerHTML = "";
     }
 
-    const browsedCategory = Category.findBySlugPathWithID(url.split("?")[0]);
+    const route = router.recognize(url);
+    if (!route?.params?.category_slug_path_with_id) {
+      return;
+    }
+
+    const browsedCategory = Category.findBySlugPathWithID(route.params.category_slug_path_with_id);
     if (!browsedCategory) {
       return;
     }

--- a/spec/system/category_calendar_spec.rb
+++ b/spec/system/category_calendar_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe "Post event", type: :system do
+  fab!(:admin)
+  fab!(:category)
+
+  let(:category_page) { PageObjects::Pages::Category.new }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.events_calendar_categories = category.id.to_s
+    sign_in(admin)
+  end
+
+  it "shows the calendar on the category page" do
+    category_page.visit(category)
+
+    expect(category_page).to have_selector("#category-events-calendar.fc")
+
+    find(".nav-item_hot").click
+
+    expect(category_page).to have_selector("#category-events-calendar.fc")
+
+    find(".nav-item_latest").click
+
+    expect(category_page).to have_selector("#category-events-calendar.fc")
+  end
+end

--- a/spec/system/category_calendar_spec.rb
+++ b/spec/system/category_calendar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Post event", type: :system do
+describe "Category calendar", type: :system do
   fab!(:admin)
   fab!(:category)
 


### PR DESCRIPTION
The previous URL parsing code was not resilient to these paths, we now use the router to recognize these paths and extract the params we need.