### PR TITLE
DEV: Convert helpers to plain functions

### DIFF
--- a/assets/javascripts/discourse/helpers/format-event-name.js
+++ b/assets/javascripts/discourse/helpers/format-event-name.js
@@ -1,7 +1,3 @@
-import { htmlHelper } from "discourse-common/lib/helpers";
-
 export function formatEventName(event) {
   return event.name || event.post.topic.title;
 }
-
-export default htmlHelper((event) => formatEventName(event));

--- a/assets/javascripts/discourse/helpers/format-future-date.js
+++ b/assets/javascripts/discourse/helpers/format-future-date.js
@@ -1,8 +1,8 @@
-import { htmlHelper } from "discourse-common/lib/helpers";
+import { htmlSafe } from "@ember/template";
 import guessDateFormat from "../lib/guess-best-date-format";
 
-export default htmlHelper((date) => {
+export default function (date) {
   date = moment.utc(date).tz(moment.tz.guess());
   const format = guessDateFormat(date);
-  return date.format(format);
-});
+  return htmlSafe(date.format(format));
+}


### PR DESCRIPTION
(`format-event-name` was unused)