### PR TITLE
DEV: moves translations under discourse_post_event

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -71,18 +71,14 @@ module DiscoursePostEvent
           else
             render json:
                      failed_json.merge(
-                       errors: [
-                         I18n.t("discourse_calendar.discourse_post_event.errors.bulk_invite.error"),
-                       ],
+                       errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
                      ),
                    status: 422
           end
         rescue StandardError
           render json:
                    failed_json.merge(
-                     errors: [
-                       I18n.t("discourse_calendar.discourse_post_event.errors.bulk_invite.error"),
-                     ],
+                     errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
                    ),
                  status: 422
         end
@@ -108,9 +104,7 @@ module DiscoursePostEvent
       rescue StandardError
         render json:
                  failed_json.merge(
-                   errors: [
-                     I18n.t("discourse_calendar.discourse_post_event.errors.bulk_invite.error"),
-                   ],
+                   errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
                  ),
                status: 422
       end

--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -128,10 +128,7 @@ module DiscoursePostEvent
       if self.raw_invitees && self.raw_invitees.length > 10
         errors.add(
           :base,
-          I18n.t(
-            "discourse_calendar.discourse_post_event.errors.models.event.raw_invitees_length",
-            count: 10,
-          ),
+          I18n.t("discourse_post_event.errors.models.event.raw_invitees_length", count: 10),
         )
       end
     end
@@ -141,9 +138,7 @@ module DiscoursePostEvent
       if self.raw_invitees && User.select(:id).where(username: self.raw_invitees).limit(1).count > 0
         errors.add(
           :base,
-          I18n.t(
-            "discourse_calendar.discourse_post_event.errors.models.event.raw_invitees.only_group",
-          ),
+          I18n.t("discourse_post_event.errors.models.event.raw_invitees.only_group"),
         )
       end
     end
@@ -154,9 +149,7 @@ module DiscoursePostEvent
            self.original_starts_at >= self.original_ends_at
         errors.add(
           :base,
-          I18n.t(
-            "discourse_calendar.discourse_post_event.errors.models.event.ends_at_before_starts_at",
-          ),
+          I18n.t("discourse_post_event.errors.models.event.ends_at_before_starts_at"),
         )
       end
     end
@@ -168,10 +161,7 @@ module DiscoursePostEvent
         if !allowed_custom_fields.include?(key)
           errors.add(
             :base,
-            I18n.t(
-              "discourse_calendar.discourse_post_event.errors.models.event.custom_field_is_invalid",
-              field: key,
-            ),
+            I18n.t("discourse_post_event.errors.models.event.custom_field_is_invalid", field: key),
           )
         end
       end
@@ -209,9 +199,9 @@ module DiscoursePostEvent
 
       message =
         if predefined_attendance
-          "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification"
+          "discourse_post_event.notifications.invite_user_predefined_attendance_notification"
         else
