### PR TITLE
DEV: Force enable glimmer topic list in specs

### DIFF
--- a/spec/system/disable_sort_spec.rb
+++ b/spec/system/disable_sort_spec.rb
@@ -28,7 +28,7 @@ describe "Disabling topic list sorting", type: :system do
     fab!(:user)
 
     before do
-      SiteSetting.glimmer_topic_list_mode = "auto"
+      SiteSetting.glimmer_topic_list_mode = "enabled"
       sign_in(user)
     end
 


### PR DESCRIPTION
Otherwise it'll fail if some other incompatible plugin is installed at the same time