### PR TITLE
FIX: prevents pushing null watching invitee

### DIFF
--- a/app/models/discourse_post_event/invitee.rb
+++ b/app/models/discourse_post_event/invitee.rb
@@ -25,6 +25,7 @@ module DiscoursePostEvent
       invitee
     rescue ActiveRecord::RecordNotUnique
       # do nothing in case multiple new attendances would be created very fast
+      Invitee.find_by(post_id: post_id, user_id: user_id)
     end
 
     def update_attendance!(status)

--- a/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -52,7 +52,7 @@ export default class DiscoursePostEventEvent {
     this.startsAt = args.starts_at;
     this.endsAt = args.ends_at;
     this.rawInvitees = args.raw_invitees;
-    this.sampleInvitees = args.sample_invitees;
+    this.sampleInvitees = args.sample_invitees || [];
     this.url = args.url;
     this.timezone = args.timezone;
     this.status = args.status;
@@ -87,9 +87,9 @@ export default class DiscoursePostEventEvent {
     return this._sampleInvitees;
   }
 
-  set sampleInvitees(invitees) {
+  set sampleInvitees(invitees = []) {
     this._sampleInvitees = new TrackedArray(
-      (invitees || []).map((u) => DiscoursePostEventInvitee.create(u))
+      invitees.map((i) => DiscoursePostEventInvitee.create(i))
     );
   }
 
@@ -143,7 +143,7 @@ export default class DiscoursePostEventEvent {
     this.canActOnDiscoursePostEvent = event.canActOnDiscoursePostEvent;
     this.shouldDisplayInvitees = event.shouldDisplayInvitees;
     this.stats = event.stats;
-    this.sampleInvitees = event.sampleInvitees;
+    this.sampleInvitees = event.sampleInvitees || [];
     this.reminders = event.reminders;
   }
 

--- a/assets/javascripts/discourse/models/discourse-post-event-invitees.js
+++ b/assets/javascripts/discourse/models/discourse-post-event-invitees.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import User from "discourse/models/user";
 import DiscoursePostEventInvitee from "./discourse-post-event-invitee";
@@ -7,37 +8,12 @@ export default class DiscoursePostEventInvitees {
     return new DiscoursePostEventInvitees(args);
   }
 
+  @tracked _invitees;
+  @tracked _suggestedUsers;
+
   constructor(args = {}) {
-    this.invitees = args.invitees;
-    this.suggestedUsers = args.meta?.suggested_users;
-  }
-
-  add(invitee) {
-    this.invitees.push(invitee);
-
-    const index = this.suggestedUsers.findIndex(
-      (su) => su.id === invitee.user.id
-    );
-    if (index > -1) {
-      this.suggestedUsers.splice(index, 1);
-    }
-  }
-
-  remove(invitee) {
-    const index = this.invitees.findIndex((i) => i.user.id === invitee.user.id);
-    if (index > -1) {
-      this.invitees.splice(index, 1);
-    }
-  }
-
-  get suggestedUsers() {
-    return this._suggestedUsers;
-  }
-
-  set suggestedUsers(suggestedUsers = []) {
-    this._suggestedUsers = new TrackedArray(
-      suggestedUsers.map((i) => User.create(i))
-    );
+    this.invitees = args.invitees || [];
+    this.suggestedUsers = args.meta?.suggested_users || [];
   }
 
   get invitees() {
@@ -48,5 +24,27 @@ export default class DiscoursePostEventInvitees {
     this._invitees = new TrackedArray(
       invitees.map((i) => DiscoursePostEventInvitee.create(i))
     );
+  }
+
+  get suggestedUsers() {
+    return this._suggestedUsers;
+  }
+
+  set suggestedUsers(suggestedUsers = []) {
+    this._suggestedUsers = new TrackedArray(
+      suggestedUsers.map((su) => User.create(su))
+    );
+  }
+
+  add(invitee) {
+    this.invitees.push(invitee);
+
+    this.suggestedUsers = this.suggestedUsers.filter(
+      (su) => su.id !== invitee.user.id
+    );
+  }
+
+  remove(invitee) {
+    this.invitees = this.invitees.filter((i) => i.user.id !== invitee.user.id);
   }
 }

--- a/assets/javascripts/discourse/services/discourse-post-event-api.js
+++ b/assets/javascripts/discourse/services/discourse-post-event-api.js
@@ -1,5 +1,4 @@
 import Service from "@ember/service";
-import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import { ajax } from "discourse/lib/ajax";
 import DiscoursePostEventEvent from "discourse/plugins/discourse-calendar/discourse/models/discourse-post-event-event";
 import DiscoursePostEventInvitee from "discourse/plugins/discourse-calendar/discourse/models/discourse-post-event-invitee";
@@ -63,8 +62,8 @@ export default class DiscoursePostEventApi extends Service {
   async leaveEvent(event, invitee) {
     await this.#deleteRequest(`/events/${event.id}/invitees/${invitee.id}`);
 
-    event.sampleInvitees = new TrackedArray(
-      event.sampleInvitees.filter((i) => i.id !== invitee.id)
+    event.sampleInvitees = event.sampleInvitees.filter(
+      (i) => i.id !== invitee.id
     );
 
     if (event.watchingInvitee?.id === invitee.id) {
@@ -81,9 +80,8 @@ export default class DiscoursePostEventApi extends Service {
 
     if (!data.user_id) {
       event.watchingInvitee = invitee;
+      event.sampleInvitees.push(event.watchingInvitee);
     }
-
-    event.sampleInvitees.push(event.watchingInvitee);
 
     event.stats = result.invitee.meta.event_stats;
     event.shouldDisplayInvitees =


### PR DESCRIPTION
This commit has 3 parts:

- Ensuring than when attempting to join a event we return an invitee even if the user was already part of the event, before we would return null which would have required a special handling. In this case we were just adding a null invitee.

- Ensures invitees/suggestedUsers/sampleInvitees use tracked properties correctly. And do not require to manually create a TrackedArray, the model should always handle this implementation detail.

- When joining an event we were pushing the watchingInvitee to the sampleInvitees even when the watchingInvitee was null, which would create an error.