-          "discourse_calendar.discourse_post_event.notifications.invite_user_notification"
+          "discourse_post_event.notifications.invite_user_notification"
         end
 
       attrs = {

--- a/assets/javascripts/discourse/components/bulk-invite-sample-csv-file.hbs
+++ b/assets/javascripts/discourse/components/bulk-invite-sample-csv-file.hbs
@@ -1,4 +1,4 @@
 <DButton
-  @label="discourse_calendar.discourse_post_event.bulk_invite_modal.download_sample_csv"
+  @label="discourse_post_event.bulk_invite_modal.download_sample_csv"
   @action={{action "downloadSampleCsv"}}
 />

--- a/assets/javascripts/discourse/components/discourse-post-event/creator.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/creator.gjs
@@ -10,9 +10,7 @@ export default class DiscoursePostEventCreator extends Component {
 
   <template>
     <span class="creators">
-      <span class="created-by">{{i18n
-          "discourse_calendar.discourse_post_event.event_ui.created_by"
-        }}</span>
+      <span class="created-by">{{i18n "discourse_post_event.created_by"}}</span>
 
       <span class="event-creator">
         <a class="topic-invitee-avatar" data-user-card={{@user.username}}>

--- a/assets/javascripts/discourse/components/discourse-post-event/event-status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/event-status.gjs
@@ -4,13 +4,13 @@ import i18n from "discourse-common/helpers/i18n";
 export default class EventStatus extends Component {
   get eventStatusLabel() {
     return i18n(
-      `discourse_calendar.discourse_post_event.models.event.status.${this.args.event.status}.title`
+      `discourse_post_event.models.event.status.${this.args.event.status}.title`
     );
   }
 
   get eventStatusDescription() {
     return i18n(
-      `discourse_calendar.discourse_post_event.models.event.status.${this.args.event.status}.description`
+      `discourse_post_event.models.event.status.${this.args.event.status}.description`
     );
   }
 
@@ -21,11 +21,11 @@ export default class EventStatus extends Component {
   <template>
     {{#if @event.isExpired}}
       <span class="status expired">
-        {{i18n "discourse_calendar.discourse_post_event.models.event.expired"}}
+        {{i18n "discourse_post_event.models.event.expired"}}
       </span>
     {{else if @event.isClosed}}
       <span class="status closed">
-        {{i18n "discourse_calendar.discourse_post_event.models.event.closed"}}
+        {{i18n "discourse_post_event.models.event.closed"}}
       </span>
     {{else}}
       <span class={{this.statusClass}} title={{this.eventStatusDescription}}>

--- a/assets/javascripts/discourse/components/discourse-post-event/invitee.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitee.gjs
@@ -23,7 +23,7 @@ export default class DiscoursePostEventInvitee extends Component {
   }
 
   get flairName() {
-    const string = `discourse_calendar.discourse_post_event.models.invitee.status.${this.args.invitee.status}`;
+    const string = `discourse_post_event.models.invitee.status.${this.args.invitee.status}`;
 
     return i18n(string);
   }

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -40,7 +40,7 @@ export default class DiscoursePostEventInvitees extends Component {
       const count = this.args.event.stats[button] || 0;
 
       const label = i18n(
-        `discourse_calendar.discourse_post_event.models.invitee.status.${localeKey}_count`,
+        `discourse_post_event.models.invitee.status.${localeKey}_count`,
         { count }
       );
 
@@ -66,7 +66,7 @@ export default class DiscoursePostEventInvitees extends Component {
 
             <DButton
               class="show-all btn-small"
-              @label="discourse_calendar.discourse_post_event.event_ui.show_all"
+              @label="discourse_post_event.show_all"
               @action={{this.showAllInvitees}}
             />
           </div>

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -127,9 +127,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
     this.menuApi.close();
 
     this.dialog.yesNoConfirm({
-      message: i18n(
-        "discourse_calendar.discourse_post_event.builder_modal.confirm_open"
-      ),
+      message: i18n("discourse_post_event.builder_modal.confirm_open"),
       didConfirm: async () => {
         try {
           const post = await this.store.find("post", this.args.event.id);
@@ -147,9 +145,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
           if (newRaw) {
             const props = {
               raw: newRaw,
-              edit_reason: i18n(
-                "discourse_calendar.discourse_post_event.edit_reason_opened"
-              ),
+              edit_reason: i18n("discourse_post_event.edit_reason_opened"),
             };
 
             const cooked = await cook(newRaw);
@@ -192,9 +188,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
     this.menuApi.close();
 
     this.dialog.yesNoConfirm({
-      message: i18n(
-        "discourse_calendar.discourse_post_event.builder_modal.confirm_close"
-      ),
+      message: i18n("discourse_post_event.builder_modal.confirm_close"),
       didConfirm: () => {
         return this.store.find("post", this.args.event.id).then((post) => {
           this.args.event.isClosed = true;
@@ -211,9 +205,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
           if (newRaw) {
             const props = {
               raw: newRaw,
-              edit_reason: i18n(
-                "discourse_calendar.discourse_post_event.edit_reason_closed"
-              ),
+              edit_reason: i18n("discourse_post_event.edit_reason_closed"),
             };
 
             return cook(newRaw).then((cooked) => {
@@ -239,7 +231,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
             <dropdown.item class="add-to-calendar">
               <DButton
                 @icon="file"
-                @label="discourse_calendar.discourse_post_event.event_ui.add_to_calendar"
+                @label="discourse_post_event.add_to_calendar"
                 @action={{this.addToCalendar}}
               />
             </dropdown.item>
@@ -251,7 +243,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
                 @icon="envelope"
                 class="btn-transparent"
                 @translatedLabel={{i18n
-                  "discourse_calendar.discourse_post_event.event_ui.send_pm_to_creator"
+                  "discourse_post_event.send_pm_to_creator"
                   (hash username=@event.creator.username)
                 }}
                 @action={{this.sendPMToCreator}}
@@ -264,9 +256,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
               <DButton
                 @icon="user-plus"
                 class="btn-transparent"
-                @translatedLabel={{i18n
-                  "discourse_calendar.discourse_post_event.event_ui.invite"
-                }}
+                @translatedLabel={{i18n "discourse_post_event.invite"}}
                 @action={{this.inviteUserOrGroup}}
               />
             </dropdown.item>
@@ -277,9 +267,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
               <DButton
                 @icon="far-calendar-plus"
                 class="btn-transparent"
-                @translatedLabel={{i18n
-                  "discourse_post_event.event_ui.upcoming_events"
-                }}
+                @translatedLabel={{i18n "discourse_post_event.upcoming_events"}}
                 @action={{this.upcomingEvents}}
               />
             </dropdown.item>
@@ -290,7 +278,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
               <DButton
                 @icon="user-group"
                 class="btn-transparent"
-                @label="discourse_calendar.discourse_post_event.event_ui.show_participants"
+                @label="discourse_post_event.show_participants"
                 @action={{this.showParticipants}}
               />
             </dropdown.item>
@@ -301,7 +289,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
               <DButton
                 @icon="file-csv"
                 class="btn-transparent"
-                @label="discourse_calendar.discourse_post_event.event_ui.export_event"
+                @label="discourse_post_event.export_event"
                 @action={{this.exportPostEvent}}
               />
             </dropdown.item>
@@ -311,7 +299,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
                 <DButton
                   @icon="file-upload"
                   class="btn-transparent"
-                  @label="discourse_calendar.discourse_post_event.event_ui.bulk_invite"
+                  @label="discourse_post_event.bulk_invite"
                   @action={{this.bulkInvite}}
                 />
               </dropdown.item>
@@ -322,7 +310,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
                 <DButton
                   @icon="unlock"
                   class="btn-transparent"
-                  @label="discourse_calendar.discourse_post_event.event_ui.open_event"
+                  @label="discourse_post_event.open_event"
                   @action={{this.openEvent}}
                 />
               </dropdown.item>
@@ -331,7 +319,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
                 <DButton
                   @icon="pencil-alt"
                   class="btn-transparent"
-                  @label="discourse_calendar.discourse_post_event.event_ui.edit_event"
+                  @label="discourse_post_event.edit_event"
                   @action={{this.editPostEvent}}
                 />
               </dropdown.item>
@@ -340,7 +328,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
                 <dropdown.item class="close-event">
                   <DButton
                     @icon="times"
-                    @label="discourse_calendar.discourse_post_event.event_ui.close_event"
+                    @label="discourse_post_event.close_event"
                     @action={{this.closeEvent}}
                     class="btn-transparent btn-danger"
                   />

--- a/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -132,7 +132,7 @@ export default class DiscoursePostEventStatus extends Component {
               <DButton
                 class="going-button"
                 @icon="check"
-                @label="discourse_calendar.discourse_post_event.models.invitee.status.going"
+                @label="discourse_post_event.models.invitee.status.going"
                 @action={{fn this.changeWatchingInviteeStatus "going"}}
               />
             </PluginOutlet>
@@ -152,7 +152,7 @@ export default class DiscoursePostEventStatus extends Component {
             <DButton
               class="interested-button"
               @icon="star"
-              @label="discourse_calendar.discourse_post_event.models.invitee.status.interested"
+              @label="discourse_post_event.models.invitee.status.interested"
               @action={{fn this.changeWatchingInviteeStatus "interested"}}
             />
           </PluginOutlet>
@@ -170,7 +170,7 @@ export default class DiscoursePostEventStatus extends Component {
               <DButton
                 class="not-going-button"
                 @icon="times"
-                @label="discourse_calendar.discourse_post_event.models.invitee.status.not_going"
+                @label="discourse_post_event.models.invitee.status.not_going"
                 @action={{fn this.changeWatchingInviteeStatus "not_going"}}
               />
             </PluginOutlet>

--- a/assets/javascripts/discourse/components/event-date.gjs
+++ b/assets/javascripts/discourse/components/event-date.gjs
@@ -93,12 +93,9 @@ export default class EventDate extends Component {
   }
 
   get timeRemainingContent() {
-    return I18n.t(
-      "discourse_calendar.discourse_post_event.topic_title.ends_in_duration",
-      {
-        duration: this.eventEndedAt.from(moment()),
-      }
-    );
+    return I18n.t("discourse_post_event.topic_title.ends_in_duration", {
+      duration: this.eventEndedAt.from(moment()),
+    });
   }
 
   _parsedDate(date) {

--- a/assets/javascripts/discourse/components/modal/post-event-builder.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.hbs
@@ -1,7 +1,7 @@
 <DModal
   @title={{i18n
     (concat
-      "discourse_calendar.discourse_post_event.builder_modal."
+      "discourse_post_event.builder_modal."
       (if @model.event.id "update_event_title" "create_event_title")
     )
   }}
@@ -21,43 +21,41 @@
 
         <EventField
           class="name"
-          @label="discourse_calendar.discourse_post_event.builder_modal.name.label"
+          @label="discourse_post_event.builder_modal.name.label"
         >
           <Input
             @value={{@model.event.name}}
             placeholder={{i18n
-              "discourse_calendar.discourse_post_event.builder_modal.name.placeholder"
+              "discourse_post_event.builder_modal.name.placeholder"
             }}
           />
         </EventField>
 
         <EventField
           class="url"
-          @label="discourse_calendar.discourse_post_event.builder_modal.url.label"
+          @label="discourse_post_event.builder_modal.url.label"
         >
           <Input
             @value={{@model.event.url}}
             placeholder={{i18n
-              "discourse_calendar.discourse_post_event.builder_modal.url.placeholder"
+              "discourse_post_event.builder_modal.url.placeholder"
             }}
           />
         </EventField>
 
         <EventField
           class="timezone"
-          @label="discourse_calendar.discourse_post_event.builder_modal.timezone.label"
+          @label="discourse_post_event.builder_modal.timezone.label"
         >
           <TimezoneInput
             @value={{@model.event.timezone}}
             @onChange={{this.setNewTimezone}}
             class="input-xxlarge"
-            @none="discourse_calendar.discourse_post_event.builder_modal.timezone.remove_timezone"
+            @none="discourse_post_event.builder_modal.timezone.remove_timezone"
           />
         </EventField>
 
-        <EventField
-          @label="discourse_calendar.discourse_post_event.builder_modal.status.label"
-        >
+        <EventField @label="discourse_post_event.builder_modal.status.label">
           <label class="radio-label">
             <RadioButton
               @name="status"
@@ -67,13 +65,11 @@
             />
             <span class="message">
               <span class="title">
-                {{i18n
-                  "discourse_calendar.discourse_post_event.models.event.status.public.title"
-                }}
+                {{i18n "discourse_post_event.models.event.status.public.title"}}
               </span>
               <span class="description">
                 {{i18n
-                  "discourse_calendar.discourse_post_event.models.event.status.public.description"
+                  "discourse_post_event.models.event.status.public.description"
                 }}
               </span>
             </span>
@@ -88,12 +84,12 @@
             <span class="message">
               <span class="title">
                 {{i18n
-                  "discourse_calendar.discourse_post_event.models.event.status.private.title"
+                  "discourse_post_event.models.event.status.private.title"
                 }}
               </span>
               <span class="description">
                 {{i18n
-                  "discourse_calendar.discourse_post_event.models.event.status.private.description"
+                  "discourse_post_event.models.event.status.private.description"
                 }}
               </span>
             </span>
@@ -108,12 +104,12 @@
             <span class="message">
               <span class="title">
                 {{i18n
-                  "discourse_calendar.discourse_post_event.models.event.status.standalone.title"
+                  "discourse_post_event.models.event.status.standalone.title"
                 }}
               </span>
               <span class="description">
                 {{i18n
-                  "discourse_calendar.discourse_post_event.models.event.status.standalone.description"
+                  "discourse_post_event.models.event.status.standalone.description"
                 }}
               </span>
             </span>
@@ -122,7 +118,7 @@
 
         <EventField
           @enabled={{eq @model.event.status "private"}}
-          @label="discourse_calendar.discourse_post_event.builder_modal.invitees.label"
+          @label="discourse_post_event.builder_modal.invitees.label"
         >
           <GroupSelector
             @fullWidthWrap={{true}}
@@ -135,7 +131,7 @@
 
         <EventField
           class="reminders"
-          @label="discourse_calendar.discourse_post_event.builder_modal.reminders.label"
+          @label="discourse_post_event.builder_modal.reminders.label"
         >
           <div class="reminders-list">
             {{#each @model.event.reminders as |reminder|}}
@@ -153,7 +149,7 @@
                   min={{0}}
                   @value={{reminder.value}}
                   placeholder={{i18n
-                    "discourse_calendar.discourse_post_event.builder_modal.name.placeholder"
+                    "discourse_post_event.builder_modal.name.placeholder"
                   }}
                 />
 
@@ -187,34 +183,34 @@
             class="add-reminder"
             @disabled={{this.addReminderDisabled}}
             @icon="plus"
-            @label="discourse_calendar.discourse_post_event.builder_modal.add_reminder"
+            @label="discourse_post_event.builder_modal.add_reminder"
             @action={{@model.event.addReminder}}
           />
         </EventField>
 
         <EventField
           class="recurrence"
-          @label="discourse_calendar.discourse_post_event.builder_modal.recurrence.label"
+          @label="discourse_post_event.builder_modal.recurrence.label"
         >
           <ComboBox
             class="available-recurrences"
             @value={{@model.event.recurrence}}
             @content={{this.availableRecurrences}}
             @options={{hash
-              none="discourse_calendar.discourse_post_event.builder_modal.recurrence.none"
+              none="discourse_post_event.builder_modal.recurrence.none"
             }}
           />
         </EventField>
 
         <EventField
           class="minimal-event"
-          @label="discourse_calendar.discourse_post_event.builder_modal.minimal.label"
+          @label="discourse_post_event.builder_modal.minimal.label"
         >
           <label class="checkbox-label">
             <Input @type="checkbox" @checked={{@model.event.minimal}} />
             <span class="message">
               {{i18n
-                "discourse_calendar.discourse_post_event.builder_modal.minimal.checkbox_label"
+                "discourse_post_event.builder_modal.minimal.checkbox_label"
               }}
             </span>
           </label>
@@ -222,11 +218,11 @@
 
         {{#if this.allowedCustomFields.length}}
           <EventField
-            @label="discourse_calendar.discourse_post_event.builder_modal.custom_fields.label"
+            @label="discourse_post_event.builder_modal.custom_fields.label"
           >
             <p class="event-field-description">
               {{i18n
-                "discourse_calendar.discourse_post_event.builder_modal.custom_fields.description"
+                "discourse_post_event.builder_modal.custom_fields.description"
               }}
             </p>
             {{#each this.allowedCustomFields as |allowedCustomField|}}
@@ -239,7 +235,7 @@
                   (get @model.event.custom_fields allowedCustomField)
                 }}
                 placeholder={{i18n
-                  "discourse_calendar.discourse_post_event.builder_modal.custom_fields.placeholder"
+                  "discourse_post_event.builder_modal.custom_fields.placeholder"
                 }}
                 {{on "input" (fn this.setCustomField allowedCustomField)}}
               />
@@ -253,7 +249,7 @@
     {{#if @model.event.id}}
       <DButton
         class="btn-primary"
-        @label="discourse_calendar.discourse_post_event.builder_modal.update"
+        @label="discourse_post_event.builder_modal.update"
         @icon="calendar-day"
         @action={{this.updateEvent}}
       />
@@ -266,7 +262,7 @@
     {{else}}
       <DButton
         class="btn-primary"
-        @label="discourse_calendar.discourse_post_event.builder_modal.create"
+        @label="discourse_post_event.builder_modal.create"
         @icon="calendar-day"
         @action={{this.createEvent}}
       />

--- a/assets/javascripts/discourse/components/modal/post-event-builder.js
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.js
@@ -34,13 +34,13 @@ export default class PostEventBuilder extends Component {
       {
         value: "notification",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.types.notification"
+          "discourse_post_event.builder_modal.reminders.types.notification"
         ),
       },
       {
         value: "bumpTopic",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.types.bump_topic"
+          "discourse_post_event.builder_modal.reminders.types.bump_topic"
         ),
       },
     ];
@@ -51,25 +51,23 @@ export default class PostEventBuilder extends Component {
       {
         value: "minutes",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.units.minutes"
+          "discourse_post_event.builder_modal.reminders.units.minutes"
         ),
       },
       {
         value: "hours",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.units.hours"
+          "discourse_post_event.builder_modal.reminders.units.hours"
         ),
       },
       {
         value: "days",
-        name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.units.days"
-        ),
+        name: I18n.t("discourse_post_event.builder_modal.reminders.units.days"),
       },
       {
         value: "weeks",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.units.weeks"
+          "discourse_post_event.builder_modal.reminders.units.weeks"
         ),
       },
     ];
@@ -80,13 +78,13 @@ export default class PostEventBuilder extends Component {
       {
         value: "before",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.periods.before"
+          "discourse_post_event.builder_modal.reminders.periods.before"
         ),
       },
       {
         value: "after",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.reminders.periods.after"
+          "discourse_post_event.builder_modal.reminders.periods.after"
         ),
       },
     ];
@@ -96,38 +94,36 @@ export default class PostEventBuilder extends Component {
     return [
       {
         id: "every_day",
-        name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.recurrence.every_day"
-        ),
+        name: I18n.t("discourse_post_event.builder_modal.recurrence.every_day"),
       },
       {
         id: "every_month",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.recurrence.every_month"
+          "discourse_post_event.builder_modal.recurrence.every_month"
         ),
       },
       {
         id: "every_weekday",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.recurrence.every_weekday"
+          "discourse_post_event.builder_modal.recurrence.every_weekday"
         ),
       },
       {
         id: "every_week",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.recurrence.every_week"
+          "discourse_post_event.builder_modal.recurrence.every_week"
         ),
       },
       {
         id: "every_two_weeks",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.recurrence.every_two_weeks"
+          "discourse_post_event.builder_modal.recurrence.every_two_weeks"
         ),
       },
       {
         id: "every_four_weeks",
         name: I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.recurrence.every_four_weeks"
+          "discourse_post_event.builder_modal.recurrence.every_four_weeks"
         ),
       },
     ];
@@ -260,9 +256,7 @@ export default class PostEventBuilder extends Component {
       if (newRaw) {
         const props = {
           raw: newRaw,
-          edit_reason: I18n.t(
-            "discourse_calendar.discourse_post_event.edit_reason"
-          ),
+          edit_reason: I18n.t("discourse_post_event.edit_reason"),
         };
 
         const cooked = await cook(newRaw);

--- a/assets/javascripts/discourse/components/modal/post-event-bulk-invite.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-bulk-invite.hbs
@@ -1,8 +1,6 @@
 <DModal
   @closeModal={{@closeModal}}
-  @title={{i18n
-    "discourse_calendar.discourse_post_event.bulk_invite_modal.title"
-  }}
+  @title={{i18n "discourse_post_event.bulk_invite_modal.title"}}
   class="post-event-bulk-invite"
   @flash={{this.flash}}
 >
@@ -11,14 +9,12 @@
       <p class="bulk-event-help">
         {{i18n
           (concat
-            "discourse_calendar.discourse_post_event.bulk_invite_modal.description_"
+            "discourse_post_event.bulk_invite_modal.description_"
             @model.event.status
           )
         }}
       </p>
-      <h3>{{i18n
-          "discourse_calendar.discourse_post_event.bulk_invite_modal.inline_title"
-        }}</h3>
+      <h3>{{i18n "discourse_post_event.bulk_invite_modal.inline_title"}}</h3>
 
       <div class="bulk-invite-rows">
         {{#each this.bulkInvites as |bulkInvite|}}
@@ -29,7 +25,7 @@
                 @single={{true}}
                 @groupFinder={{this.groupFinder}}
                 @groupNames={{bulkInvite.identifier}}
-                @placeholderKey="discourse_calendar.discourse_post_event.bulk_invite_modal.group_selector_placeholder"
+                @placeholderKey="discourse_post_event.bulk_invite_modal.group_selector_placeholder"
                 @onChangeCallback={{fn
                   this.updateBulkGroupInviteIdentifier
                   bulkInvite
@@ -43,7 +39,7 @@
                 @onChange={{fn this.updateInviteIdentifier bulkInvite}}
                 @options={{hash
                   maximum=1
-                  filterPlaceholder="discourse_calendar.discourse_post_event.bulk_invite_modal.user_selector_placeholder"
+                  filterPlaceholder="discourse_post_event.bulk_invite_modal.user_selector_placeholder"
                 }}
               />
             {{/if}}
@@ -69,7 +65,7 @@
       <div class="bulk-invite-actions">
         <DButton
           class="send-bulk-invites btn-primary"
-          @label="discourse_calendar.discourse_post_event.bulk_invite_modal.send_bulk_invites"
+          @label="discourse_post_event.bulk_invite_modal.send_bulk_invites"
           @action={{this.sendBulkInvites}}
           @disabled={{this.bulkInviteDisabled}}
         />
@@ -82,9 +78,7 @@
     </div>
 
     <div class="csv-bulk-invites">
-      <h3>{{i18n
-          "discourse_calendar.discourse_post_event.bulk_invite_modal.csv_title"
-        }}</h3>
+      <h3>{{i18n "discourse_post_event.bulk_invite_modal.csv_title"}}</h3>
 
       <div class="bulk-invite-actions">
         <BulkInviteSampleCsvFile />
@@ -96,7 +90,7 @@
             @model.event.id
             "/csv-bulk-invite"
           }}
-          @i18nPrefix="discourse_calendar.discourse_post_event.bulk_invite_modal"
+          @i18nPrefix="discourse_post_event.bulk_invite_modal"
           @uploadDone={{this.uploadDone}}
         />
       </div>

--- a/assets/javascripts/discourse/components/modal/post-event-bulk-invite.js
+++ b/assets/javascripts/discourse/components/modal/post-event-bulk-invite.js
@@ -22,27 +22,19 @@ export default class PostEventBulkInvite extends Component {
   get bulkInviteStatuses() {
     return [
       {
-        label: I18n.t(
-          "discourse_calendar.discourse_post_event.models.invitee.status.unknown"
-        ),
+        label: I18n.t("discourse_post_event.models.invitee.status.unknown"),
         name: "unknown",
       },
       {
-        label: I18n.t(
-          "discourse_calendar.discourse_post_event.models.invitee.status.going"
-        ),
+        label: I18n.t("discourse_post_event.models.invitee.status.going"),
         name: "going",
       },
       {
-        label: I18n.t(
-          "discourse_calendar.discourse_post_event.models.invitee.status.not_going"
-        ),
+        label: I18n.t("discourse_post_event.models.invitee.status.not_going"),
         name: "not_going",
       },
       {
-        label: I18n.t(
-          "discourse_calendar.discourse_post_event.models.invitee.status.interested"
-        ),
+        label: I18n.t("discourse_post_event.models.invitee.status.interested"),
         name: "interested",
       },
     ];
@@ -105,9 +97,7 @@ export default class PostEventBulkInvite extends Component {
   @action
   async uploadDone() {
     await this.dialog.alert(
-      I18n.t(
-        "discourse_calendar.discourse_post_event.bulk_invite_modal.success"
-      )
+      I18n.t("discourse_post_event.bulk_invite_modal.success")
     );
     this.args.closeModal();
   }

--- a/assets/javascripts/discourse/components/modal/post-event-invite-user-or-group.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-invite-user-or-group.hbs
@@ -1,7 +1,5 @@
 <DModal
-  @title={{i18n
-    "discourse_calendar.discourse_post_event.invite_user_or_group.title"
-  }}
+  @title={{i18n "discourse_post_event.invite_user_or_group.title"}}
   @closeModal={{@closeModal}}
   @flash={{this.flash}}
 >
@@ -24,7 +22,7 @@
     <DButton
       @type="button"
       class="btn-primary"
-      @label="discourse_calendar.discourse_post_event.invite_user_or_group.invite"
+      @label="discourse_post_event.invite_user_or_group.invite"
       @action={{this.invite}}
     />
   </:footer>

--- a/assets/javascripts/discourse/components/modal/post-event-invitees/index.gjs
+++ b/assets/javascripts/discourse/components/modal/post-event-invitees/index.gjs
@@ -39,7 +39,7 @@ export default class PostEventInviteesModal extends Component {
 
   get title() {
     return I18n.t(
-      `discourse_calendar.discourse_post_event.invitees_modal.${
+      `discourse_post_event.invitees_modal.${
         this.args.model.title || "title_invited"
       }`
     );
@@ -103,7 +103,7 @@ export default class PostEventInviteesModal extends Component {
           {{on "input" this.onFilterChanged}}
           type="text"
           placeholder={{i18n
-            "discourse_calendar.discourse_post_event.invitees_modal.filter_placeholder"
+            "discourse_post_event.invitees_modal.filter_placeholder"
           }}
           class="filter"
         />
@@ -121,7 +121,7 @@ export default class PostEventInviteesModal extends Component {
                       @icon="trash-alt"
                       @action={{fn this.removeInvitee invitee}}
                       title={{i18n
-                        "discourse_calendar.discourse_post_event.invitees_modal.remove_invitee"
+                        "discourse_post_event.invitees_modal.remove_invitee"
                       }}
                     />
                   {{/if}}
@@ -138,7 +138,7 @@ export default class PostEventInviteesModal extends Component {
                       @icon="plus"
                       @action={{fn this.addInvitee user}}
                       title={{i18n
-                        "discourse_calendar.discourse_post_event.invitees_modal.add_invitee"
+                        "discourse_post_event.invitees_modal.add_invitee"
                       }}
                     />
                   </li>
@@ -147,9 +147,7 @@ export default class PostEventInviteesModal extends Component {
             {{/if}}
           {{else}}
             <p class="no-users">
-              {{i18n
-                "discourse_calendar.discourse_post_event.models.invitee.no_users"
-              }}
+              {{i18n "discourse_post_event.models.invitee.no_users"}}
             </p>
           {{/if}}
         </ConditionalLoadingSpinner>

--- a/assets/javascripts/discourse/components/toggle-invitees.hbs
+++ b/assets/javascripts/discourse/components/toggle-invitees.hbs
@@ -1,6 +1,6 @@
 <div class="invitees-type-filter">
   <DButton
-    @label="discourse_calendar.discourse_post_event.models.invitee.status.going"
+    @label="discourse_post_event.models.invitee.status.going"
     class={{concat-class
       "btn toggle-going"
       (if (eq @viewType "going") "btn-danger" "btn-default")
@@ -9,7 +9,7 @@
   />
 
   <DButton
-    @label="discourse_calendar.discourse_post_event.models.invitee.status.interested"
+    @label="discourse_post_event.models.invitee.status.interested"
     class={{concat-class
       "btn toggle-interested"
       (if (eq @viewType "interested") "btn-danger" "btn-default")
@@ -18,7 +18,7 @@
   />
 
   <DButton
-    @label="discourse_calendar.discourse_post_event.models.invitee.status.not_going"
+    @label="discourse_post_event.models.invitee.status.not_going"
     class={{concat-class
       "btn toggle-not-going"
       (if (eq @viewType "not_going") "btn-danger" "btn-default")

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -32,21 +32,11 @@ export default class UpcomingEventsList extends Component {
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
 
-  title = I18n.t(
-    "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-  );
-  emptyMessage = I18n.t(
-    "discourse_calendar.discourse_post_event.upcoming_events_list.empty"
-  );
-  allDayLabel = I18n.t(
-    "discourse_calendar.discourse_post_event.upcoming_events_list.all_day"
-  );
-  errorMessage = I18n.t(
-    "discourse_calendar.discourse_post_event.upcoming_events_list.error"
-  );
-  viewAllLabel = I18n.t(
-    "discourse_calendar.discourse_post_event.upcoming_events_list.view_all"
-  );
+  title = I18n.t("discourse_post_event.upcoming_events_list.title");
+  emptyMessage = I18n.t("discourse_post_event.upcoming_events_list.empty");
+  allDayLabel = I18n.t("discourse_post_event.upcoming_events_list.all_day");
+  errorMessage = I18n.t("discourse_post_event.upcoming_events_list.error");
+  viewAllLabel = I18n.t("discourse_post_event.upcoming_events_list.view_all");
 
   constructor() {
     super(...arguments);
@@ -156,7 +146,7 @@ export default class UpcomingEventsList extends Component {
             </div>
             <DButton
               @action={{this.updateEventsList}}
-              @label="discourse_calendar.discourse_post_event.upcoming_events_list.try_again"
+              @label="discourse_post_event.upcoming_events_list.try_again"
               class="btn-link upcoming-events-list__try-again"
             />
           {{/if}}

--- a/assets/javascripts/discourse/initializers/add-event-ui-builder.js
+++ b/assets/javascripts/discourse/initializers/add-event-ui-builder.js
@@ -20,7 +20,7 @@ function initializeEventBuilder(api) {
     },
     group: "insertions",
     icon: "calendar-day",
-    label: "discourse_calendar.discourse_post_event.builder_modal.attach",
+    label: "discourse_post_event.builder_modal.attach",
     condition: (composer) => {
       if (!currentUser || !currentUser.can_create_discourse_post_event) {
         return false;

--- a/assets/javascripts/discourse/initializers/add-upcoming-events-to-sidebar.js
+++ b/assets/javascripts/discourse/initializers/add-upcoming-events-to-sidebar.js
@@ -15,12 +15,8 @@ export default {
           return class UpcomingEventsSectionLink extends baseSectionLink {
             name = "upcoming-events";
             route = "discourse-post-event-upcoming-events";
-            text = I18n.t(
-              "discourse_calendar.discourse_post_event.upcoming_events.title"
-            );
-            title = I18n.t(
-              "discourse_calendar.discourse_post_event.upcoming_events.title"
-            );
+            text = I18n.t("discourse_post_event.upcoming_events.title");
+            title = I18n.t("discourse_post_event.upcoming_events.title");
           };
         });
       });

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -285,7 +285,7 @@ function initializeDiscourseCalendar(api) {
           get label() {
             if (
               this.notification.data.message ===
-              "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification"
+              "discourse_post_event.notifications.invite_user_predefined_attendance_notification"
             ) {
               return I18n.t(this.notification.data.message, {
                 username: this.username,

--- a/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
+++ b/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
@@ -8,7 +8,7 @@ function _validEventPreview(eventContainer) {
   eventContainer.innerHTML = "";
   eventContainer.classList.add("discourse-post-event-preview");
 
-  const statusLocaleKey = `discourse_calendar.discourse_post_event.models.event.status.${
+  const statusLocaleKey = `discourse_post_event.models.event.status.${
     eventContainer.dataset.status || "public"
   }.title`;
   if (I18n.lookup(statusLocaleKey, { locale: "en" })) {
@@ -56,7 +56,7 @@ function _invalidEventPreview(eventContainer) {
   );
   eventContainer.classList.remove("discourse-post-event");
   eventContainer.innerText = I18n.t(
-    "discourse_calendar.discourse_post_event.preview.more_than_one_event"
+    "discourse_post_event.preview.more_than_one_event"
   );
 }
 

--- a/assets/javascripts/discourse/lib/event-relative-date.js
+++ b/assets/javascripts/discourse/lib/event-relative-date.js
@@ -8,12 +8,9 @@ function _computeCurrentEvent(container, endsAt) {
 
   const text = document.createElement("span");
   text.classList.add("text");
-  text.innerText = I18n.t(
-    "discourse_calendar.discourse_post_event.topic_title.ends_in_duration",
-    {
-      duration: endsAt.from(moment()),
-    }
-  );
+  text.innerText = I18n.t("discourse_post_event.topic_title.ends_in_duration", {
+    duration: endsAt.from(moment()),
+  });
   container.appendChild(text);
 }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -307,170 +307,11 @@ en:
         week: "Week"
         day: "Day"
         list: "List"
-      discourse_post_event:
-        notifications:
-          invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to"
-          before_event_reminder: "An event is about to start"
-          after_event_reminder: "An event has ended"
-          ongoing_event_reminder: "An event is ongoing"
-          # TODO: delete the following keys (until ongoing_event_reminder_html)
-          # when event-invitation and event-reminder notification item widgets
-          # are removed
-          invite_user_notification: "%{username} %{description}"
-          invite_user_predefined_attendance_notification_html: "%{username} has automatically set your attendance and invited you to %{description}"
-          before_event_reminder_html: "An event is about to start %{description}"
-          after_event_reminder_html: "An event has ended %{description}"
-          ongoing_event_reminder_html: "An event is ongoing  %{description}"
-        preview:
-          more_than_one_event: "You can’t have more than one event."
-        edit_reason: "Event updated"
-        topic_title:
-          starts_at: "Event will start: %{date}"
-          ended_at: "Event ended: %{date}"
-          ends_in_duration: "Ends %{duration}"
-        models:
-          invitee:
-            no_users: "No users found"
-            status:
-              unknown: "Not interested"
-              going: "Going"
-              not_going: "Not Going"
-              interested: "Interested"
-              going_count:
-                one: "%{count} going"
-                other: "%{count} going"
-              not_going_count:
-                one: "%{count} not going"
-                other: "%{count} not going"
-              interested_count:
-                one: "%{count} interested"
-                other: "%{count} interested"
-              invited_count:
-                one: "%{count} user invited"
-                other: "%{count} users invited"
-          event:
-            expired: "Expired"
-            closed: "Closed"
-            status:
-              standalone:
-                title: "Standalone"
-                description: "A standalone event can't be joined."
-              public:
-                title: "Public"
-                description: "A public event can be joined by anyone."
-              private:
-                title: "Private"
-                description: "A private event can only be joined by invited users."
-        event_ui:
-          show_all: "Show all"
-          show_participants: "Show participants"
-          participants:
-            one: "%{count} user participated."
-            other: "%{count} users participated."
-          invite: "Notify user"
-          add_to_calendar: "Add to calendar"
-          send_pm_to_creator: "Send PM to %{username}"
-          leave: "Leave event"
-          edit_event: "Edit event"
-          export_event: "Export event"
-          created_by: "Created by"
-          bulk_invite: "Bulk Invite"
-          close_event: "Close event"
-          open_event: "Open event"
-        invitees_modal:
-          title_invited: "Event Participation"
-          title_participated: "List of users who participated"
-          filter_placeholder: "Filter users"
-          remove_invitee: "Remove invitee from list"
-          add_invitee: "Add invitee to list"
-        bulk_invite_modal:
-          confirm: "confirm"
-          text: "Upload CSV file"
-          title: "Bulk Invite"
-          success: "File uploaded successfully, you will be notified via message when the process is complete."
-          error: "Sorry, file should be CSV format."
-          confirmation_message: "You’re about to notify everyone in the uploaded file."
-          description_public: "Public events only accept usernames for bulk invites."
-          description_private: "Private events only accept group names for bulk invites."
-          download_sample_csv: "Download a sample CSV file"
-          send_bulk_invites: "Send invites"
-          group_selector_placeholder: "Choose a group..."
-          user_selector_placeholder: "Choose user..."
-          inline_title: "Inline bulk invite"
-          csv_title: "CSV bulk invite"
-        builder_modal:
-          custom_fields:
-            label: "Custom Fields"
-            placeholder: "Optional"
-            description: "Allowed custom fields are defined in site settings. Custom fields are used to transmit data to other plugins."
-          create_event_title: "Create Event"
-          update_event_title: "Edit Event"
-          confirm_delete: "Are you sure you want to delete this event?"
-          confirm_close: "Are you sure you want to close this event?"
-          confirm_open: "Are you sure you want to open this event?"
-          create: "Create"
-          update: "Save"
-          attach: "Create event"
-          add_reminder: "Add reminder"
-          timezone:
-            label: Timezone
-            remove_timezone: No timezone (UTC)
-          reminders:
-            label: "Reminders"
-            types:
-              bump_topic: "auto-bump topic"
-              notification: "notify participants"
-            units:
-              minutes: "minutes"
-              hours: "hours"
-              days: "days"
-              weeks: "weeks"
-            periods:
-              before: "before"
-              after: "after"
-          recurrence:
-            label: "Recurrence"
-            none: "No recurrence"
-            every_day: "Every day"
-            every_month: "Every month at this weekday"
-            every_weekday: "Every weekday"
-            every_week: "Every week at this weekday"
-            every_two_weeks: "Every two weeks at this weekday"
-            every_four_weeks: "Every four weeks at this weekday"
-          minimal:
-            label: "Minimal event"
-            checkbox_label: "Hide Going/Not going buttons and invitees status"
-          url:
-            label: "URL"
-            placeholder: "Optional"
-          name:
-            label: "Event name"
-            placeholder: "Optional, defaults to topic title"
-          invitees:
-            label: "Invited groups"
-          status:
-            label: "Status"
-        invite_user_or_group:
-          title: "Notify user(s) or group(s)"
-          invite: "Send"
-        upcoming_events:
-          title: "Upcoming events"
-          creator: "Creator"
-          status: "Status"
-          starts_at: "Starts at"
-        upcoming_events_list:
-          title: "Upcoming events"
-          empty: "No upcoming events"
-          all_day: "All-day"
-          error: "Failed to retrieve events"
-          try_again: "Try again"
-          view_all: "View all"
     group_timezones:
       search: "Search..."
       group_availability: "%{group} availability"
     discourse_post_event:
       notifications:
-        invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to"
         before_event_reminder: "An event is about to start"
         after_event_reminder: "An event has ended"
         ongoing_event_reminder: "An event is ongoing"
@@ -482,8 +323,6 @@ en:
         before_event_reminder_html: "An event is about to start %{description}"
         after_event_reminder_html: "An event has ended %{description}"
         ongoing_event_reminder_html: "An event is ongoing  %{description}"
-      preview:
-        more_than_one_event: "You can’t have more than one event."
       edit_reason: "Event updated"
       edit_reason_closed: "Event closed"
       edit_reason_opened: "Event opened"
@@ -491,45 +330,27 @@ en:
         starts_at: "Event will start: %{date}"
         ended_at: "Event ended: %{date}"
         ends_in_duration: "Ends %{duration}"
-      models:
-        invitee:
-          no_users: "There are no users of this type."
-          status:
-            unknown: "Not interested"
-            going: "Going"
-            not_going: "Not Going"
-            interested: "Interested"
-        event:
-          expired: "Expired"
-          status:
-            standalone:
-              title: "Standalone"
-              description: "A standalone event can't be joined."
-            public:
-              title: "Public"
-              description: "A public event can be joined by anyone."
-            private:
-              title: "Private"
-              description: "A private event can only be joined by invited users."
-      event_ui:
-        show_all: "Show all"
-        participants:
-          one: "%{count} user participated."
-          other: "%{count} users participated."
-        invite: "Notify user"
-        add_to_calendar: "Add to calendar"
-        upcoming_events: "Upcoming events"
-        send_pm_to_creator: "Send PM to %{username}"
-        leave: "Leave event"
-        edit_event: "Edit event"
-        export_event: "Export event"
-        created_by: "Created by"
-        bulk_invite: "Bulk Invite"
-        close_event: "Close event"
+      show_all: "Show all"
+      show_participants: "Show participants"
+      participants:
+        one: "%{count} user participated."
+        other: "%{count} users participated."
+      invite: "Notify user"
+      add_to_calendar: "Add to calendar"
+      send_pm_to_creator: "Send PM to %{username}"
+      leave: "Leave event"
+      edit_event: "Edit event"
+      export_event: "Export event"
+      created_by: "Created by"
+      bulk_invite: "Bulk Invite"
+      close_event: "Close event"
+      open_event: "Open event"
       invitees_modal:
-        title_invited: "List of RSVPed users"
+        title_invited: "Event Participation"
         title_participated: "List of users who participated"
         filter_placeholder: "Filter users"
+        remove_invitee: "Remove invitee from list"
+        add_invitee: "Add invitee to list"
       bulk_invite_modal:
         confirm: "confirm"
         text: "Upload CSV file"
@@ -545,6 +366,58 @@ en:
         user_selector_placeholder: "Choose user..."
         inline_title: "Inline bulk invite"
         csv_title: "CSV bulk invite"
+      upcoming_events:
+        title: "Upcoming events"
+        creator: "Creator"
+        status: "Status"
+        starts_at: "Starts at"
+      upcoming_events_list:
+        title: "Upcoming events"
+        empty: "No upcoming events"
+        all_day: "All-day"
+        error: "Failed to retrieve events"
+        try_again: "Try again"
+        view_all: "View all"
+      category:
+        sort_topics_by_event_start_date: "Sort topics by event start date."
+        disable_topic_resorting: "Disable topic resorting."
+        settings_sections:
+          event_sorting: "Event Sorting"
+      preview:
+        more_than_one_event: "You can’t have more than one event."
+      models:
+        invitee:
+          no_users: "No users found"
+          status:
+            unknown: "Not interested"
+            going: "Going"
+            not_going: "Not Going"
+            interested: "Interested"
+            going_count:
+              one: "%{count} going"
+              other: "%{count} going"
+            not_going_count:
+              one: "%{count} not going"
+              other: "%{count} not going"
+            interested_count:
+              one: "%{count} interested"
+              other: "%{count} interested"
+            invited_count:
+              one: "%{count} user invited"
+              other: "%{count} users invited"
+        event:
+          expired: "Expired"
+          closed: "Closed"
+          status:
+            standalone:
+              title: "Standalone"
+              description: "A standalone event can't be joined."
+            public:
+              title: "Public"
+              description: "A public event can be joined by anyone."
+            private:
+              title: "Private"
+              description: "A private event can only be joined by invited users."
       builder_modal:
         custom_fields:
           label: "Custom Fields"
@@ -554,6 +427,7 @@ en:
         update_event_title: "Edit Event"
         confirm_delete: "Are you sure you want to delete this event?"
         confirm_close: "Are you sure you want to close this event?"
+        confirm_open: "Are you sure you want to open this event?"
         create: "Create"
         update: "Save"
         attach: "Create event"
@@ -599,19 +473,3 @@ en:
       invite_user_or_group:
         title: "Notify user(s) or group(s)"
         invite: "Send"
-      upcoming_events:
-        title: "Upcoming events"
-        creator: "Creator"
-        status: "Status"
-        starts_at: "Starts at"
-      upcoming_events_list:
-        title: "Upcoming events"
-        empty: "No upcoming events"
-        all_day: "All-day"
-        error: "Failed to retrieve events"
-        try_again: "Try again"
-    category:
-      sort_topics_by_event_start_date: "Sort topics by event start date."
-      disable_topic_resorting: "Disable topic resorting."
-      settings_sections:
-        event_sorting: "Event Sorting"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -66,34 +66,34 @@ en:
     event_expired: "Event expired"
     holiday_status:
       description: "On holiday"
-    discourse_post_event:
-      notifications:
-        before_event_reminder: "%{title} is about to start."
-        after_event_reminder: "%{title} has ended."
-        ongoing_event_reminder: "%{title} is ongoing."
-      errors:
-        bulk_invite:
-          max_invitees: "First %{max_invittes} invitees have been created. Try splitting the file in smaller parts."
-          error: "There was an error uploading that file. Please try again later."
-        models:
-          event:
-            only_one_event: "A post can only have one event."
-            must_be_in_first_post: "An event can only be in the first post of a topic."
-            raw_invitees_length: "An event is limited to %{count} users/groups."
-            raw_invitees:
-              only_group: "An event accepts only group names."
-            ends_at_before_starts_at: "An event can't end before it starts."
-            start_must_be_present_and_a_valid_date: "An event requires a valid start date."
-            end_must_be_a_valid_date: "End date must be a valid date."
-            invalid_recurrence: "Recurrence must be one of: every_month, every_week, every_two_weeks, every_four_weeks, every_day, every_weekday."
-            invalid_timezone: "Timezone not recognized."
-            acting_user_not_allowed_to_create_event: "Current user is not allowed to create events."
-            acting_user_not_allowed_to_act_on_this_event: "Current user is not allowed to act on this event."
-            invalid_allowed_groups: "Invalid allowed groups."
-            acting_user_not_allowed_to_invite_these_groups: "Current user is not allowed to invite these groups."
-            custom_field_is_invalid: "The custom field `%{field}` is not allowed."
-            name:
-              length: "Event name length must be between %{minimum} and %{maximum} characters."
+  discourse_post_event:
+    notifications:
+      before_event_reminder: "%{title} is about to start."
+      after_event_reminder: "%{title} has ended."
+      ongoing_event_reminder: "%{title} is ongoing."
+    errors:
+      bulk_invite:
+        max_invitees: "First %{max_invittes} invitees have been created. Try splitting the file in smaller parts."
+        error: "There was an error uploading that file. Please try again later."
+      models:
+        event:
+          only_one_event: "A post can only have one event."
+          must_be_in_first_post: "An event can only be in the first post of a topic."
+          raw_invitees_length: "An event is limited to %{count} users/groups."
+          raw_invitees:
+            only_group: "An event accepts only group names."
+          ends_at_before_starts_at: "An event can't end before it starts."
+          start_must_be_present_and_a_valid_date: "An event requires a valid start date."
+          end_must_be_a_valid_date: "End date must be a valid date."
+          invalid_recurrence: "Recurrence must be one of: every_month, every_week, every_two_weeks, every_four_weeks, every_day, every_weekday."
+          invalid_timezone: "Timezone not recognized."
+          acting_user_not_allowed_to_create_event: "Current user is not allowed to create events."
+          acting_user_not_allowed_to_act_on_this_event: "Current user is not allowed to act on this event."
+          invalid_allowed_groups: "Invalid allowed groups."
+          acting_user_not_allowed_to_invite_these_groups: "Current user is not allowed to invite these groups."
+          custom_field_is_invalid: "The custom field `%{field}` is not allowed."
+          name:
+            length: "Event name length must be between %{minimum} and %{maximum} characters."
   discourse_push_notifications:
     popup:
       event_reminder: "Event Reminder"

--- a/jobs/regular/discourse_post_event/send_reminder.rb
+++ b/jobs/regular/discourse_post_event/send_reminder.rb
@@ -66,8 +66,7 @@ module Jobs
           data: {
             topic_title: event.name || event.post.topic.title,
             display_username: invitee.user.username,
-            message:
-              "discourse_calendar.discourse_post_event.notifications.#{prefix}_event_reminder",
+            message: "discourse_post_event.notifications.#{prefix}_event_reminder",
           }.to_json,
         }
 
@@ -80,7 +79,7 @@ module Jobs
           notification_type: Notification.types[:event_reminder] || Notification.types[:custom],
           excerpt:
             I18n.t(
-              "discourse_calendar.discourse_post_event.notifications.#{prefix}_event_reminder",
+              "discourse_post_event.notifications.#{prefix}_event_reminder",
               title: event.name || event.post.topic.title,
               locale: invitee.user.effective_locale,
             ),

--- a/lib/discourse_post_event/event_validator.rb
+++ b/lib/discourse_post_event/event_validator.rb
@@ -21,19 +21,14 @@ module DiscoursePostEvent
       return false if extracted_events.count == 0
 
       if extracted_events.count > 1
-        @post.errors.add(
-          :base,
-          I18n.t("discourse_calendar.discourse_post_event.errors.models.event.only_one_event"),
-        )
+        @post.errors.add(:base, I18n.t("discourse_post_event.errors.models.event.only_one_event"))
         return false
       end
 
       if !@post.is_first_post?
         @post.errors.add(
           :base,
-          I18n.t(
-            "discourse_calendar.discourse_post_event.errors.models.event.must_be_in_first_post",
-          ),
+          I18n.t("discourse_post_event.errors.models.event.must_be_in_first_post"),
         )
         return false
       end
@@ -47,7 +42,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_act_on_this_event",
+              "discourse_post_event.errors.models.event.acting_user_not_allowed_to_act_on_this_event",
             ),
           )
           return false
@@ -57,7 +52,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
+              "discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
             ),
           )
           return false
@@ -74,9 +69,7 @@ module DiscoursePostEvent
            ).nil?
         @post.errors.add(
           :base,
-          I18n.t(
-            "discourse_calendar.discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date",
-          ),
+          I18n.t("discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date"),
         )
         return false
       end
@@ -91,9 +84,7 @@ module DiscoursePostEvent
            ).nil?
         @post.errors.add(
           :base,
-          I18n.t(
-            "discourse_calendar.discourse_post_event.errors.models.event.end_must_be_a_valid_date",
-          ),
+          I18n.t("discourse_post_event.errors.models.event.end_must_be_a_valid_date"),
         )
         return false
       end
@@ -102,9 +93,7 @@ module DiscoursePostEvent
         if Time.parse(extracted_event[:start]) > Time.parse(extracted_event[:end])
           @post.errors.add(
             :base,
-            I18n.t(
-              "discourse_calendar.discourse_post_event.errors.models.event.ends_at_before_starts_at",
-            ),
+            I18n.t("discourse_post_event.errors.models.event.ends_at_before_starts_at"),
           )
           return false
         end
@@ -115,7 +104,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_calendar.discourse_post_event.errors.models.event.name.length",
+              "discourse_post_event.errors.models.event.name.length",
               minimum: Event::MIN_NAME_LENGTH,
               maximum: Event::MAX_NAME_LENGTH,
             ),
@@ -128,9 +117,7 @@ module DiscoursePostEvent
         if !VALID_RECURRENCES.include?(extracted_event[:recurrence].to_s)
           @post.errors.add(
             :base,
-            I18n.t(
-              "discourse_calendar.discourse_post_event.errors.models.event.invalid_recurrence",
-            ),
+            I18n.t("discourse_post_event.errors.models.event.invalid_recurrence"),
           )
         end
       end
@@ -140,7 +127,7 @@ module DiscoursePostEvent
           @post.errors.add(
             :base,
             I18n.t(
-              "discourse_calendar.discourse_post_event.errors.models.event.invalid_timezone",
+              "discourse_post_event.errors.models.event.invalid_timezone",
               timezone: extracted_event[:timezone],
             ),
           )
@@ -169,9 +156,7 @@ module DiscoursePostEvent
           if !group || !guardian.can_see_group?(group)
             @post.errors.add(
               :base,
-              I18n.t(
-                "discourse_calendar.discourse_post_event.errors.models.event.invalid_allowed_groups",
-              ),
+              I18n.t("discourse_post_event.errors.models.event.invalid_allowed_groups"),
             )
             return false
           end
@@ -180,7 +165,7 @@ module DiscoursePostEvent
             @post.errors.add(
               :base,
               I18n.t(
-                "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_invite_these_groups",
+                "discourse_post_event.errors.models.event.acting_user_not_allowed_to_invite_these_groups",
               ),
             )
             return false

--- a/spec/integration/post_spec.rb
+++ b/spec/integration/post_spec.rb
@@ -324,7 +324,7 @@ describe Post do
             end.to(
               raise_error(ActiveRecord::RecordNotSaved).with_message(
                 I18n.t(
-                  "discourse_calendar.discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
+                  "discourse_post_event.errors.models.event.acting_user_not_allowed_to_create_event",
                 ),
               ),
             )
@@ -344,7 +344,7 @@ describe Post do
             end.to(
               raise_error(ActiveRecord::RecordNotSaved).with_message(
                 I18n.t(
-                  "discourse_calendar.discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date",
+                  "discourse_post_event.errors.models.event.start_must_be_present_and_a_valid_date",
                 ),
               ),
             )
@@ -354,9 +354,7 @@ describe Post do
         context "when recurrence is invalid" do
           it "raises an error" do
             expect { create_post_with_event(user, 'recurrence="foo"') }.to raise_error(
-              I18n.t(
-                "discourse_calendar.discourse_post_event.errors.models.event.invalid_recurrence",
-              ),
+              I18n.t("discourse_post_event.errors.models.event.invalid_recurrence"),
             )
           end
         end
@@ -382,9 +380,7 @@ describe Post do
               )
             end.to(
               raise_error(ActiveRecord::RecordNotSaved).with_message(
-                I18n.t(
-                  "discourse_calendar.discourse_post_event.errors.models.event.end_must_be_a_valid_date",
-                ),
+                I18n.t("discourse_post_event.errors.models.event.end_must_be_a_valid_date"),
               ),
             )
           end
@@ -401,7 +397,7 @@ describe Post do
                 [/event]
               TXT
             raise_error(ActiveRecord::RecordNotSaved).with_message(
-              I18n.t("discourse_calendar.discourse_post_event.errors.models.event.only_one_event"),
+              I18n.t("discourse_post_event.errors.models.event.only_one_event"),
             ),
           )
         end
@@ -761,9 +757,7 @@ describe Post do
           title: "Beach party",
           raw: "[event start='2022-07-24 14:01' timezone='Westeros/Winterfell']\n[/event]",
         )
-      }.to raise_error(
-        I18n.t("discourse_calendar.discourse_post_event.errors.models.event.invalid_timezone"),
-      )
+      }.to raise_error(I18n.t("discourse_post_event.errors.models.event.invalid_timezone"))
     end
 
     it "handles simple weekly recurrence correctly" do

--- a/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
+++ b/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
@@ -249,8 +249,7 @@ describe Jobs::DiscoursePostEventSendReminder do
             data: {
               topic_title: event_1.name || post_1.topic.title,
               display_username: going_user.username,
-              message:
-                "discourse_calendar.discourse_post_event.notifications.before_event_reminder",
+              message: "discourse_post_event.notifications.before_event_reminder",
             }.to_json,
           )
 
@@ -265,8 +264,8 @@ describe Jobs::DiscoursePostEventSendReminder do
             ).pluck("data::json ->> 'message'")
 
           expect(messages).to contain_exactly(
-            "discourse_calendar.discourse_post_event.notifications.before_event_reminder",
-            "discourse_calendar.discourse_post_event.notifications.ongoing_event_reminder",
+            "discourse_post_event.notifications.before_event_reminder",
+            "discourse_post_event.notifications.ongoing_event_reminder",
           )
         end
 

--- a/test/javascripts/acceptance/notifications-test.js
+++ b/test/javascripts/acceptance/notifications-test.js
@@ -26,7 +26,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Monthly Hangout #3",
               display_username: "fun-haver",
               message:
-                "discourse_calendar.discourse_post_event.notifications.before_event_reminder",
+                "discourse_post_event.notifications.before_event_reminder",
             },
           },
           {
@@ -44,7 +44,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Fancy title and pants",
               display_username: "fancy-pants-wearer",
               message:
-                "discourse_calendar.discourse_post_event.notifications.ongoing_event_reminder",
+                "discourse_post_event.notifications.ongoing_event_reminder",
             },
           },
           {
@@ -62,7 +62,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Topic with event and after_event reminder",
               display_username: "attender-no193",
               message:
-                "discourse_calendar.discourse_post_event.notifications.after_event_reminder",
+                "discourse_post_event.notifications.after_event_reminder",
             },
           },
           {
@@ -80,7 +80,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Tuesdays are for Among Us",
               display_username: "imposter",
               message:
-                "discourse_calendar.discourse_post_event.notifications.invite_user_notification",
+                "discourse_post_event.notifications.invite_user_notification",
             },
           },
           {
@@ -98,7 +98,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               topic_title: "Asia Pacific team call",
               display_username: "apacer",
               message:
-                "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification",
+                "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
             },
           },
         ],
@@ -118,7 +118,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[0].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_calendar.discourse_post_event.notifications.before_event_reminder"
+        "discourse_post_event.notifications.before_event_reminder"
       )} Monthly Hangout #3`,
       "before event reminder notification has the right content"
     );
@@ -133,7 +133,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_calendar.discourse_post_event.notifications.ongoing_event_reminder"
+        "discourse_post_event.notifications.ongoing_event_reminder"
       )} Fancy title and pants`,
       "ongoing event reminder notification has the right content"
     );
@@ -148,7 +148,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[2].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_calendar.discourse_post_event.notifications.after_event_reminder"
+        "discourse_post_event.notifications.after_event_reminder"
       )} Topic with event and after_event reminder`,
       "after event reminder notification has the right content"
     );
@@ -178,7 +178,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
     assert.strictEqual(
       notifications[4].textContent.replaceAll(/\s+/g, " ").trim(),
       `${I18n.t(
-        "discourse_calendar.discourse_post_event.notifications.invite_user_predefined_attendance_notification",
+        "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
         { username: "apacer" }
       )} Asia Pacific team call`,
       "event invitation with predefined attendance notification has the right content"

--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -24,7 +24,7 @@ acceptance("Post event - composer", function (needs) {
     await click(".toolbar-popup-menu-options .dropdown-select-box-header");
     await click(
       `.toolbar-popup-menu-options *[data-name='${I18n.t(
-        "discourse_calendar.discourse_post_event.builder_modal.attach"
+        "discourse_post_event.builder_modal.attach"
       )}']`
     );
 
@@ -94,7 +94,7 @@ acceptance("Post event - composer", function (needs) {
       await click(".toolbar-popup-menu-options .dropdown-select-box-header");
       await click(
         `.toolbar-popup-menu-options *[data-name='${I18n.t(
-          "discourse_calendar.discourse_post_event.builder_modal.attach"
+          "discourse_post_event.builder_modal.attach"
         )}']`
       );
 

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -59,9 +59,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.title"),
       "it displays the title"
     );
 
@@ -69,9 +67,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__empty-message").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.empty"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.empty"),
       "it displays the empty list message"
     );
   });
@@ -85,9 +81,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.title"),
       "it displays the title"
     );
 
@@ -120,9 +114,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
         (el) => el.innerText
       ),
       [
-        I18n.t(
-          "discourse_calendar.discourse_post_event.upcoming_events_list.all_day"
-        ),
+        I18n.t("discourse_post_event.upcoming_events_list.all_day"),
         moment(nextMonth).format(DEFAULT_TIME_FORMAT),
       ],
       "it displays the formatted time"
