### PR TITLE
DEV: Update to Font Awesome 6 icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: 5f6942c1f3616d43eec18a71d76baa0e55e1340b
 < 3.4.0.beta1-dev: 908ad614bc412f831f929ca726a4bda0b9ccaab6
 < 3.3.0.beta2-dev: 455eeed541a9b5cacf627349e543028427178a44
 < 3.3.0.beta1-dev: 84ef46a38cf02748ecacad16c5d9c6fec12dc8da

--- a/plugin.rb
+++ b/plugin.rb
@@ -32,11 +32,11 @@ register_asset "stylesheets/desktop/discourse-calendar.scss", :desktop
 register_asset "stylesheets/colors.scss", :color_definitions
 register_asset "stylesheets/common/user-preferences.scss"
 register_asset "stylesheets/common/upcoming-events-list.scss"
-register_svg_icon "fas fa-calendar-day"
-register_svg_icon "fas fa-clock"
-register_svg_icon "fas fa-file-csv"
-register_svg_icon "fas fa-star"
-register_svg_icon "fas fa-file-upload"
+register_svg_icon "calendar-day"
+register_svg_icon "clock"
+register_svg_icon "file-csv"
+register_svg_icon "star"
+register_svg_icon "file-arrow-up"
 
 module ::DiscourseCalendar
   PLUGIN_NAME = "discourse-calendar"


### PR DESCRIPTION
This PR maps deprecated Font Awesome icon names to their FA6 variants