### PR TITLE
FIX: correctly render html of event title

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -1,13 +1,11 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 import { modifier } from "ember-modifier";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import replaceEmoji from "discourse/helpers/replace-emoji";
 import routeAction from "discourse/helpers/route-action";
-import { emojiUnescape } from "discourse/lib/text";
-import { escapeExpression } from "discourse/lib/utilities";
 import icon from "discourse-common/helpers/d-icon";
 import Creator from "./creator";
 import Dates from "./dates";
@@ -54,12 +52,7 @@ export default class DiscoursePostEvent extends Component {
   }
 
   get eventName() {
-    return htmlSafe(
-      emojiUnescape(
-        escapeExpression(this.args.event.name) ||
-          this.args.event.post.topic.title
-      )
-    );
+    return this.args.event.name || this.args.event.post.topic.title;
   }
 
   get isPublicEvent() {
@@ -90,7 +83,7 @@ export default class DiscoursePostEvent extends Component {
             </div>
             <div class="event-info">
               <span class="name">
-                {{this.eventName}}
+                {{replaceEmoji this.eventName}}
               </span>
               <div class="status-and-creators">
                 <PluginOutlet

--- a/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -56,9 +56,8 @@ export default class DiscoursePostEvent extends Component {
   get eventName() {
     return htmlSafe(
       emojiUnescape(
-        escapeExpression(
-          this.args.event.name || this.args.event.post.topic.title
-        )
+        escapeExpression(this.args.event.name) ||
+          this.args.event.post.topic.title
       )
     );
   }

--- a/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import { modifier } from "ember-modifier";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
@@ -53,8 +54,12 @@ export default class DiscoursePostEvent extends Component {
   }
 
   get eventName() {
-    return emojiUnescape(
-      escapeExpression(this.args.event.name) || this.args.event.post.topic.title
+    return htmlSafe(
+      emojiUnescape(
+        escapeExpression(
+          this.args.event.name || this.args.event.post.topic.title
+        )
+      )
     );
   }
 

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -9,10 +9,23 @@ describe "Post event", type: :system do
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
     sign_in(admin)
-    visit "/new-topic"
+  end
+
+  it "renders html and emojis in the event name" do
+    post =
+      PostCreator.create(
+        admin,
+        title: "My test meetup event",
+        raw: "[event name=':cat: My test meetup event' start='2222-02-22 00:00']\n[/event]",
+      )
+
+    visit(post.topic.url)
+
+    expect(page).to have_css(".event-info .name img.emoji[title='cat']")
   end
 
   it "can create, close, and open an event" do
+    visit "/new-topic"
     title = "My upcoming l33t event"
     tomorrow = (Time.zone.now + 1.day).strftime("%Y-%m-%d")
 

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -11,17 +11,18 @@ describe "Post event", type: :system do
     sign_in(admin)
   end
 
-  it "renders html and emojis in the event name" do
+  it "safely renders html and emojis in the event name" do
     post =
       PostCreator.create(
         admin,
         title: "My test meetup event",
-        raw: "[event name=':cat: My test meetup event' start='2222-02-22 00:00']\n[/event]",
+        raw: "[event name=':cat: <script>alert(1);</script>' start='2222-02-22 00:00']\n[/event]",
       )
 
     visit(post.topic.url)
 
     expect(page).to have_css(".event-info .name img.emoji[title='cat']")
+    expect(page).to have_css(".event-info .name", text: "<script>alert(1);</script>")
   end
 
   it "can create, close, and open an event" do

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -11,7 +11,7 @@ describe "Post event", type: :system do
     sign_in(admin)
   end
 
-  it "safely renders html and emojis in the event name" do
+  it "safely renders event name" do
     post =
       PostCreator.create(
         admin,


### PR DESCRIPTION
This has been lost during the move to glimmer.