### PR TITLE
FEATURE: Allow users to set a custom title to sidebar calendar

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -86,9 +86,7 @@ export default class UpcomingEventsList extends Component {
       );
       const custom_title = customTitleLookup?.custom_title;
 
-      return I18n.t("discourse_post_event.upcoming_events_list.custom_title", {
-        upcoming_events_title: custom_title,
-      });
+      return custom_title;
     } else {
       return I18n.t("discourse_post_event.upcoming_events_list.title");
     }

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -84,9 +84,7 @@ export default class UpcomingEventsList extends Component {
       const customTitleLookup = titleMap.find(
         (o) => o.category_slug === categorySlug
       );
-      const custom_title = customTitleLookup?.custom_title;
-
-      return custom_title;
+      return customTitleLookup?.custom_title;
     } else {
       return I18n.t("discourse_post_event.upcoming_events_list.title");
     }

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -26,6 +26,21 @@ function addToResult(date, item, result) {
   result[monthKey][day].push(item);
 }
 
+// function title() {
+//   const titleMap = JSON.parse(siteSettings);
+//   const categorySlug = this.args.params?.categorySlug;
+
+//   const obj = titleMap.find((o) => o.category_slug === categorySlug);
+//   const customTitle = customTitleObj
+//     ? customTitleObj.custom_title
+//     : "Upcoming Events";
+//   // technically the default value in the setting, but wouldn't hurt to have it here as well?
+
+//   return I18n.t("discourse_post_event.upcoming_events_list.title", {
+//     upcoming_events_title: customTitle,
+//   });
+// }
+
 export default class UpcomingEventsList extends Component {
   @service appEvents;
   @service siteSettings;
@@ -41,7 +56,18 @@ export default class UpcomingEventsList extends Component {
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
 
-  title = I18n.t("discourse_post_event.upcoming_events_list.title");
+  titleMap = JSON.parse(this.siteSettings.map_events_title);
+  categorySlug = this.args.params?.categorySlug;
+
+  obj = titleMap.find((o) => o.category_slug === categorySlug);
+  customTitle = customTitleObj
+    ? customTitleObj.custom_title
+    : "Upcoming Events";
+
+  title = I18n.t("discourse_post_event.upcoming_events_list.title", {
+    upcoming_events_title: customTitle,
+  });
+
   emptyMessage = I18n.t("discourse_post_event.upcoming_events_list.empty");
   allDayLabel = I18n.t("discourse_post_event.upcoming_events_list.all_day");
   errorMessage = I18n.t("discourse_post_event.upcoming_events_list.error");

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -26,20 +26,9 @@ function addToResult(date, item, result) {
   result[monthKey][day].push(item);
 }
 
-// function title() {
-//   const titleMap = JSON.parse(siteSettings);
-//   const categorySlug = this.args.params?.categorySlug;
+function isCustomTitle() {
 
-//   const obj = titleMap.find((o) => o.category_slug === categorySlug);
-//   const customTitle = customTitleObj
-//     ? customTitleObj.custom_title
-//     : "Upcoming Events";
-//   // technically the default value in the setting, but wouldn't hurt to have it here as well?
-
-//   return I18n.t("discourse_post_event.upcoming_events_list.title", {
-//     upcoming_events_title: customTitle,
-//   });
-// }
+}
 
 export default class UpcomingEventsList extends Component {
   @service appEvents;
@@ -56,18 +45,7 @@ export default class UpcomingEventsList extends Component {
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
 
-  titleMap = JSON.parse(this.siteSettings.map_events_title);
-  categorySlug = this.args.params?.categorySlug;
-
-  obj = titleMap.find((o) => o.category_slug === categorySlug);
-  customTitle = customTitleObj
-    ? customTitleObj.custom_title
-    : "Upcoming Events";
-
-  title = I18n.t("discourse_post_event.upcoming_events_list.title", {
-    upcoming_events_title: customTitle,
-  });
-
+  title = this.title;
   emptyMessage = I18n.t("discourse_post_event.upcoming_events_list.empty");
   allDayLabel = I18n.t("discourse_post_event.upcoming_events_list.all_day");
   errorMessage = I18n.t("discourse_post_event.upcoming_events_list.error");
@@ -92,6 +70,22 @@ export default class UpcomingEventsList extends Component {
 
   get categoryId() {
     return this.router.currentRoute.attributes?.category?.id;
+  }
+
+  get title() {
+    const titleMap = JSON.parse(this.siteSettings.map_events_title);
+    const categorySlug = this.router.currentRoute.attributes?.category?.slug;
+    const customTitleValue = titleMap.find(
+      (o) => o.category_slug === categorySlug
+    );
+
+    const title = customTitleValue
+      ? customTitleValue.custom_title
+      : null;
+
+    return I18n.t("discourse_post_event.upcoming_events_list.title", {
+      upcoming_events_title: title,
+    });
   }
 
   get hasEmptyResponse() {

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -26,10 +26,6 @@ function addToResult(date, item, result) {
   result[monthKey][day].push(item);
 }
 
-function isCustomTitle() {
-
-}
-
 export default class UpcomingEventsList extends Component {
   @service appEvents;
   @service siteSettings;
@@ -45,7 +41,6 @@ export default class UpcomingEventsList extends Component {
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
 
-  title = this.title;
   emptyMessage = I18n.t("discourse_post_event.upcoming_events_list.empty");
   allDayLabel = I18n.t("discourse_post_event.upcoming_events_list.all_day");
   errorMessage = I18n.t("discourse_post_event.upcoming_events_list.error");
@@ -73,22 +68,32 @@ export default class UpcomingEventsList extends Component {
   }
 
   get title() {
-    const titleMap = JSON.parse(this.siteSettings.map_events_title);
     const categorySlug = this.router.currentRoute.attributes?.category?.slug;
-    const customTitleFind = titleMap.find(
-      (o) => o.category_slug === categorySlug
+    const titleSetting = this.siteSettings?.map_events_title;
+
+    if (titleSetting == "") {
+      return I18n.t("discourse_post_event.upcoming_events_list.title");
+    }
+
+    const categories = JSON.parse(titleSetting).map(
+      ({ category_slug }) => category_slug
     );
 
-    const title = (typeof customTitleFind === "undefined") ? null : customTitleFind.custom_title;
+    if (categories.includes(categorySlug)) {
+      const titleMap = JSON.parse(titleSetting);
+      const customTitleLookup = titleMap.find(
+        (o) => o.category_slug === categorySlug
+      );
+      const custom_title =
+        typeof customTitleLookup === "undefined"
+          ? null
+          : customTitleLookup.custom_title;
 
-    if (!title) {
-      return I18n.t("discourse_post_event.upcoming_events_list.title", {
-        upcoming_events_title: "Upcoming Events",
+      return I18n.t("discourse_post_event.upcoming_events_list.custom_title", {
+        upcoming_events_title: custom_title,
       });
     } else {
-      return I18n.t("discourse_post_event.upcoming_events_list.title", {
-        upcoming_events_title: title,
-      });
+      return I18n.t("discourse_post_event.upcoming_events_list.title");
     }
   }
 

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -71,7 +71,7 @@ export default class UpcomingEventsList extends Component {
     const categorySlug = this.router.currentRoute.attributes?.category?.slug;
     const titleSetting = this.siteSettings?.map_events_title;
 
-    if (titleSetting == "") {
+    if (titleSetting === "") {
       return I18n.t("discourse_post_event.upcoming_events_list.title");
     }
 

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -69,7 +69,7 @@ export default class UpcomingEventsList extends Component {
 
   get title() {
     const categorySlug = this.router.currentRoute.attributes?.category?.slug;
-    const titleSetting = this.siteSettings?.map_events_title;
+    const titleSetting = this.siteSettings.map_events_title;
 
     if (titleSetting === "") {
       return I18n.t("discourse_post_event.upcoming_events_list.title");
@@ -84,10 +84,7 @@ export default class UpcomingEventsList extends Component {
       const customTitleLookup = titleMap.find(
         (o) => o.category_slug === categorySlug
       );
-      const custom_title =
-        typeof customTitleLookup === "undefined"
-          ? null
-          : customTitleLookup.custom_title;
+      const custom_title = customTitleLookup?.custom_title;
 
       return I18n.t("discourse_post_event.upcoming_events_list.custom_title", {
         upcoming_events_title: custom_title,

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -75,17 +75,21 @@ export default class UpcomingEventsList extends Component {
   get title() {
     const titleMap = JSON.parse(this.siteSettings.map_events_title);
     const categorySlug = this.router.currentRoute.attributes?.category?.slug;
-    const customTitleValue = titleMap.find(
+    const customTitleFind = titleMap.find(
       (o) => o.category_slug === categorySlug
     );
 
-    const title = customTitleValue
-      ? customTitleValue.custom_title
-      : null;
+    const title = (typeof customTitleFind === "undefined") ? null : customTitleFind.custom_title;
 
-    return I18n.t("discourse_post_event.upcoming_events_list.title", {
-      upcoming_events_title: title,
-    });
+    if (!title) {
+      return I18n.t("discourse_post_event.upcoming_events_list.title", {
+        upcoming_events_title: "Upcoming Events",
+      });
+    } else {
+      return I18n.t("discourse_post_event.upcoming_events_list.title", {
+        upcoming_events_title: title,
+      });
+    }
   }
 
   get hasEmptyResponse() {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -373,7 +373,6 @@ en:
         starts_at: "Starts at"
       upcoming_events_list:
         title: "Upcoming events"
-        custom_title: "%{upcoming_events_title}"
         empty: "No upcoming events"
         all_day: "All-day"
         error: "Failed to retrieve events"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -372,7 +372,8 @@ en:
         status: "Status"
         starts_at: "Starts at"
       upcoming_events_list:
-        title: "%{upcoming_events_title}"
+        title: "Upcoming events"
+        custom_title: "%{upcoming_events_title}"
         empty: "No upcoming events"
         all_day: "All-day"
         error: "Failed to retrieve events"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -372,7 +372,7 @@ en:
         status: "Status"
         starts_at: "Starts at"
       upcoming_events_list:
-        title: "Upcoming events"
+        title: "%{upcoming_events_title}"
         empty: "No upcoming events"
         all_day: "All-day"
         error: "Failed to retrieve events"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -31,6 +31,7 @@ en:
   site_settings:
     events_max_rows: "Maximum text rows per event in the Calendar."
     map_events_to_color: "Assign a color to each tag or category."
+    map_events_title: "Overwrites 'Events' in the 'Upcoming Events' sidebar title per category."
     calendar_enabled: "Enable the discourse-calendar plugin. This will add support for a [calendar][/calendar] tag in the first post of a topic."
     discourse_post_event_enabled: "Enables the Event features. Note: also needs `calendar enabled` to be enabled."
     displayed_invitees_limit: "Limits the numbers of invitees displayed on an event."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,6 +120,10 @@ discourse_calendar:
     client: true
     default: "[]"
     json_schema: DiscourseCalendar::SiteSettings::MapEventTagColorsJsonSchema
+  map_events_title:
+    client: true
+    default: "[]"
+    json_schema: DiscourseCalendar::SiteSettings::MapEventsTitleJsonSchema
   include_expired_events_on_calendar:
     default: false
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -122,7 +122,7 @@ discourse_calendar:
     json_schema: DiscourseCalendar::SiteSettings::MapEventTagColorsJsonSchema
   map_events_title:
     client: true
-    default: "[]"
+    default: ""
     json_schema: DiscourseCalendar::SiteSettings::MapEventsTitleJsonSchema
   include_expired_events_on_calendar:
     default: false

--- a/lib/discourse_calendar/site_settings/map_events_title_json_schema.rb
+++ b/lib/discourse_calendar/site_settings/map_events_title_json_schema.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DiscourseCalendar
+  module SiteSettings
+    class MapEventsTitleJsonSchema
+      def self.schema
+        @schema ||= {
+          type: "array",
+          uniqueItems: true,
+          items: {
+            type: "object",
+            title: "Title Mapping",
+            properties: {
+              category_slug: {
+                type: "string",
+                description: "Slug of the category",
+              },
+              custom_title: {
+                type: "string",
+                default: "Upcoming events",
+                description:
+                  "The words you want to replace 'Upcoming Events' with for the sidebar calendar",
+              },
+            },
+            required: %w[category_slug custom_title],
+          },
+        }
+      end
+    end
+  end
+end

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -1,7 +1,5 @@
 import { hash } from "@ember/helper";
 import Service from "@ember/service";
-import sinon from "sinon";
-import { getOwner } from "@ember/owner";
 import { click, currentURL, render, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -20,7 +18,7 @@ import UpcomingEventsList, {
 } from "../../discourse/components/upcoming-events-list";
 
 class RouterStub extends Service {
-  currentRoute = { attributes: { category: { id: 1 } } };
+  currentRoute = { attributes: { category: { id: 1, slug: "announcements" } } };
   currentRouteName = "discovery.latest";
   on() {}
   off() {}
@@ -165,9 +163,10 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     );
   });
 
-  test("with events, overridden titles", async function (assert) {
-    const router = getOwner(this).lookup("service:router");
-    sinon.stub(router, "currentURL").value("/program-pillars");
+  test("Uses custom category name from 'map_events_title'", async function (assert) {
+    pretender.get("/discourse-post-event/events", () => {
+      return response({ events: [] });
+    });
 
     this.siteSettings.map_events_title =
       '[{"category_slug": "announcements", "custom_title": "Upcoming Announcements"}]';
@@ -176,28 +175,28 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     this.appEvents.trigger("page:changed", { url: "/c/announcements" });
 
     assert.strictEqual(
-      // query below returns null
       query(".upcoming-events-list__heading").innerText,
       "Upcoming Announcements",
       "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
     );
-
-    // this.args.params.categorySlug = "events";
-    // assert.equal(
-    //   component.title(),
-    //   "Upcoming Cool Events",
-    //   "it sets 'Upcoming Cool Events' as the title in 'c/events'"
-    // );
-    // this.args.params.categorySlug = "unknown";
-    // assert.equal(
-    //   component.title(),
-    //   "Upcoming Events",
-    //   "it returns the default value for title when otherwise not specified"
-    // );
   });
 
-  // in pair got UI working, QUnit test difficult because we need to set a page category and this is just component -- in system spec we ran into the issue with not having/loading the theme component
-  // try QUnit one more time to see if i can get the cat working
+  test("Uses default title for upcoming events list", async function (assert) {
+    pretender.get("/discourse-post-event/events", () => {
+      return response({ events: [] });
+    });
+
+    this.siteSettings.map_events_title = "";
+
+    await render(<template><UpcomingEventsList /></template>);
+    this.appEvents.trigger("page:changed", { url: "/c/announcements" });
+
+    assert.strictEqual(
+      query(".upcoming-events-list__heading").innerText,
+      "Upcoming events",
+      "it sets default value as the title in 'c/announcements'"
+    );
+  });
 
   test("with events, view-all navigation", async function (assert) {
     pretender.get("/discourse-post-event/events", twoEventsResponseHandler);

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -163,41 +163,37 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     );
   });
 
-  test("it returns the correct custom title based on categorySlug", function (assert) {
-    this.siteSettings.map_events_title = JSON.stringify([
-      {
-        category_slug: "c/announcements",
-        custom_title: "Upcoming Announcements",
-      },
-      { category_slug: "c/events", custom_title: "Upcoming Cool Events" },
-    ]);
+  // test("with events, overridden titles", async function (assert) {
+  //   await render(
+  //     <template>
+  //     <UpcomingEventsList
+  //     />
+  //   </template>
+  //   );
 
-    const params = { categorySlug: "c/announcements" };
-    const component = UpcomingEventsList.create({
-      siteSettings,
-      args: { params },
-    });
+  //   this.appEvents.trigger("page:changed", { url: "/" });
 
-    assert.equal(
-      component.title(),
-      "Upcoming Announcements",
-      "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
-    );
+  //   this.args.params.categorySlug = "c/announcements";
+  //   assert.equal(
+  //     component.title(),
+  //     "Upcoming Announcements",
+  //     "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
+  //   );
 
-    component.args.params.categorySlug = "c/events";
-    assert.equal(
-      component.title(),
-      "Upcoming Cool Events",
-      "it sets 'Upcoming Cool Events' as the title in 'c/events'"
-    );
+  //   this.args.params.categorySlug = "c/events";
+  //   assert.equal(
+  //     component.title(),
+  //     "Upcoming Cool Events",
+  //     "it sets 'Upcoming Cool Events' as the title in 'c/events'"
+  //   );
 
-    component.args.params.categorySlug = "c/unknown";
-    assert.equal(
-      component.title(),
-      "Upcoming Events",
-      "it returns the default value for title when otherwise not specified"
-    );
-  });
+  //   this.args.params.categorySlug = "c/unknown";
+  //   assert.equal(
+  //     component.title(),
+  //     "Upcoming Events",
+  //     "it returns the default value for title when otherwise not specified"
+  //   );
+  // });
 
   test("with events, view-all navigation", async function (assert) {
     pretender.get("/discourse-post-event/events", twoEventsResponseHandler);

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -174,11 +174,12 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     await render(<template><UpcomingEventsList /></template>);
     this.appEvents.trigger("page:changed", { url: "/c/announcements" });
 
-    assert.strictEqual(
-      query(".upcoming-events-list__heading").innerText,
-      "Upcoming Announcements",
-      "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
-    );
+    assert
+      .dom(".upcoming-events-list__heading")
+      .hasText(
+        "Upcoming Announcements",
+        "sets 'Upcoming Announcements' as the title in 'c/announcements'"
+      );
   });
 
   test("Uses default title for upcoming events list", async function (assert) {

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -163,32 +163,6 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     );
   });
 
-  test("with events, overridden titles", async function (assert) {
-    // this.siteSettings.map_events_title =
-    //   '[{"category_slug": "announcements", "custom_title": "Upcoming Announcements"}]';
-    // await render(<template><UpcomingEventsList /></template>);
-    // this.appEvents.trigger("page:changed", { url: "/c/1" });
-    // debugger;
-    // // this.args.params.categorySlug = "announcements";
-    // assert.strictEqual(
-    //   query(".upcoming-events-list__heading").innerText,
-    //   "Upcoming Announcements",
-    //   "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
-    // );
-    // this.args.params.categorySlug = "events";
-    // assert.equal(
-    //   component.title(),
-    //   "Upcoming Cool Events",
-    //   "it sets 'Upcoming Cool Events' as the title in 'c/events'"
-    // );
-    // this.args.params.categorySlug = "unknown";
-    // assert.equal(
-    //   component.title(),
-    //   "Upcoming Events",
-    //   "it returns the default value for title when otherwise not specified"
-    // );
-  });
-
   test("with events, view-all navigation", async function (assert) {
     pretender.get("/discourse-post-event/events", twoEventsResponseHandler);
 

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -192,11 +192,12 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     await render(<template><UpcomingEventsList /></template>);
     this.appEvents.trigger("page:changed", { url: "/c/announcements" });
 
-    assert.strictEqual(
-      query(".upcoming-events-list__heading").innerText,
-      "Upcoming events",
-      "it sets default value as the title in 'c/announcements'"
-    );
+    assert
+      .dom(".upcoming-events-list__heading")
+      .hasText(
+        "Upcoming events",
+        "it sets default value as the title in 'c/announcements'"
+      );
   });
 
   test("with events, view-all navigation", async function (assert) {

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -163,6 +163,42 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     );
   });
 
+  test("it returns the correct custom title based on categorySlug", function (assert) {
+    this.siteSettings.map_events_title = JSON.stringify([
+      {
+        category_slug: "c/announcements",
+        custom_title: "Upcoming Announcements",
+      },
+      { category_slug: "c/events", custom_title: "Upcoming Cool Events" },
+    ]);
+
+    const params = { categorySlug: "c/announcements" };
+    const component = UpcomingEventsList.create({
+      siteSettings,
+      args: { params },
+    });
+
+    assert.equal(
+      component.title(),
+      "Upcoming Announcements",
+      "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
+    );
+
+    component.args.params.categorySlug = "c/events";
+    assert.equal(
+      component.title(),
+      "Upcoming Cool Events",
+      "it sets 'Upcoming Cool Events' as the title in 'c/events'"
+    );
+
+    component.args.params.categorySlug = "c/unknown";
+    assert.equal(
+      component.title(),
+      "Upcoming Events",
+      "it returns the default value for title when otherwise not specified"
+    );
+  });
+
   test("with events, view-all navigation", async function (assert) {
     pretender.get("/discourse-post-event/events", twoEventsResponseHandler);
 

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -163,37 +163,31 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
     );
   });
 
-  // test("with events, overridden titles", async function (assert) {
-  //   await render(
-  //     <template>
-  //     <UpcomingEventsList
-  //     />
-  //   </template>
-  //   );
-
-  //   this.appEvents.trigger("page:changed", { url: "/" });
-
-  //   this.args.params.categorySlug = "c/announcements";
-  //   assert.equal(
-  //     component.title(),
-  //     "Upcoming Announcements",
-  //     "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
-  //   );
-
-  //   this.args.params.categorySlug = "c/events";
-  //   assert.equal(
-  //     component.title(),
-  //     "Upcoming Cool Events",
-  //     "it sets 'Upcoming Cool Events' as the title in 'c/events'"
-  //   );
-
-  //   this.args.params.categorySlug = "c/unknown";
-  //   assert.equal(
-  //     component.title(),
-  //     "Upcoming Events",
-  //     "it returns the default value for title when otherwise not specified"
-  //   );
-  // });
+  test("with events, overridden titles", async function (assert) {
+    // this.siteSettings.map_events_title =
+    //   '[{"category_slug": "announcements", "custom_title": "Upcoming Announcements"}]';
+    // await render(<template><UpcomingEventsList /></template>);
+    // this.appEvents.trigger("page:changed", { url: "/c/1" });
+    // debugger;
+    // // this.args.params.categorySlug = "announcements";
+    // assert.strictEqual(
+    //   query(".upcoming-events-list__heading").innerText,
+    //   "Upcoming Announcements",
+    //   "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
+    // );
+    // this.args.params.categorySlug = "events";
+    // assert.equal(
+    //   component.title(),
+    //   "Upcoming Cool Events",
+    //   "it sets 'Upcoming Cool Events' as the title in 'c/events'"
+    // );
+    // this.args.params.categorySlug = "unknown";
+    // assert.equal(
+    //   component.title(),
+    //   "Upcoming Events",
+    //   "it returns the default value for title when otherwise not specified"
+    // );
+  });
 
   test("with events, view-all navigation", async function (assert) {
     pretender.get("/discourse-post-event/events", twoEventsResponseHandler);

--- a/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -1,5 +1,7 @@
 import { hash } from "@ember/helper";
 import Service from "@ember/service";
+import sinon from "sinon";
+import { getOwner } from "@ember/owner";
 import { click, currentURL, render, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -162,6 +164,40 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
       "it displays the multiday event on all scheduled dates"
     );
   });
+
+  test("with events, overridden titles", async function (assert) {
+    const router = getOwner(this).lookup("service:router");
+    sinon.stub(router, "currentURL").value("/program-pillars");
+
+    this.siteSettings.map_events_title =
+      '[{"category_slug": "announcements", "custom_title": "Upcoming Announcements"}]';
+
+    await render(<template><UpcomingEventsList /></template>);
+    this.appEvents.trigger("page:changed", { url: "/c/announcements" });
+
+    assert.strictEqual(
+      // query below returns null
+      query(".upcoming-events-list__heading").innerText,
+      "Upcoming Announcements",
+      "it sets 'Upcoming Announcements' as the title in 'c/announcements'"
+    );
+
+    // this.args.params.categorySlug = "events";
+    // assert.equal(
+    //   component.title(),
+    //   "Upcoming Cool Events",
+    //   "it sets 'Upcoming Cool Events' as the title in 'c/events'"
+    // );
+    // this.args.params.categorySlug = "unknown";
+    // assert.equal(
+    //   component.title(),
+    //   "Upcoming Events",
+    //   "it returns the default value for title when otherwise not specified"
+    // );
+  });
+
+  // in pair got UI working, QUnit test difficult because we need to set a page category and this is just component -- in system spec we ran into the issue with not having/loading the theme component
+  // try QUnit one more time to see if i can get the cat working
 
   test("with events, view-all navigation", async function (assert) {
     pretender.get("/discourse-post-event/events", twoEventsResponseHandler);


### PR DESCRIPTION
This allows users to change the title of the calendar sidebar according to the category. The example use-case is "Upcoming Releases" in the "Product News" category.

Default:
<img width="299" alt="Screenshot 2024-11-27 at 1 50 45 PM" src="https://github.com/user-attachments/assets/569f84b2-26f5-4957-ad05-ba1547f3c5ac">

Custom:
<img width="280" alt="Screenshot 2024-11-27 at 1 51 30 PM" src="https://github.com/user-attachments/assets/24b580ef-1c6e-422f-af2d-91b4c4508b3f">

Setting:
<img width="589" alt="Screenshot 2024-11-27 at 1 51 15 PM" src="https://github.com/user-attachments/assets/ec38ff6a-5b29-48f0-aad4-4f8eb208dbc5">

Tests will be added into the Right Sidebar Blocks component, as this feature only works in conjunction with specific settings in that component.