### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20200409102639_drop_incorrect_future_schema_migrations.rb
+++ b/db/migrate/20200409102639_drop_incorrect_future_schema_migrations.rb
@@ -9,4 +9,8 @@ class DropIncorrectFutureSchemaMigrations < ActiveRecord::Migration[5.2]
       DELETE FROM schema_migration_details WHERE version = '20201303000002';
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20200409120815_rename_topic_custom_field_topic_post_event_starts_at_index.rb
+++ b/db/migrate/20200409120815_rename_topic_custom_field_topic_post_event_starts_at_index.rb
@@ -10,4 +10,8 @@ class RenameTopicCustomFieldTopicPostEventStartsAtIndex < ActiveRecord::Migratio
               unique: true,
               where: "name = '#{DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT}'"
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20200409181607_remove_display_invitees.rb
+++ b/db/migrate/20200409181607_remove_display_invitees.rb
@@ -4,4 +4,8 @@ class RemoveDisplayInvitees < ActiveRecord::Migration[6.0]
   def up
     remove_column :discourse_post_event_events, :display_invitees
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20200926144256_add_unique_index_to_topic_event_ends_at_custom_field.rb
+++ b/db/migrate/20200926144256_add_unique_index_to_topic_event_ends_at_custom_field.rb
@@ -8,4 +8,8 @@ class AddUniqueIndexToTopicEventEndsAtCustomField < ActiveRecord::Migration[6.0]
               unique: true,
               where: "name = '#{DiscoursePostEvent::TOPIC_POST_EVENT_ENDS_AT}'"
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20220724130519_fix_post_event_timezones.rb
+++ b/db/migrate/20220724130519_fix_post_event_timezones.rb
@@ -30,4 +30,8 @@ class FixPostEventTimezones < ActiveRecord::Migration[7.0]
       AND topic_custom_fields.name IN ('TopicEventStartsAt', 'TopicEventEndsAt')
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.

