### PR TITLE
UX: Tc right sidebar changes

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { applyLocalDates } from "discourse/lib/local-dates";
 import { cook } from "discourse/lib/text";
+import icon from "discourse-common/helpers/d-icon";
 import guessDateFormat from "../../lib/guess-best-date-format";
 
 export default class DiscoursePostEventDates extends Component {
@@ -76,9 +77,7 @@ export default class DiscoursePostEventDates extends Component {
   }
 
   <template>
-    <section
-      class="event__section event-dates"
-      {{didInsert this.computeDates}}
-    >{{this.htmlDates}}</section>
+    <section class="event__section event-dates" {{didInsert this.computeDates}}>
+      {{icon "clock"}}{{this.htmlDates}}</section>
   </template>
 }

--- a/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -67,6 +67,10 @@ export default class DiscoursePostEvent extends Component {
     return this.currentUser && this.args.event.can_act_on_discourse_post_event;
   }
 
+  get watchingInviteeStatus() {
+    return this.args.event.watchingInvitee?.status;
+  }
+
   <template>
     <div
       class={{concatClass
@@ -108,12 +112,6 @@ export default class DiscoursePostEvent extends Component {
             />
           </header>
 
-          {{#if @event.canUpdateAttendance}}
-            <section class="event__section event-actions">
-              <Status @event={{@event}} />
-            </section>
-          {{/if}}
-
           <PluginOutlet
             @name="discourse-post-event-info"
             @outletArgs={{hash
@@ -122,11 +120,15 @@ export default class DiscoursePostEvent extends Component {
               Url=(component Url url=@event.url)
               Dates=(component Dates event=@event)
               Invitees=(component Invitees event=@event)
+              Status=(component Status event=@event)
             }}
           >
             <Url @url={{@event.url}} />
             <Dates @event={{@event}} />
             <Invitees @event={{@event}} />
+            {{#if @event.canUpdateAttendance}}
+              <Status @event={{@event}} />
+            {{/if}}
           </PluginOutlet>
         {{/if}}
       </div>

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
+import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import PostEventInvitees from "../modal/post-event-invitees";
 import Invitee from "./invitee";
@@ -70,11 +71,21 @@ export default class DiscoursePostEventInvitees extends Component {
               @action={{this.showAllInvitees}}
             />
           </div>
-          <ul class="event-invitees-avatars">
-            {{#each @event.sampleInvitees as |invitee|}}
-              <Invitee @invitee={{invitee}} />
-            {{/each}}
-          </ul>
+          <div class="event-invitees-avatars-container">
+            {{icon "users"}}
+            <ul class="event-invitees-avatars">
+              {{#each @event.sampleInvitees as |invitee|}}
+                <Invitee @invitee={{invitee}} />
+              {{/each}}
+            </ul>
+          </div>
+        </section>
+      {{else}}
+        <section class="event__section event-invitees no-rsvp">
+          <p class="no-rsvp-description">{{i18n
+              "discourse_post_event.models.invitee.status.going_count.other"
+              count="0"
+            }}</p>
         </section>
       {{/if}}
     {{/unless}}

--- a/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -12,10 +12,6 @@ export default class DiscoursePostEventStatus extends Component {
   @service discoursePostEventApi;
   @service siteSettings;
 
-  get watchingInviteeStatus() {
-    return this.args.event.watchingInvitee?.status;
-  }
-
   get eventButtons() {
     return this.siteSettings.event_participation_buttons.split("|");
   }
@@ -34,6 +30,10 @@ export default class DiscoursePostEventStatus extends Component {
 
   get canLeave() {
     return this.args.event.watchingInvitee && this.args.event.isPublic;
+  }
+
+  get watchingInviteeStatus() {
+    return this.args.event.watchingInvitee?.status;
   }
 
   @action
@@ -107,12 +107,12 @@ export default class DiscoursePostEventStatus extends Component {
   }
 
   <template>
-    <div
+    <section
       class={{concatClass
-        "event-status"
+        "event__section event-actions event-status"
         (if
           this.watchingInviteeStatus
-          (concat "status-" this.watchingInviteeStatus)
+          (concat "status-" this.args.watchingInviteeStatus)
         )
       }}
     >
@@ -177,6 +177,6 @@ export default class DiscoursePostEventStatus extends Component {
           {{/unless}}
         {{/if}}
       </PluginOutlet>
-    </div>
+    </section>
   </template>
 }

--- a/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -12,10 +12,6 @@ export default class DiscoursePostEventStatus extends Component {
   @service discoursePostEventApi;
   @service siteSettings;
 
-  get watchingInviteeStatus() {
-    return this.args.event.watchingInvitee?.status;
-  }
-
   get eventButtons() {
     return this.siteSettings.event_participation_buttons.split("|");
   }
@@ -34,6 +30,10 @@ export default class DiscoursePostEventStatus extends Component {
 
   get canLeave() {
     return this.args.event.watchingInvitee && this.args.event.isPublic;
+  }
+
+  get watchingInviteeStatus() {
+    return this.args.event.watchingInvitee?.status;
   }
 
   @action
@@ -107,9 +107,9 @@ export default class DiscoursePostEventStatus extends Component {
   }
 
   <template>
-    <div
+    <section
       class={{concatClass
-        "event-status"
+        "event__section event-actions event-status"
         (if
           this.watchingInviteeStatus
           (concat "status-" this.watchingInviteeStatus)
@@ -177,6 +177,6 @@ export default class DiscoursePostEventStatus extends Component {
           {{/unless}}
         {{/if}}
       </PluginOutlet>
-    </div>
+    </section>
   </template>
 }

--- a/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -112,7 +112,7 @@ export default class DiscoursePostEventStatus extends Component {
         "event__section event-actions event-status"
         (if
           this.watchingInviteeStatus
-          (concat "status-" this.args.watchingInviteeStatus)
+          (concat "status-" this.watchingInviteeStatus)
         )
       }}
     >

--- a/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -12,6 +12,10 @@ export default class DiscoursePostEventStatus extends Component {
   @service discoursePostEventApi;
   @service siteSettings;
 
+  get watchingInviteeStatus() {
+    return this.args.event.watchingInvitee?.status;
+  }
+
   get eventButtons() {
     return this.siteSettings.event_participation_buttons.split("|");
   }
@@ -30,10 +34,6 @@ export default class DiscoursePostEventStatus extends Component {
 
   get canLeave() {
     return this.args.event.watchingInvitee && this.args.event.isPublic;
-  }
-
-  get watchingInviteeStatus() {
-    return this.args.event.watchingInvitee?.status;
   }
 
   @action
@@ -107,9 +107,9 @@ export default class DiscoursePostEventStatus extends Component {
   }
 
   <template>
-    <section
+    <div
       class={{concatClass
-        "event__section event-actions event-status"
+        "event-status"
         (if
           this.watchingInviteeStatus
           (concat "status-" this.watchingInviteeStatus)
@@ -177,6 +177,6 @@ export default class DiscoursePostEventStatus extends Component {
           {{/unless}}
         {{/if}}
       </PluginOutlet>
-    </section>
+    </div>
   </template>
 }

--- a/assets/javascripts/discourse/components/modal/post-event-builder.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.hbs
@@ -123,7 +123,7 @@
           <GroupSelector
             @fullWidthWrap={{true}}
             @groupFinder={{this.groupFinder}}
-            @groupNames={{@model.event.raw_invitees}}
+            @groupNames={{@model.event.rawInvitees}}
             @onChangeCallback={{this.setRawInvitees}}
             @placeholderKey="topic.invite_private.group_name"
           />
@@ -232,7 +232,7 @@
               <Input
                 class="custom-field-input"
                 @value={{readonly
-                  (get @model.event.custom_fields allowedCustomField)
+                  (get @model.event.customFields allowedCustomField)
                 }}
                 placeholder={{i18n
                   "discourse_post_event.builder_modal.custom_fields.placeholder"

--- a/assets/javascripts/discourse/components/modal/post-event-builder.js
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.js
@@ -146,7 +146,7 @@ export default class PostEventBuilder extends Component {
 
   @action
   setCustomField(field, e) {
-    this.event[field] = e.target.value;
+    this.event.customFields[field] = e.target.value;
   }
 
   @action

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -12,8 +12,6 @@ import { i18n } from "discourse-i18n";
 import or from "truth-helpers/helpers/or";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 
-export const DEFAULT_MONTH_FORMAT = "MMMM YYYY";
-export const DEFAULT_DATE_FORMAT = "dddd, MMM D";
 export const DEFAULT_TIME_FORMAT = "LT";
 const DEFAULT_UPCOMING_DAYS = 180;
 const DEFAULT_COUNT = 8;
@@ -36,8 +34,6 @@ export default class UpcomingEventsList extends Component {
   @tracked hasError = false;
   @tracked eventsByMonth = {};
 
-  monthFormat = this.args.params?.monthFormat ?? DEFAULT_MONTH_FORMAT;
-  dateFormat = this.args.params?.dateFormat ?? DEFAULT_DATE_FORMAT;
   timeFormat = this.args.params?.timeFormat ?? DEFAULT_TIME_FORMAT;
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
@@ -97,16 +93,6 @@ export default class UpcomingEventsList extends Component {
     } finally {
       this.isLoading = false;
     }
-  }
-
-  @action
-  formatMonth(month) {
-    return moment(month, "YYYY-MM").format(this.monthFormat);
-  }
-
-  @action
-  formatDate(month, day) {
-    return moment(`${month}-${day}`, "YYYY-MM-DD").format(this.dateFormat);
   }
 
   @action

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -7,7 +7,6 @@ import ConditionalLoadingSpinner from "discourse/components/conditional-loading-
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { ajax } from "discourse/lib/ajax";
-import icon from "discourse-common/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import or from "truth-helpers/helpers/or";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -2,12 +2,13 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
-import { inject as service } from "@ember/service";
+import { service } from "@ember/service";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { ajax } from "discourse/lib/ajax";
-import I18n from "discourse-i18n";
+import icon from "discourse-common/helpers/d-icon";
+import { i18n } from "discourse-i18n";
 import or from "truth-helpers/helpers/or";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 
@@ -41,11 +42,11 @@ export default class UpcomingEventsList extends Component {
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
 
-  title = I18n.t("discourse_post_event.upcoming_events_list.title");
-  emptyMessage = I18n.t("discourse_post_event.upcoming_events_list.empty");
-  allDayLabel = I18n.t("discourse_post_event.upcoming_events_list.all_day");
-  errorMessage = I18n.t("discourse_post_event.upcoming_events_list.error");
-  viewAllLabel = I18n.t("discourse_post_event.upcoming_events_list.view_all");
+  title = i18n("discourse_post_event.upcoming_events_list.title");
+  emptyMessage = i18n("discourse_post_event.upcoming_events_list.empty");
+  allDayLabel = i18n("discourse_post_event.upcoming_events_list.all_day");
+  errorMessage = i18n("discourse_post_event.upcoming_events_list.error");
+  viewAllLabel = i18n("discourse_post_event.upcoming_events_list.view_all");
 
   constructor() {
     super(...arguments);
@@ -115,6 +116,16 @@ export default class UpcomingEventsList extends Component {
       : this.allDayLabel;
   }
 
+  @action
+  startsAtMonth(month, day) {
+    return moment(`${month}-${day}`).format("MMM");
+  }
+
+  @action
+  startsAtDay(month, day) {
+    return moment(`${month}-${day}`).format("D");
+  }
+
   groupByMonthAndDay(data) {
     return data.reduce((result, item) => {
       const startDate = moment(item.starts_at);
@@ -168,35 +179,34 @@ export default class UpcomingEventsList extends Component {
           {{#unless this.isLoading}}
             <PluginOutlet @name="upcoming-events-list-container">
               {{#each-in this.eventsByMonth as |month monthData|}}
-                {{#if this.monthFormat}}
-                  <h4 class="upcoming-events-list__formatted-month">
-                    {{this.formatMonth month}}
-                  </h4>
-                {{/if}}
-
                 {{#each-in monthData as |day events|}}
-                  <div class="upcoming-events-list__day-section">
-                    <div class="upcoming-events-list__formatted-day">
-                      {{this.formatDate month day}}
-                    </div>
-
-                    {{#each events as |event|}}
-                      <a
-                        class="upcoming-events-list__event"
-                        href={{event.post.url}}
-                      >
-                        {{#if this.timeFormat}}
-                          <div class="upcoming-events-list__event-time">
-                            {{this.formatTime event}}
-                          </div>
-                        {{/if}}
-
-                        <div class="upcoming-events-list__event-name">
+                  {{#each events as |event|}}
+                    <a
+                      class="upcoming-events-list__event"
+                      href={{event.post.url}}
+                    >
+                      <div class="upcoming-events-list__event-date">
+                        <div class="month">{{this.startsAtMonth
+                            month
+                            day
+                          }}</div>
+                        <div class="day">{{this.startsAtDay month day}}</div>
+                      </div>
+                      <div class="upcoming-events-list__event-content">
+                        <span
+                          class="upcoming-events-list__event-name"
+                          title="{{or event.name event.post.topic.title}}"
+                        >
                           {{or event.name event.post.topic.title}}
-                        </div>
-                      </a>
-                    {{/each}}
-                  </div>
+                        </span>
+                        {{#if this.timeFormat}}
+                          <span class="upcoming-events-list__event-time">
+                            {{this.formatTime event}}
+                          </span>
+                        {{/if}}
+                      </div>
+                    </a>
+                  {{/each}}
                 {{/each-in}}
               {{/each-in}}
             </PluginOutlet>

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -181,7 +181,7 @@ export default class UpcomingEventsList extends Component {
                       <div class="upcoming-events-list__event-content">
                         <span
                           class="upcoming-events-list__event-name"
-                          title="{{or event.name event.post.topic.title}}"
+                          title={{or event.name event.post.topic.title}}
                         >
                           {{or event.name event.post.topic.title}}
                         </span>

--- a/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -26,6 +26,7 @@ export default class DiscoursePostEventEvent {
   @tracked rawInvitees;
   @tracked url;
   @tracked timezone;
+  @tracked status;
   @tracked post;
   @tracked minimal;
   @tracked canUpdateAttendance;

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -1,14 +1,13 @@
 $interested: #fb985d;
+$show-interested: inherit;
 
 .discourse-post-event {
   display: flex;
+  max-width: 35rem;
+  justify-content: center;
 
   .event__section {
     padding: 0.5em 1em;
-
-    &:not(:last-child) {
-      border-bottom: 1px solid var(--primary-low);
-    }
 
     &:first-child {
       border-top: 1px solid var(--primary-low);
@@ -28,14 +27,16 @@ $interested: #fb985d;
   }
 
   .discourse-post-event-widget {
-    border: 5px solid var(--primary-low);
+    box-shadow: 0px 0px 0px 3px var(--primary-100);
+    border: 1px solid var(--primary-300);
     display: flex;
     background: var(--secondary);
     margin: 5px 0;
     flex-direction: column;
     flex: 1 0 auto;
-    max-width: 100%;
+    max-width: calc(100% - 2px - 6px);
     box-sizing: border-box;
+    border-radius: var(--d-button-border-radius);
 
     .widget-dropdown {
       margin: 0;
@@ -66,15 +67,15 @@ $interested: #fb985d;
   }
 
   .event-header {
+    column-gap: 1em;
     display: flex;
-    align-items: center;
-    padding: 0 1em;
-    height: 75px;
+    align-items: flex-start;
+    padding: 0.5em 1em;
+    margin-top: 0.5em;
 
     .more-dropdown {
       margin-left: auto;
       align-self: flex-start;
-      margin-top: 1em;
 
       &.has-no-actions {
         display: none;
@@ -102,21 +103,29 @@ $interested: #fb985d;
 
   .event-date {
     display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 3em;
+    height: 3em;
+    margin: 0;
+    padding: 0;
+    border: 1px solid var(--primary-low);
+    border-radius: var(--d-button-border-radius);
     flex-direction: column;
-    width: auto;
-    margin-right: 1em;
 
     .month {
       text-align: center;
       color: red;
-      font-size: var(--font-down-1);
+      font-size: var(--font-down-2);
+      font-weight: 400;
       text-transform: uppercase;
     }
 
     .day {
       text-align: center;
-      font-weight: 500;
-      font-size: var(--font-up-2);
+      font-size: var(--font-up-1);
+      font-weight: 400;
     }
   }
 
@@ -127,19 +136,32 @@ $interested: #fb985d;
     margin-right: 0.5rem;
 
     .name {
-      font-weight: 700;
       @include ellipsis;
       max-width: 45vw;
+      font-size: var(--font-up-2);
+      font-weight: 400;
+      white-space: initial;
+      margin-bottom: 0.25rem;
     }
     .status-and-creators {
       display: flex;
       align-items: center;
       color: var(--primary-medium);
       font-size: var(--font-down-1);
-      margin: 0.25em 0;
+      font-weight: 400;
+      margin: 0;
 
       .separator {
         margin: 0 0.25em;
+      }
+
+      .created-by {
+        margin-right: 0.25em;
+      }
+
+      .username {
+        margin-left: 0.25em;
+        color: var(--primary);
       }
 
       .creators {
@@ -173,12 +195,20 @@ $interested: #fb985d;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height: 60px;
-    padding: 0 1em;
+    padding: 0.5em 1em;
+    flex-wrap: wrap;
+    border-top: 1px solid var(--primary-low);
 
-    .event-status {
+    &.event-status {
       margin: 0;
+      gap: 0.5em;
+      .btn {
+        flex: 1;
+      }
 
+      .interested-button {
+        display: $show-interested;
+      }
       &.status-going .going-button .d-icon {
         color: var(--success);
       }
@@ -187,6 +217,9 @@ $interested: #fb985d;
       }
       &.status-not_going .not-going-button .d-icon {
         color: var(--danger);
+      }
+      .not-going-button span {
+        white-space: nowrap;
       }
     }
   }
@@ -198,6 +231,7 @@ $interested: #fb985d;
   }
 
   .event-invitees {
+    height: 1.5em;
     display: flex;
     align-items: flex-start;
     justify-content: center;
@@ -205,7 +239,7 @@ $interested: #fb985d;
     flex-direction: column;
 
     .header {
-      display: flex;
+      display: none;
       justify-content: space-between;
       align-items: center;
       margin-bottom: 1em;
@@ -233,14 +267,13 @@ $interested: #fb985d;
     .event-invitees-avatars {
       padding: 0;
       margin: 0;
+      gap: 0.25em;
       display: flex;
       flex-wrap: wrap;
       width: 100%;
 
       .event-invitee {
         list-style: none;
-        margin-right: 0.5em;
-        margin-bottom: 0.5em;
         opacity: 0.25;
 
         &.status-going,
@@ -249,15 +282,19 @@ $interested: #fb985d;
           opacity: 1;
         }
 
-        &.status-going .avatar-flair {
+        &.status-interested {
+          display: $show-interested;
+        }
+
+        &.status-going .avatar-flair .d-icon {
           color: var(--success);
         }
 
-        &.status-not_going .avatar-flair {
+        &.status-not_going .avatar-flair .d-icon {
           color: var(--danger);
         }
 
-        &.status-interested .avatar-flair {
+        &.status-interested .avatar-flair .d-icon {
           color: $interested;
         }
       }
@@ -265,6 +302,11 @@ $interested: #fb985d;
       .topic-invitee-avatar {
         position: relative;
         display: inline-block;
+        padding-right: 0.5em;
+
+        .avatar {
+          width: 1.5rem;
+        }
 
         .avatar-flair {
           position: absolute;
@@ -272,16 +314,16 @@ $interested: #fb985d;
           bottom: 0;
           background: var(--secondary);
           border-radius: 50%;
-          height: 16px;
-          width: 16px;
+          height: 1rem;
+          width: 1rem;
           display: flex;
           align-items: center;
           justify-content: center;
           color: var(--primary-medium);
-          border: 1px solid var(--primary-low);
+          box-shadow: 0 0 0 1px var(--primary-100);
 
           .d-icon {
-            font-size: var(--font-down-3);
+            font-size: var(--font-down-2);
           }
         }
       }
@@ -293,12 +335,18 @@ $interested: #fb985d;
   }
 
   .event-url,
-  .event-dates {
-    display: flex;
+  .event-dates,
+  .event-invitees-avatars-container {
+    display: grid;
+    grid-template-columns: 3em 1fr;
+    grid-column-gap: 1em;
     align-items: center;
+    height: min-content;
 
     .d-icon {
       color: var(--primary-high);
+      margin: 0 auto;
+      padding: 0;
     }
   }
 
@@ -308,32 +356,49 @@ $interested: #fb985d;
       @include ellipsis;
     }
   }
+}
 
-  .event-dates {
-    // hardcoded as cooking date is async and will change height after initial rendering otherwise
-    // not ideal but a decent low tech solution
-    height: 24px;
+.event-dates {
+  // hardcoded as cooking date is async and will change height after initial rendering otherwise
+  // not ideal but a decent low tech solution
+  height: 24px;
 
-    .participants {
-      margin-left: 0.5em;
-      color: var(--primary-medium);
+  .participants {
+    margin-left: 0.5em;
+    color: var(--primary-medium);
+  }
+
+  .discourse-local-date {
+    .d-icon {
+      display: none;
     }
+  }
 
-    .date {
-      color: var(--primary-high);
-      margin-left: 1em;
+  .separator {
+    color: var(--primary-high);
+    margin: 0 0.5em;
+    text-align: center;
+  }
+}
 
-      .discourse-local-date {
-        .d-icon {
-          display: none;
-        }
-      }
-    }
-
-    .separator {
-      color: var(--primary-high);
-      margin: 0 0.5em;
-      text-align: center;
-    }
+.discourse-post-event {
+  .cooked-date,
+  .participants,
+  .event-url .url {
+    font-size: var(--base-font-size);
+    font-weight: 400;
+    border-bottom: none;
+    margin: 0;
+  }
+  .event__section.no-rsvp {
+    display: grid;
+    grid-template-columns: 3em 1fr;
+    grid-column-gap: 1em;
+  }
+  p.no-rsvp-description {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
+    font-weight: 400;
+    grid-column-start: 2;
   }
 }

--- a/assets/stylesheets/common/upcoming-events-list.scss
+++ b/assets/stylesheets/common/upcoming-events-list.scss
@@ -2,10 +2,10 @@
   &__event {
     column-gap: 0.5em;
     display: flex;
-    margin-top: 0.5em;
+    margin-top: 0.75em;
   }
   &__event:last-of-type {
-    margin-bottom: 0.5em;
+    margin-bottom: 0.75em;
   }
   &__event-date {
     display: flex;
@@ -23,15 +23,14 @@
   }
   &__event-date .month {
     text-align: center;
-    color: red;
+    color: var(--primary);
     font-size: var(--font-down-3);
-    font-weight: 400;
     text-transform: uppercase;
   }
   &__event-date .day {
     text-align: center;
-    font-weight: 400;
     color: var(--primary);
+    font-weight: bold;
     font-size: var(--font-down-1);
   }
   &__event-content {
@@ -47,9 +46,9 @@
     color: var(--primary);
   }
   &__event-time {
-    font-size: var(--font-down-1);
+    font-size: var(--font-down-2);
     font-weight: 400;
-    color: var(--primary-medium);
+    color: var(--primary-700);
   }
   &__footer {
     margin-top: 1em;

--- a/assets/stylesheets/common/upcoming-events-list.scss
+++ b/assets/stylesheets/common/upcoming-events-list.scss
@@ -58,8 +58,12 @@
     margin-top: 1em;
     font-size: var(--font-down-2);
     line-height: var(--line-height-medium);
+    padding-left: 0.5em;
   }
   &__footer a {
     color: var(--primary-high);
+  }
+  &__footer a:hover {
+    color: var(--primary);
   }
 }

--- a/assets/stylesheets/common/upcoming-events-list.scss
+++ b/assets/stylesheets/common/upcoming-events-list.scss
@@ -1,43 +1,62 @@
 .upcoming-events-list {
-  &__formatted-month {
-    font-weight: 600;
+  &__event {
+    column-gap: 0.5em;
+    display: flex;
+    margin-top: 0.5em;
   }
-
-  &__day-section {
+  &__event:last-of-type {
+    margin-bottom: 0.5em;
+  }
+  &__event-date {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 2.5em;
+    height: 2.5em;
+    margin: 0;
+    padding: 0;
+    border: 1px solid var(--primary-low);
+    border-radius: var(--d-button-border-radius);
+    flex-direction: column;
+    background-color: var(--secondary);
+  }
+  &__event-date .month {
+    text-align: center;
+    color: red;
+    font-size: var(--font-down-3);
+    font-weight: 400;
+    text-transform: uppercase;
+  }
+  &__event-date .day {
+    text-align: center;
+    font-weight: 400;
+    color: var(--primary);
+    font-size: var(--font-down-1);
+  }
+  &__event-content {
     display: flex;
     flex-direction: column;
-    padding-bottom: 0.5rem;
-    gap: 0.5rem;
   }
-
-  &__formatted-day {
-    margin-left: 0.5rem;
-    font-weight: 600;
-    font-size: var(--base-font-size);
-  }
-
-  &__event {
-    display: flex;
-    align-items: center;
-    margin-left: 1rem;
-    gap: 0.25rem;
-    font-size: var(--font-down-1);
-    line-height: var(--line-height-medium);
-  }
-
   &__event-name {
-    width: 70%;
-  }
-
-  &__event-time {
-    width: 30%;
-    text-align: center;
-  }
-
-  &__footer {
-    border-top: 1px solid var(--primary-low);
-    padding-top: 0.5em;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
     font-size: var(--font-down-1);
+    color: var(--primary);
+  }
+  &__event-time {
+    font-size: var(--font-down-1);
+    font-weight: 400;
+    color: var(--primary-medium);
+  }
+  &__footer {
+    margin-top: 1em;
+    font-size: var(--font-down-2);
     line-height: var(--line-height-medium);
+  }
+  &__footer a {
+    color: var(--primary-high);
   }
 }

--- a/assets/stylesheets/common/upcoming-events-list.scss
+++ b/assets/stylesheets/common/upcoming-events-list.scss
@@ -2,10 +2,14 @@
   &__event {
     column-gap: 0.5em;
     display: flex;
-    margin-top: 0.75em;
+    padding: 0.5em;
+    border-radius: var(--d-border-radius);
   }
   &__event:last-of-type {
     margin-bottom: 0.75em;
+  }
+  &__event:hover {
+    background-color: var(--primary-50);
   }
   &__event-date {
     display: flex;

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -3,13 +3,11 @@
 describe "Post event", type: :system do
   fab!(:admin)
   fab!(:user) { Fabricate(:admin, username: "jane") }
-  fab!(:group) { Fabricate(:group, name: "test_group") }
   let(:composer) { PageObjects::Components::Composer.new }
 
   before do
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
-    SiteSetting.discourse_post_event_allowed_custom_fields = "custom"
     sign_in(admin)
   end
 
@@ -58,7 +56,8 @@ describe "Post event", type: :system do
     expect(page).to have_css(".discourse-post-event .status-and-creators .status.public")
 
     page.find(".going-button").click
-    page.find(".event-invitees .show-all").click
+    page.find(".discourse-post-event-more-menu-trigger").click
+    page.find(".show-all-participants").click
     page.find(".d-modal input.filter").fill_in(with: "jan")
     page.find(".d-modal .add-invitee").click
 
@@ -69,36 +68,5 @@ describe "Post event", type: :system do
     event = topic.posts.first.event
 
     expect(event.invitees.count).to eq(2)
-  end
-
-  it "can update fields and invitees and they are kept when re-opening" do
-    visit "/new-topic"
-    title = "Test event with updates"
-
-    composer.fill_title(title)
-
-    page.find(".toolbar-popup-menu-options .dropdown-select-box-header").click
-
-    page.find(
-      ".toolbar-popup-menu-options [data-name='#{I18n.t("js.discourse_post_event.builder_modal.attach")}']",
-    ).click
-
-    page.find(".d-modal input[name=status][value=private]").click
-
-    page.find(".d-modal input.group-selector").fill_in(with: "test_")
-    page.find(".autocomplete.ac-group").click
-
-    page.find(".d-modal .custom-field-input").fill_in(with: "custom value")
-
-    page.find(".d-modal .btn-primary").click
-
-    composer.submit
-
-    page.find(".discourse-post-event-more-menu-trigger").click
-    page.find(".edit-event").click
-
-    expect(page.find(".d-modal input[name=status][value=private]").checked?).to eq(true)
-    expect(page.find(".d-modal")).to have_text("test_group")
-    expect(page.find(".d-modal .custom-field-input").value).to eq("custom value")
   end
 end

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -3,11 +3,13 @@
 describe "Post event", type: :system do
   fab!(:admin)
   fab!(:user) { Fabricate(:admin, username: "jane") }
+  fab!(:group) { Fabricate(:group, name: "test_group") }
   let(:composer) { PageObjects::Components::Composer.new }
 
   before do
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.discourse_post_event_allowed_custom_fields = "custom"
     sign_in(admin)
   end
 
@@ -67,5 +69,36 @@ describe "Post event", type: :system do
     event = topic.posts.first.event
 
     expect(event.invitees.count).to eq(2)
+  end
+
+  it "can update fields and invitees and they are kept when re-opening" do
+    visit "/new-topic"
+    title = "Test event with updates"
+
+    composer.fill_title(title)
+
+    page.find(".toolbar-popup-menu-options .dropdown-select-box-header").click
+
+    page.find(
+      ".toolbar-popup-menu-options [data-name='#{I18n.t("js.discourse_post_event.builder_modal.attach")}']",
+    ).click
+
+    page.find(".d-modal input[name=status][value=private]").click
+
+    page.find(".d-modal input.group-selector").fill_in(with: "test_")
+    page.find(".autocomplete.ac-group").click
+
+    page.find(".d-modal .custom-field-input").fill_in(with: "custom value")
+
+    page.find(".d-modal .btn-primary").click
+
+    composer.submit
+
+    page.find(".discourse-post-event-more-menu-trigger").click
+    page.find(".edit-event").click
+
+    expect(page.find(".d-modal input[name=status][value=private]").checked?).to eq(true)
+    expect(page.find(".d-modal")).to have_text("test_group")
+    expect(page.find(".d-modal .custom-field-input").value).to eq("custom value")
   end
 end


### PR DESCRIPTION
This PR brings the right sidebar injected component up to date with the topic-post event rendering. (when the right sidebar blocks theme component is installed & active)

Related PR -> https://github.com/discourse/discourse-calendar/pull/641

**After**
<img width="1181" alt="image" src="https://github.com/user-attachments/assets/3d71d617-af52-42bb-ab7c-508f8c42bec8">

**Before**
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/885fb380-e83e-4726-a9e1-07b6e60dcf4e">

