### PR TITLE
FIX: prevents error if post event node is not found

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
@@ -87,11 +87,18 @@ function initializeDiscoursePostEventDecorator(api) {
           return;
         }
 
-        const div = document.createElement("div");
-        cooked.querySelector(".discourse-post-event").before(div);
+        const postEventNode = cooked.querySelector(".discourse-post-event");
+
+        if (!postEventNode) {
+          return;
+        }
+
+        const wrapper = document.createElement("div");
+        postEventNode.before(wrapper);
+
         const event = DiscoursePostEventEvent.create(post.event);
 
-        helper.renderGlimmer(div, <template>
+        helper.renderGlimmer(wrapper, <template>
           <DiscoursePostEvent @event={{event}} />
         </template>);
       }


### PR DESCRIPTION
This could happen during a server error for example. Ideally we should ensure the post event doesn't disappear on such error, but at least for now we avoid the crash.