### PR TITLE
FIX: category settings for calendar were incorrect

### DIFF
--- a/assets/javascripts/discourse/adapters/connectors/category-custom-settings/show-event-category-sorting-settings.hbs
+++ b/assets/javascripts/discourse/adapters/connectors/category-custom-settings/show-event-category-sorting-settings.hbs
@@ -1,27 +1,38 @@
-<section>
-  <h3>{{i18n "category.settings_sections.event_sorting"}}</h3>
+{{#if
+  (or
+    siteSettings.sort_categories_by_event_start_date_enabled
+    siteSettings.disable_resorting_on_categories_enabled
+  )
+}}
+  <section>
+    <h3>{{i18n
+        "discourse_post_event.category.settings_sections.event_sorting"
+      }}</h3>
 
-  {{#if siteSettings.sort_categories_by_event_start_date_enabled}}
-    <section class="field show-subcategory-list-field">
-      <label>
-        <Input
-          @type="checkbox"
-          @checked={{this.category.custom_fields.sort_topics_by_event_start_date}}
-        />
-        {{i18n "category.sort_topics_by_event_start_date"}}
-      </label>
-    </section>
-  {{/if}}
+    {{#if siteSettings.sort_categories_by_event_start_date_enabled}}
+      <section class="field show-subcategory-list-field">
+        <label>
+          <Input
+            @type="checkbox"
+            @checked={{this.category.custom_fields.sort_topics_by_event_start_date}}
+          />
+          {{i18n
+            "discourse_post_event.category.sort_topics_by_event_start_date"
+          }}
+        </label>
+      </section>
+    {{/if}}
 
-  {{#if siteSettings.disable_resorting_on_categories_enabled}}
-    <section class="field show-subcategory-list-field">
-      <label>
-        <Input
-          @type="checkbox"
-          @checked={{this.category.custom_fields.disable_topic_resorting}}
-        />
-        {{i18n "category.disable_topic_resorting"}}
-      </label>
-    </section>
-  {{/if}}
-</section>
+    {{#if siteSettings.disable_resorting_on_categories_enabled}}
+      <section class="field show-subcategory-list-field">
+        <label>
+          <Input
+            @type="checkbox"
+            @checked={{this.category.custom_fields.disable_topic_resorting}}
+          />
+          {{i18n "discourse_post_event.category.disable_topic_resorting"}}
+        </label>
+      </section>
+    {{/if}}
+  </section>
+{{/if}}


### PR DESCRIPTION
Following the key change in https://github.com/discourse/discourse-calendar/commit/d31933bf4963ad8c107e9a9c0e8349a2b96145ad this has been broken.

This commit also hides the section if `sort_categories_by_event_start_date_enabled` AND `disable_resorting_on_categories_enabled` are not enabled, prior to this change we would just show the title, with no checkbox to check.