### PR TITLE
FEATURE: suppress interested and not going buttons by default

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/creator.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/creator.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import avatar from "discourse/helpers/avatar";
 import { formatUsername } from "discourse/lib/utilities";
+import i18n from "discourse-common/helpers/i18n";
 
 export default class DiscoursePostEventCreator extends Component {
   get username() {
@@ -8,11 +9,17 @@ export default class DiscoursePostEventCreator extends Component {
   }
 
   <template>
-    <span class="event-creator">
-      <a class="topic-invitee-avatar" data-user-card={{@user.username}}>
-        {{avatar @user imageSize="tiny"}}
-        <span class="username">{{this.username}}</span>
-      </a>
+    <span class="creators">
+      <span class="created-by">{{i18n
+          "discourse_calendar.discourse_post_event.event_ui.created_by"
+        }}</span>
+
+      <span class="event-creator">
+        <a class="topic-invitee-avatar" data-user-card={{@user.username}}>
+          {{avatar @user imageSize="tiny"}}
+          <span class="username">{{this.username}}</span>
+        </a>
+      </span>
     </span>
   </template>
 }

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -77,7 +77,7 @@ export default class DiscoursePostEventDates extends Component {
 
   <template>
     <section
-      class="event-dates"
+      class="event__section event-dates"
       {{didInsert this.computeDates}}
     >{{this.htmlDates}}</section>
   </template>

--- a/assets/javascripts/discourse/components/discourse-post-event/event-status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/event-status.gjs
@@ -1,0 +1,36 @@
+import Component from "@glimmer/component";
+import i18n from "discourse-common/helpers/i18n";
+
+export default class EventStatus extends Component {
+  get eventStatusLabel() {
+    return i18n(
+      `discourse_calendar.discourse_post_event.models.event.status.${this.args.event.status}.title`
+    );
+  }
+
+  get eventStatusDescription() {
+    return i18n(
+      `discourse_calendar.discourse_post_event.models.event.status.${this.args.event.status}.description`
+    );
+  }
+
+  get statusClass() {
+    return `status ${this.args.event.status}`;
+  }
+
+  <template>
+    {{#if @event.isExpired}}
+      <span class="status expired">
+        {{i18n "discourse_calendar.discourse_post_event.models.event.expired"}}
+      </span>
+    {{else if @event.isClosed}}
+      <span class="status closed">
+        {{i18n "discourse_calendar.discourse_post_event.models.event.closed"}}
+      </span>
+    {{else}}
+      <span class={{this.statusClass}} title={{this.eventStatusDescription}}>
+        {{this.eventStatusLabel}}
+      </span>
+    {{/if}}
+  </template>
+}

--- a/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { concat, hash } from "@ember/helper";
+import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -18,7 +18,6 @@ import Url from "./url";
 
 const StatusSeparator = <template><span class="separator">·</span></template>;
 
-const InfoSeparator = <template><hr /></template>;
 const InfoSection = <template>
   <section class="event__section" ...attributes>
     {{#if @icon}}

--- a/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 import { modifier } from "ember-modifier";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
@@ -76,39 +75,12 @@ export default class DiscoursePostEvent extends Component {
     return this.currentUser && this.args.event.can_act_on_discourse_post_event;
   }
 
-  get containerHeight() {
-    const datesHeight = 50;
-    const urlHeight = 50;
-    const headerHeight = 75;
-    const bordersHeight = 10;
-    const separatorsHeight = 4;
-    const margins = 10;
-
-    let widgetHeight =
-      datesHeight + headerHeight + bordersHeight + separatorsHeight + margins;
-
-    if (this.args.event.shouldDisplayInvitees && !this.args.event.minimal) {
-      widgetHeight += 110;
-    }
-
-    if (this.args.event.canUpdateAttendance) {
-      widgetHeight += 60;
-    }
-
-    if (this.args.event.url) {
-      widgetHeight += urlHeight;
-    }
-
-    return htmlSafe(`height: ${widgetHeight}px`);
-  }
-
   <template>
     <div
       class={{concatClass
         "discourse-post-event"
         (if @event "is-loaded" "is-loading")
       }}
-      style={{this.containerHeight}}
     >
       <div class="discourse-post-event-widget">
         {{#if @event}}

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -23,8 +23,9 @@ export default class DiscoursePostEventInvitees extends Component {
 
   get statsInfo() {
     const stats = [];
-    const visibleStats =
-      this.siteSettings.event_participation_buttons.split("|");
+    const visibleStats = this.siteSettings.event_participation_buttons
+      .split("|")
+      .filter(Boolean);
 
     if (this.args.event.isPrivate) {
       visibleStats.push("invited");

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -8,6 +8,7 @@ import Invitee from "./invitee";
 
 export default class DiscoursePostEventInvitees extends Component {
   @service modal;
+  @service siteSettings;
 
   @action
   showAllInvitees() {
@@ -20,29 +21,48 @@ export default class DiscoursePostEventInvitees extends Component {
     });
   }
 
+  get statusButtons() {
+    const buttons = [];
+    const allowed_buttons =
+      this.siteSettings.event_participation_buttons.split("|");
+
+    if (this.args.event.isPrivate) {
+      allowed_buttons.push("invited");
+    }
+
+    allowed_buttons.forEach((button) => {
+      const localeKey = button.replace(" ", "_");
+      if (button === "not_going") {
+        button = "notGoing";
+      }
+
+      const count = this.args.event.stats[button] || 0;
+
+      const name = i18n(
+        `discourse_calendar.discourse_post_event.models.invitee.status.${localeKey}_count`,
+        {
+          count,
+        }
+      );
+
+      const className = `event-status-${localeKey}`;
+
+      buttons.push({
+        class: className,
+        name,
+      });
+    });
+
+    return buttons;
+  }
+
   <template>
     <section class="event-invitees">
       <div class="header">
         <div class="event-invitees-status">
-          <span>{{@event.stats.going}}
-            {{i18n
-              "discourse_calendar.discourse_post_event.models.invitee.status.going"
-            }}
-            -</span>
-          <span>{{@event.stats.interested}}
-            {{i18n
-              "discourse_calendar.discourse_post_event.models.invitee.status.interested"
-            }}
-            -</span>
-          <span>{{@event.stats.notGoing}}
-            {{i18n
-              "discourse_calendar.discourse_post_event.models.invitee.status.not_going"
-            }}</span>
-          {{#if @event.isPrivate}}
-            <span class="invited">- on
-              {{@event.stats.invited}}
-              users invited</span>
-          {{/if}}
+          {{#each this.statusButtons as |button|}}
+            <span class={{button.class}}>{{button.name}}</span>
+          {{/each}}
         </div>
 
         <DButton

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -54,26 +54,29 @@ export default class DiscoursePostEventInvitees extends Component {
   }
 
   <template>
-    <section class="event-invitees">
-      <div class="header">
-        <div class="event-invitees-status">
-          {{#each this.statsInfo as |info|}}
-            <span class={{info.class}}>{{info.label}}</span>
-          {{/each}}
-        </div>
+    {{#unless @event.minimal}}
+      {{#if @event.shouldDisplayInvitees}}
+        <section class="event__section event-invitees">
+          <div class="header">
+            <div class="event-invitees-status">
+              {{#each this.statsInfo as |info|}}
+                <span class={{info.class}}>{{info.label}}</span>
+              {{/each}}
+            </div>
 
-        <DButton
-          class="show-all btn-small"
-          @label="discourse_calendar.discourse_post_event.event_ui.show_all"
-          @action={{this.showAllInvitees}}
-        />
-
-      </div>
-      <ul class="event-invitees-avatars">
-        {{#each @event.sampleInvitees as |invitee|}}
-          <Invitee @invitee={{invitee}} />
-        {{/each}}
-      </ul>
-    </section>
+            <DButton
+              class="show-all btn-small"
+              @label="discourse_calendar.discourse_post_event.event_ui.show_all"
+              @action={{this.showAllInvitees}}
+            />
+          </div>
+          <ul class="event-invitees-avatars">
+            {{#each @event.sampleInvitees as |invitee|}}
+              <Invitee @invitee={{invitee}} />
+            {{/each}}
+          </ul>
+        </section>
+      {{/if}}
+    {{/unless}}
   </template>
 }

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -21,16 +21,16 @@ export default class DiscoursePostEventInvitees extends Component {
     });
   }
 
-  get statusButtons() {
-    const buttons = [];
-    const allowed_buttons =
+  get statsInfo() {
+    const stats = [];
+    const visibleStats =
       this.siteSettings.event_participation_buttons.split("|");
 
     if (this.args.event.isPrivate) {
-      allowed_buttons.push("invited");
+      visibleStats.push("invited");
     }
 
-    allowed_buttons.forEach((button) => {
+    visibleStats.forEach((button) => {
       const localeKey = button.replace(" ", "_");
       if (button === "not_going") {
         button = "notGoing";
@@ -38,30 +38,26 @@ export default class DiscoursePostEventInvitees extends Component {
 
       const count = this.args.event.stats[button] || 0;
 
-      const name = i18n(
+      const label = i18n(
         `discourse_calendar.discourse_post_event.models.invitee.status.${localeKey}_count`,
-        {
-          count,
-        }
+        { count }
       );
 
-      const className = `event-status-${localeKey}`;
-
-      buttons.push({
-        class: className,
-        name,
+      stats.push({
+        class: `event-status-${localeKey}`,
+        label,
       });
     });
 
-    return buttons;
+    return stats;
   }
 
   <template>
     <section class="event-invitees">
       <div class="header">
         <div class="event-invitees-status">
-          {{#each this.statusButtons as |button|}}
-            <span class={{button.class}}>{{button.name}}</span>
+          {{#each this.statsInfo as |info|}}
+            <span class={{info.class}}>{{info.label}}</span>
           {{/each}}
         </div>
 

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -15,6 +15,7 @@ import { buildParams, replaceRaw } from "../../lib/raw-event-helper";
 import PostEventBuilder from "../modal/post-event-builder";
 import PostEventBulkInvite from "../modal/post-event-bulk-invite";
 import PostEventInviteUserOrGroup from "../modal/post-event-invite-user-or-group";
+import PostEventInvitees from "../modal/post-event-invitees";
 
 export default class DiscoursePostEventMoreMenu extends Component {
   @service appEvents;
@@ -197,6 +198,19 @@ export default class DiscoursePostEventMoreMenu extends Component {
   }
 
   @action
+  showParticipants() {
+    this.menuApi.close();
+
+    this.modal.show(PostEventInvitees, {
+      model: {
+        event: this.args.event,
+        title: this.args.event.title,
+        extraClass: this.args.event.extraClass,
+      },
+    });
+  }
+
+  @action
   async closeEvent() {
     this.menuApi.close();
 
@@ -308,6 +322,13 @@ export default class DiscoursePostEventMoreMenu extends Component {
           {{/if}}
 
           {{#if this.canActOnEvent}}
+
+            <DButton
+              @icon="user-group"
+              class="btn-transparent"
+              @label="discourse_calendar.discourse_post_event.event_ui.show_participants"
+              @action={{this.showParticipants}}
+            />
             <dropdown.divider />
 
             <dropdown.item class="export-event">

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -41,10 +41,6 @@ export default class DiscoursePostEventMoreMenu extends Component {
     );
   }
 
-  get canLeave() {
-    return this.args.event.watchingInvitee && this.args.event.isPublic;
-  }
-
   get canSeeUpcomingEvents() {
     return !this.args.event.isClosed && this.args.event.recurrence;
   }
@@ -102,24 +98,6 @@ export default class DiscoursePostEventMoreMenu extends Component {
     try {
       this.modal.show(PostEventInviteUserOrGroup, {
         model: { event: this.args.event },
-      });
-    } catch (e) {
-      popupAjaxError(e);
-    }
-  }
-
-  @action
-  async leaveEvent() {
-    this.menuApi.close();
-
-    try {
-      const invitee = this.args.event.watchingInvitee;
-
-      await this.discoursePostEventApi.leaveEvent(this.args.event, invitee);
-
-      this.appEvents.trigger("calendar:invitee-left-event", {
-        invitee,
-        postId: this.args.event.id,
       });
     } catch (e) {
       popupAjaxError(e);

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -295,19 +295,6 @@ export default class DiscoursePostEventMoreMenu extends Component {
             </dropdown.item>
           {{/if}}
 
-          {{#if this.canLeave}}
-            <dropdown.item class="leave-event">
-              <DButton
-                @icon="times"
-                class="btn-transparent"
-                @translatedLabel={{i18n
-                  "discourse_calendar.discourse_post_event.event_ui.leave"
-                }}
-                @action={{this.leaveEvent}}
-              />
-            </dropdown.item>
-          {{/if}}
-
           {{#if this.canSeeUpcomingEvents}}
             <dropdown.item class="upcoming-events">
               <DButton

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -18,7 +18,6 @@ import PostEventInviteUserOrGroup from "../modal/post-event-invite-user-or-group
 import PostEventInvitees from "../modal/post-event-invitees";
 
 export default class DiscoursePostEventMoreMenu extends Component {
-  @service appEvents;
   @service currentUser;
   @service dialog;
   @service discoursePostEventApi;

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -322,13 +322,15 @@ export default class DiscoursePostEventMoreMenu extends Component {
           {{/if}}
 
           {{#if this.canActOnEvent}}
+            <dropdown.item class="show-all-participants">
+              <DButton
+                @icon="user-group"
+                class="btn-transparent"
+                @label="discourse_calendar.discourse_post_event.event_ui.show_participants"
+                @action={{this.showParticipants}}
+              />
+            </dropdown.item>
 
-            <DButton
-              @icon="user-group"
-              class="btn-transparent"
-              @label="discourse_calendar.discourse_post_event.event_ui.show_participants"
-              @action={{this.showParticipants}}
-            />
             <dropdown.divider />
 
             <dropdown.item class="export-event">

--- a/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -9,9 +9,26 @@ import concatClass from "discourse/helpers/concat-class";
 export default class DiscoursePostEventStatus extends Component {
   @service appEvents;
   @service discoursePostEventApi;
+  @service siteSettings;
 
   get watchingInviteeStatus() {
     return this.args.event.watchingInvitee?.status;
+  }
+
+  get eventButtons() {
+    return this.siteSettings.event_participation_buttons.split("|");
+  }
+
+  get showGoingButton() {
+    return !!this.eventButtons.find((button) => button === "going");
+  }
+
+  get showInterestedButton() {
+    return !!this.eventButtons.find((button) => button === "interested");
+  }
+
+  get showNotGoingButton() {
+    return !!this.eventButtons.find((button) => button === "not going");
   }
 
   @action
@@ -55,54 +72,62 @@ export default class DiscoursePostEventStatus extends Component {
         @name="discourse-post-event-status-buttons"
         @outletArgs={{hash event=@event}}
       >
-        {{#unless @event.minimal}}
+        {{#if this.showGoingButton}}
+          {{#unless @event.minimal}}
+            <PluginOutlet
+              @name="discourse-post-event-status-going-button"
+              @outletArgs={{hash
+                event=@event
+                markAsGoing=(fn this.changeWatchingInviteeStatus "going")
+              }}
+            >
+              <DButton
+                class="going-button"
+                @icon="check"
+                @label="discourse_calendar.discourse_post_event.models.invitee.status.going"
+                @action={{fn this.changeWatchingInviteeStatus "going"}}
+              />
+            </PluginOutlet>
+          {{/unless}}
+        {{/if}}
+
+        {{#if this.showInterestedButton}}
           <PluginOutlet
-            @name="discourse-post-event-status-going-button"
+            @name="discourse-post-event-status-interested-button"
             @outletArgs={{hash
               event=@event
-              markAsGoing=(fn this.changeWatchingInviteeStatus "going")
+              markAsInterested=(fn
+                this.changeWatchingInviteeStatus "interested"
+              )
             }}
           >
             <DButton
-              class="going-button"
-              @icon="check"
-              @label="discourse_calendar.discourse_post_event.models.invitee.status.going"
-              @action={{fn this.changeWatchingInviteeStatus "going"}}
+              class="interested-button"
+              @icon="star"
+              @label="discourse_calendar.discourse_post_event.models.invitee.status.interested"
+              @action={{fn this.changeWatchingInviteeStatus "interested"}}
             />
           </PluginOutlet>
-        {{/unless}}
+        {{/if}}
 
-        <PluginOutlet
-          @name="discourse-post-event-status-interested-button"
-          @outletArgs={{hash
-            event=@event
-            markAsInterested=(fn this.changeWatchingInviteeStatus "interested")
-          }}
-        >
-          <DButton
-            class="interested-button"
-            @icon="star"
-            @label="discourse_calendar.discourse_post_event.models.invitee.status.interested"
-            @action={{fn this.changeWatchingInviteeStatus "interested"}}
-          />
-        </PluginOutlet>
-
-        {{#unless @event.minimal}}
-          <PluginOutlet
-            @name="discourse-post-event-status-not-going-button"
-            @outletArgs={{hash
-              event=@event
-              markAsNotGoing=(fn this.changeWatchingInviteeStatus "not_going")
-            }}
-          >
-            <DButton
-              class="not-going-button"
-              @icon="times"
-              @label="discourse_calendar.discourse_post_event.models.invitee.status.not_going"
-              @action={{fn this.changeWatchingInviteeStatus "not_going"}}
-            />
-          </PluginOutlet>
-        {{/unless}}
+        {{#if this.showNotGoingButton}}
+          {{#unless @event.minimal}}
+            <PluginOutlet
+              @name="discourse-post-event-status-not-going-button"
+              @outletArgs={{hash
+                event=@event
+                markAsNotGoing=(fn this.changeWatchingInviteeStatus "not_going")
+              }}
+            >
+              <DButton
+                class="not-going-button"
+                @icon="times"
+                @label="discourse_calendar.discourse_post_event.models.invitee.status.not_going"
+                @action={{fn this.changeWatchingInviteeStatus "not_going"}}
+              />
+            </PluginOutlet>
+          {{/unless}}
+        {{/if}}
       </PluginOutlet>
     </div>
   </template>

--- a/assets/javascripts/discourse/components/discourse-post-event/url.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/url.gjs
@@ -9,16 +9,18 @@ export default class DiscoursePostEventUrl extends Component {
   }
 
   <template>
-    <section class="event-url">
-      {{icon "link"}}
-      <a
-        class="url"
-        href={{this.url}}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {{@url}}
-      </a>
-    </section>
+    {{#if @url}}
+      <section class="event__section event-url">
+        {{icon "link"}}
+        <a
+          class="url"
+          href={{this.url}}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{@url}}
+        </a>
+      </section>
+    {{/if}}
   </template>
 }

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -3,6 +3,30 @@ $interested: #fb985d;
 .discourse-post-event {
   display: flex;
 
+  .event__section {
+    padding: 0.5em 1em;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid var(--primary-low);
+    }
+
+    &:first-child {
+      border-top: 1px solid var(--primary-low);
+    }
+
+    p {
+      margin: 0;
+    }
+
+    > .d-icon {
+      padding-right: 0.25em;
+    }
+
+    .discourse-local-date .d-icon {
+      padding-right: 0.25em;
+    }
+  }
+
   .discourse-post-event-widget {
     border: 5px solid var(--primary-low);
     display: flex;
@@ -175,8 +199,6 @@ $interested: #fb985d;
 
   .event-invitees {
     display: flex;
-    height: 110px;
-    padding: 0 1em;
     align-items: flex-start;
     justify-content: center;
     overflow-y: auto;
@@ -274,9 +296,6 @@ $interested: #fb985d;
   .event-dates {
     display: flex;
     align-items: center;
-    padding: 0 1em;
-    height: 50px;
-    flex: 1;
 
     .d-icon {
       color: var(--primary-high);
@@ -285,7 +304,6 @@ $interested: #fb985d;
 
   .event-url {
     .url {
-      margin-left: 1em;
       max-width: 80%;
       @include ellipsis;
     }

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -292,6 +292,10 @@ $interested: #fb985d;
   }
 
   .event-dates {
+    // hardcoded as cooking date is async and will change height after initial rendering otherwise
+    // not ideal but a decent low tech solution
+    height: 24px;
+
     .participants {
       margin-left: 0.5em;
       color: var(--primary-medium);

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -195,9 +195,14 @@ $interested: #fb985d;
 
       .event-invitees-status {
         font-weight: 700;
-
-        .invited {
-          font-weight: 500;
+        display: flex;
+        span:not(:last-child)::after {
+          content: '-';
+          font-weight: 400;
+          margin: 0 0.3em;
+        }
+        .event-status-invited {
+          font-weight: 600;
           color: var(--primary-medium);
         }
       }

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -197,7 +197,7 @@ $interested: #fb985d;
         font-weight: 700;
         display: flex;
         span:not(:last-child)::after {
-          content: '-';
+          content: "-";
           font-weight: 400;
           margin: 0 0.3em;
         }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -336,6 +336,18 @@ en:
               going: "Going"
               not_going: "Not Going"
               interested: "Interested"
+              going_count:
+                one: "%{count} going"
+                other: "%{count} going"
+              not_going_count:
+                one: "%{count} not going"
+                other: "%{count} not going"
+              interested_count:
+                one: "%{count} interested"
+                other: "%{count} interested"
+              invited_count:
+                one: "%{count} user invited"
+                other: "%{count} users invited"
           event:
             expired: "Expired"
             closed: "Closed"
@@ -351,6 +363,7 @@ en:
                 description: "A private event can only be joined by invited users."
         event_ui:
           show_all: "Show all"
+          show_participants: "Show participants"
           participants:
             one: "%{count} user participated."
             other: "%{count} users participated."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,6 +55,7 @@ en:
     sort_categories_by_event_start_date_enabled: "Enable the sorting of category topics by event start date."
     disable_resorting_on_categories_enabled: "Allow categories to disable the ability for users to sort on the event category."
     calendar_automatic_holidays_enabled: "Automatically set holiday status based on a users region (note: you can disable specific automatic holidays in plugin settings)"
+    event_participation_buttons: "List of event participation buttons users can use."
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'."
     include_expired_events_on_calendar: "Include past/expired events on Category Calendar and Upcoming Events views."
   discourse_calendar:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,6 +59,16 @@ discourse_calendar:
     default: false
     client: true
     hidden: true
+  event_participation_buttons:
+    default: "going"
+    client: true
+    type: list
+    list_type: simple
+    allow_any: false
+    choices:
+      - going
+      - interested
+      - not going
   discourse_post_event_enabled:
     default: false
     client: true


### PR DESCRIPTION
Interested and not going are generally not used.

To avoid adding this clutter to the UI we now suppress this.

Sites wishing to have these buttons can amend the `event_participation_buttons` site setting

Also:

- Add a show participants button even if there are no participants (so admins can populate events)
- Fix localization for event participation
- Allow toggling attendance by pressing the same button
- Removes leave event button from the dropdown menu
- Refactors outlets to allow maximum flexibility