### PR TITLE
FEATURE: keeps going invitees for recurring events

### DIFF
--- a/app/models/discourse_post_event/event.rb
+++ b/app/models/discourse_post_event/event.rb
@@ -53,12 +53,14 @@ module DiscoursePostEvent
         end
       end
 
-      publish_update!
-      invitees.update_all(status: nil, notified: false)
+      invitees.where.not(status: Invitee.statuses[:going]).update_all(status: nil, notified: false)
+
       if !next_dates[:rescheduled]
         notify_invitees!
         notify_missing_invitees!
       end
+
+      publish_update!
     end
 
     def set_topic_bump

--- a/app/models/discourse_post_event/event_date.rb
+++ b/app/models/discourse_post_event/event_date.rb
@@ -41,11 +41,6 @@ module DiscoursePostEvent
       end
     end
 
-    after_commit :reset_invitees_status, on: %i[create]
-    def reset_invitees_status
-      self.event.invitees.update_all(status: nil)
-    end
-
     def started?
       starts_at <= Time.current
     end

--- a/spec/integration/post_spec.rb
+++ b/spec/integration/post_spec.rb
@@ -130,16 +130,20 @@ describe Post do
                 expect(event_1.ends_at.to_s).to eq("2020-08-19 16:32:00 UTC")
               end
 
-              it "it removes status from every invitees" do
-                expect(event_1.invitees.pluck(:status)).to match_array(
-                  [
-                    DiscoursePostEvent::Invitee.statuses[:going],
-                    DiscoursePostEvent::Invitee.statuses[:interested],
-                  ],
-                )
+              it "it removes status from non going invitees" do
+                going_invitee =
+                  event_1.invitees.find_by(status: DiscoursePostEvent::Invitee.statuses[:going])
+                interested_invitee =
+                  event_1.invitees.find_by(
+                    status: DiscoursePostEvent::Invitee.statuses[:interested],
+                  )
 
                 event_1.update_with_params!(original_ends_at: Time.now)
-                expect(event_1.invitees.pluck(:status).compact).to eq([])
+
+                expect(going_invitee.reload.status).to eq(
+                  DiscoursePostEvent::Invitee.statuses[:going],
+                )
+                expect(interested_invitee.reload.status).to eq(nil)
               end
 
               # that will be handled by new job, uncomment when finished


### PR DESCRIPTION
Prior to this fix when computing the next event date we were resetting the status of every invitees. The status will now only be reset for non going users.