### PR TITLE
FIX: correctly set upcoming events key

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -267,7 +267,9 @@ export default class DiscoursePostEventMoreMenu extends Component {
               <DButton
                 @icon="far-calendar-plus"
                 class="btn-transparent"
-                @translatedLabel={{i18n "discourse_post_event.upcoming_events"}}
+                @translatedLabel={{i18n
+                  "discourse_post_event.upcoming_events.title"
+                }}
                 @action={{this.upcomingEvents}}
               />
             </dropdown.item>


### PR DESCRIPTION
The previous one has been removed in https://github.com/discourse/discourse-calendar/commit/d31933bf4963ad8c107e9a9c0e8349a2b96145ad