### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -222,7 +222,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
     <DMenu
       @identifier="discourse-post-event-more-menu"
       @triggerClass="more-dropdown"
-      @icon="ellipsis-h"
+      @icon="ellipsis"
       @onRegisterApi={{this.registerMenuApi}}
     >
       <:content>
@@ -299,7 +299,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
             {{#if this.canBulkInvite}}
               <dropdown.item class="bulk-invite">
                 <DButton
-                  @icon="file-upload"
+                  @icon="file-arrow-up"
                   class="btn-transparent"
                   @label="discourse_post_event.bulk_invite"
                   @action={{this.bulkInvite}}
@@ -319,7 +319,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
             {{else}}
               <dropdown.item class="edit-event">
                 <DButton
-                  @icon="pencil-alt"
+                  @icon="pencil"
                   class="btn-transparent"
                   @label="discourse_post_event.edit_event"
                   @action={{this.editPostEvent}}
@@ -329,7 +329,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
               {{#unless @event.isExpired}}
                 <dropdown.item class="close-event">
                   <DButton
-                    @icon="times"
+                    @icon="xmark"
                     @label="discourse_post_event.close_event"
                     @action={{this.closeEvent}}
                     class="btn-transparent btn-danger"

--- a/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -169,7 +169,7 @@ export default class DiscoursePostEventStatus extends Component {
             >
               <DButton
                 class="not-going-button"
-                @icon="times"
+                @icon="xmark"
                 @label="discourse_post_event.models.invitee.status.not_going"
                 @action={{fn this.changeWatchingInviteeStatus "not_going"}}
               />

--- a/assets/javascripts/discourse/components/modal/post-event-builder.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.hbs
@@ -171,7 +171,7 @@
 
                 <DButton
                   class="remove-reminder"
-                  @icon="times"
+                  @icon="xmark"
                   @action={{fn @model.event.removeReminder reminder}}
                 />
 
@@ -255,7 +255,7 @@
       />
 
       <DButton
-        @icon="trash-alt"
+        @icon="trash-can"
         class="btn-danger"
         @action={{this.destroyPostEvent}}
       />

--- a/assets/javascripts/discourse/components/modal/post-event-bulk-invite.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-bulk-invite.hbs
@@ -54,7 +54,7 @@
             />
 
             <DButton
-              @icon="trash-alt"
+              @icon="trash-can"
               @action={{fn this.removeBulkInvite bulkInvite}}
               class="remove-bulk-invite"
             />

--- a/assets/javascripts/discourse/components/modal/post-event-invitees/index.gjs
+++ b/assets/javascripts/discourse/components/modal/post-event-invitees/index.gjs
@@ -119,7 +119,7 @@ export default class PostEventInviteesModal extends Component {
                   {{#if @model.event.canActOnDiscoursePostEvent}}
                     <DButton
                       class="remove-invitee"
-                      @icon="trash-alt"
+                      @icon="trash-can"
                       @action={{fn this.removeInvitee invitee}}
                       title={{i18n
                         "discourse_post_event.invitees_modal.remove_invitee"


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.