### PR TITLE
UX: Render invitees count

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import DButton from "discourse/components/d-button";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import PostEventInvitees from "../modal/post-event-invitees";

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import PostEventInvitees from "../modal/post-event-invitees";
@@ -21,57 +22,31 @@ export default class DiscoursePostEventInvitees extends Component {
     });
   }
 
+  get hasAttendees() {
+    return this.args.event.stats["going"] > 0;
+  }
+
   get statsInfo() {
-    const stats = [];
-    const visibleStats = this.siteSettings.event_participation_buttons
-      .split("|")
-      .filter(Boolean);
+    return this.args.event.stats["going"];
+  }
 
-    if (this.args.event.isPrivate) {
-      visibleStats.push("invited");
-    }
-
-    visibleStats.forEach((button) => {
-      const localeKey = button.replace(" ", "_");
-      if (button === "not_going") {
-        button = "notGoing";
-      }
-
-      const count = this.args.event.stats[button] || 0;
-
-      const label = i18n(
-        `discourse_post_event.models.invitee.status.${localeKey}_count`,
-        { count }
-      );
-
-      stats.push({
-        class: `event-status-${localeKey}`,
-        label,
-      });
+  get inviteesTitle() {
+    return i18n("discourse_post_event.models.invitee.status.going_count", {
+      count: this.args.event.stats["going"],
     });
-
-    return stats;
   }
 
   <template>
     {{#unless @event.minimal}}
       {{#if @event.shouldDisplayInvitees}}
         <section class="event__section event-invitees">
-          <div class="header">
-            <div class="event-invitees-status">
-              {{#each this.statsInfo as |info|}}
-                <span class={{info.class}}>{{info.label}}</span>
-              {{/each}}
-            </div>
-
-            <DButton
-              class="show-all btn-small"
-              @label="discourse_post_event.show_all"
-              @action={{this.showAllInvitees}}
-            />
-          </div>
           <div class="event-invitees-avatars-container">
-            {{icon "users"}}
+            <div class="event-invitees-icon" title={{this.inviteesTitle}}>
+              {{icon "users"}}
+              {{#if this.hasAttendees}}
+                <span class="going">{{this.statsInfo}}</span>
+              {{/if}}
+            </div>
             <ul class="event-invitees-avatars">
               {{#each @event.sampleInvitees as |invitee|}}
                 <Invitee @invitee={{invitee}} />

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -11,16 +11,16 @@ export default class DiscoursePostEventInvitees extends Component {
   @service siteSettings;
 
   get hasAttendees() {
-    return this.args.event.stats["going"] > 0;
+    return this.args.event.stats.going > 0;
   }
 
   get statsInfo() {
-    return this.args.event.stats["going"];
+    return this.args.event.stats.going;
   }
 
   get inviteesTitle() {
     return i18n("discourse_post_event.models.invitee.status.going_count", {
-      count: this.args.event.stats["going"],
+      count: this.args.event.stats.going,
     });
   }
 

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -10,17 +10,6 @@ export default class DiscoursePostEventInvitees extends Component {
   @service modal;
   @service siteSettings;
 
-  @action
-  showAllInvitees() {
-    this.modal.show(PostEventInvitees, {
-      model: {
-        event: this.args.event,
-        title: this.args.event.title,
-        extraClass: this.args.event.extraClass,
-      },
-    });
-  }
-
   get hasAttendees() {
     return this.args.event.stats["going"] > 0;
   }

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -22,57 +22,31 @@ export default class DiscoursePostEventInvitees extends Component {
     });
   }
 
+  get hasAttendees() {
+    return this.args.event.stats["going"] > 0;
+  }
+
   get statsInfo() {
-    const stats = [];
-    const visibleStats = this.siteSettings.event_participation_buttons
-      .split("|")
-      .filter(Boolean);
+    return this.args.event.stats["going"];
+  }
 
-    if (this.args.event.isPrivate) {
-      visibleStats.push("invited");
-    }
-
-    visibleStats.forEach((button) => {
-      const localeKey = button.replace(" ", "_");
-      if (button === "not_going") {
-        button = "notGoing";
-      }
-
-      const count = this.args.event.stats[button] || 0;
-
-      const label = i18n(
-        `discourse_post_event.models.invitee.status.${localeKey}_count`,
-        { count }
-      );
-
-      stats.push({
-        class: `event-status-${localeKey}`,
-        label,
-      });
+  get inviteesTitle() {
+    return i18n("discourse_post_event.models.invitee.status.going_count", {
+      count: this.args.event.stats["going"],
     });
-
-    return stats;
   }
 
   <template>
     {{#unless @event.minimal}}
       {{#if @event.shouldDisplayInvitees}}
         <section class="event__section event-invitees">
-          <div class="header">
-            <div class="event-invitees-status">
-              {{#each this.statsInfo as |info|}}
-                <span class={{info.class}}>{{info.label}}</span>
-              {{/each}}
-            </div>
-
-            <DButton
-              class="show-all btn-small"
-              @label="discourse_post_event.show_all"
-              @action={{this.showAllInvitees}}
-            />
-          </div>
           <div class="event-invitees-avatars-container">
-            {{icon "users"}}
+            <div class="event-invitees-icon" title={{this.inviteesTitle}}>
+              {{icon "users"}}
+              {{#if this.hasAttendees}}
+                <span class="going">{{this.statsInfo}}</span>
+              {{/if}}
+            </div>
             <ul class="event-invitees-avatars">
               {{#each @event.sampleInvitees as |invitee|}}
                 <Invitee @invitee={{invitee}} />

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import DButton from "discourse/components/d-button";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import PostEventInvitees from "../modal/post-event-invitees";
@@ -22,31 +21,57 @@ export default class DiscoursePostEventInvitees extends Component {
     });
   }
 
-  get hasAttendees() {
-    return this.args.event.stats["going"] > 0;
-  }
-
   get statsInfo() {
-    return this.args.event.stats["going"];
-  }
+    const stats = [];
+    const visibleStats = this.siteSettings.event_participation_buttons
+      .split("|")
+      .filter(Boolean);
 
-  get inviteesTitle() {
-    return i18n("discourse_post_event.models.invitee.status.going_count", {
-      count: this.args.event.stats["going"],
+    if (this.args.event.isPrivate) {
+      visibleStats.push("invited");
+    }
+
+    visibleStats.forEach((button) => {
+      const localeKey = button.replace(" ", "_");
+      if (button === "not_going") {
+        button = "notGoing";
+      }
+
+      const count = this.args.event.stats[button] || 0;
+
+      const label = i18n(
+        `discourse_post_event.models.invitee.status.${localeKey}_count`,
+        { count }
+      );
+
+      stats.push({
+        class: `event-status-${localeKey}`,
+        label,
+      });
     });
+
+    return stats;
   }
 
   <template>
     {{#unless @event.minimal}}
       {{#if @event.shouldDisplayInvitees}}
         <section class="event__section event-invitees">
-          <div class="event-invitees-avatars-container">
-            <div class="event-invitees-icon" title={{this.inviteesTitle}}>
-              {{icon "users"}}
-              {{#if this.hasAttendees}}
-                <span class="going">{{this.statsInfo}}</span>
-              {{/if}}
+          <div class="header">
+            <div class="event-invitees-status">
+              {{#each this.statsInfo as |info|}}
+                <span class={{info.class}}>{{info.label}}</span>
+              {{/each}}
             </div>
+
+            <DButton
+              class="show-all btn-small"
+              @label="discourse_post_event.show_all"
+              @action={{this.showAllInvitees}}
+            />
+          </div>
+          <div class="event-invitees-avatars-container">
+            {{icon "users"}}
             <ul class="event-invitees-avatars">
               {{#each @event.sampleInvitees as |invitee|}}
                 <Invitee @invitee={{invitee}} />

--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -1,9 +1,7 @@
 import Component from "@glimmer/component";
-import { action } from "@ember/object";
 import { service } from "@ember/service";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
-import PostEventInvitees from "../modal/post-event-invitees";
 import Invitee from "./invitee";
 
 export default class DiscoursePostEventInvitees extends Component {

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -401,4 +401,20 @@ $show-interested: inherit;
     font-weight: 400;
     grid-column-start: 2;
   }
+  .event-invitees-icon {
+    position: relative;
+    display: flex;
+  }
+  .event-invitees-icon .going {
+    font-size: var(--font-down-3);
+    position: absolute;
+    right: 4px;
+    bottom: -8px;
+    background: var(--secondary);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary-medium);
+  }
 }


### PR DESCRIPTION
This PR adds a "going" count back into the events UI. The counts were removed previously to minimize the amount of information, but "going" should have remained.

**After**
![CleanShot 2024-12-05 at 15 48 00@2x](https://github.com/user-attachments/assets/7e8886a5-9af6-4842-b123-7ef09c04b90b)


**Before**
![CleanShot 2024-12-05 at 15 48 48@2x](https://github.com/user-attachments/assets/bdd43849-84f6-40d8-b7b5-ae1de1ead645)

