### PR TITLE
FIX: correctly apply local dates on event dates

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import { schedule, next } from "@ember/runloop";
+import { next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { applyLocalDates } from "discourse/lib/local-dates";

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import { schedule } from "@ember/runloop";
+import { schedule, next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { applyLocalDates } from "discourse/lib/local-dates";
@@ -59,13 +59,15 @@ export default class DiscoursePostEventDates extends Component {
       const result = await cook(this.datesBBCode.join("<span> → </span>"));
       this.htmlDates = htmlSafe(result.toString());
 
-      schedule("afterRender", () => {
-        applyLocalDates(
-          element.querySelectorAll(
-            `[data-post-id="${this.args.event.id}"] .discourse-local-date`
-          ),
-          this.siteSettings
-        );
+      next(() => {
+        schedule("afterRender", () => {
+          applyLocalDates(
+            element.querySelectorAll(
+              `[data-post-id="${this.args.event.id}"] .discourse-local-date`
+            ),
+            this.siteSettings
+          );
+        });
       });
     } else {
       let dates = `${this.startsAt.format(this.format)}`;

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -61,6 +61,10 @@ export default class DiscoursePostEventDates extends Component {
 
       next(() => {
         schedule("afterRender", () => {
+          if (this.isDestroying || this.isDestroyed) {
+            return;
+          }
+
           applyLocalDates(
             element.querySelectorAll(
               `[data-post-id="${this.args.event.id}"] .discourse-local-date`


### PR DESCRIPTION
The next ensures `this.htmlDates` has correctly been set and a render is on going which is going to be awaited by the schedule render. Before this fix `querySelectorAll` could return an empty nodes list as the dates were not rendered yet.