### PR TITLE
UX: Remove going indicator for standalone events

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitees.gjs
@@ -41,12 +41,14 @@ export default class DiscoursePostEventInvitees extends Component {
           </div>
         </section>
       {{else}}
-        <section class="event__section event-invitees no-rsvp">
-          <p class="no-rsvp-description">{{i18n
-              "discourse_post_event.models.invitee.status.going_count.other"
-              count="0"
-            }}</p>
-        </section>
+        {{#unless @event.isStandalone}}
+          <section class="event__section event-invitees no-rsvp">
+            <p class="no-rsvp-description">{{i18n
+                "discourse_post_event.models.invitee.status.going_count.other"
+                count="0"
+              }}</p>
+          </section>
+        {{/unless}}
       {{/if}}
     {{/unless}}
   </template>

--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -38,6 +38,10 @@ $show-interested: inherit;
     box-sizing: border-box;
     border-radius: var(--d-button-border-radius);
 
+    section:last-child {
+      padding-bottom: 0.75em;
+    }
+
     .widget-dropdown {
       margin: 0;
 
@@ -394,6 +398,7 @@ $show-interested: inherit;
     display: grid;
     grid-template-columns: 3em 1fr;
     grid-column-gap: 1em;
+    align-items: center;
   }
   p.no-rsvp-description {
     color: var(--primary-medium);


### PR DESCRIPTION
This PR removes the "0 Going" indicator if an event is standalone. Because users cannot mark they are "going" to a standalone event, the "0 Going" was always present, which is not ideal.

I also added a small line of CSS to always add padding to the bottom of the last section equal to the to section in the event post component.

**Before**
![CleanShot 2024-12-24 at 08 01 45@2x](https://github.com/user-attachments/assets/705003d3-692c-44ba-8c0e-cfd33dd19347)


**After**
![CleanShot 2024-12-24 at 08 01 27@2x](https://github.com/user-attachments/assets/61eb53d6-3484-4ff9-9911-2a566f17b756)