@@ -153,9 +145,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__view-all").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.view_all"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.view_all"),
       "it displays the view-all link"
     );
 
@@ -181,9 +171,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.title"),
       "it displays the title"
     );
 
@@ -202,9 +190,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
         (el) => el.innerText
       ),
       [
-        I18n.t(
-          "discourse_calendar.discourse_post_event.upcoming_events_list.all_day"
-        ),
+        I18n.t("discourse_post_event.upcoming_events_list.all_day"),
         moment(nextMonth).format("LLL"),
       ],
       "it displays the formatted time"
@@ -230,9 +216,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     assert
       .dom(".upcoming-events-list__heading")
       .hasText(
-        I18n.t(
-          "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-        ),
+        I18n.t("discourse_post_event.upcoming_events_list.title"),
         "it displays the title"
       );
 
@@ -258,9 +242,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.title"),
       "it displays the title"
     );
 
@@ -268,17 +250,13 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__error-message").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.error"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.error"),
       "it displays the error message"
     );
 
     assert.strictEqual(
       query(".upcoming-events-list__try-again").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.try_again"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.try_again"),
       "it displays the try again button"
     );
   });
@@ -294,9 +272,7 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
 
     assert.strictEqual(
       query(".upcoming-events-list__heading").innerText,
-      I18n.t(
-        "discourse_calendar.discourse_post_event.upcoming_events_list.title"
-      ),
+      I18n.t("discourse_post_event.upcoming_events_list.title"),
       "it displays the title"
     );
 


### PR DESCRIPTION
Various events in the life of this plugin have caused an over complicated key hierarchy and duplicated keys. This commit attempts to regroup everything related to discourse_post_event under a top level `discourse_post_event` key, removes the `event_ui` level as it's not very clear, technically everything is UI. And finally attempts to remove the duplicates.