### PR TITLE
DEV: Update Public Holidays for Singapore 2025

### DIFF
--- a/vendor/holidays/definitions/sg.yaml
+++ b/vendor/holidays/definitions/sg.yaml
@@ -16,31 +16,30 @@ months:
     regions: [sg]
     mday: 1
     observed: to_weekday_if_weekend(date)
-  2:
-  - name: First day of Chinese New Year (Observed)
-    regions: [sg]
-    mday: 10
-    observed: to_weekday_if_weekend(date)
-    year_ranges:
-      limited: [2024]
-  - name: Second day of Chinese New Year
-    regions: [sg]
-    mday: 11
-    observed: to_weekday_if_weekend(date)
-    year_ranges:
-      limited: [2024]
-  3:
-  - name: Good Friday
+  - name: First day of Chinese New Year
     regions: [sg]
     mday: 29
+    observed: to_weekday_if_weekend(date)
     year_ranges:
-      limited: [2024]
-  4:
-  - name: Hari Raya Puasa (Observed)
+      limited: [2025]
+  - name: Second day of Chinese New Year
     regions: [sg]
-    mday: 10
+    mday: 30
+    observed: to_weekday_if_weekend(date)
     year_ranges:
-      limited: [2024]
+      limited: [2025]
+  3:
+  - name: Hari Raya Puasa
+    regions: [sg]
+    mday: 31
+    year_ranges:
+      limited: [2025]
+  4:
+  - name: Good Friday
+    regions: [sg]
+    mday: 18
+    year_ranges:
+      limited: [2025]
   5:
   - name: Labour Day
     regions: [sg]
@@ -48,15 +47,15 @@ months:
     observed: to_weekday_if_weekend(date)
   - name: Vesak Day
     regions: [sg]
-    mday: 22
+    mday: 12
     year_ranges:
-      limited: [2024]
+      limited: [2025]
   6:
   - name: Hari Raya Haji
     regions: [sg]
-    mday: 17
+    mday: 7
     year_ranges:
-      limited: [2024]
+      limited: [2025]
   8:
   - name: National Day
     regions: [sg]
@@ -65,9 +64,9 @@ months:
   10:
   - name: Deepavali (Observed)
     regions: [sg]
-    mday: 31
+    mday: 20
     year_ranges:
-      limited: [2024]
+      limited: [2025]
   12:
   - name: Christmas Day
     regions: [sg]

--- a/vendor/holidays/lib/generated_definitions/sg.rb
+++ b/vendor/holidays/lib/generated_definitions/sg.rb
@@ -12,16 +12,16 @@ module Holidays
 
     def self.holidays_by_month
       {
-                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:sg]}],
-      2 => [{:mday => 10, :year_ranges => { :limited => [2024] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "First day of Chinese New Year (Observed)", :regions => [:sg]},
-            {:mday => 11, :year_ranges => { :limited => [2024] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Second day of Chinese New Year", :regions => [:sg]}],
-      3 => [{:mday => 29, :year_ranges => { :limited => [2024] },:name => "Good Friday", :regions => [:sg]}],
-      4 => [{:mday => 10, :year_ranges => { :limited => [2024] },:name => "Hari Raya Puasa (Observed)", :regions => [:sg]}],
+                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:sg]},
+            {:mday => 29, :year_ranges => { :limited => [2025] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "First day of Chinese New Year", :regions => [:sg]},
+            {:mday => 30, :year_ranges => { :limited => [2025] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Second day of Chinese New Year", :regions => [:sg]}],
+      3 => [{:mday => 31, :year_ranges => { :limited => [2025] },:name => "Hari Raya Puasa", :regions => [:sg]}],
+      4 => [{:mday => 18, :year_ranges => { :limited => [2025] },:name => "Good Friday", :regions => [:sg]}],
       5 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Labour Day", :regions => [:sg]},
-            {:mday => 22, :year_ranges => { :limited => [2024] },:name => "Vesak Day", :regions => [:sg]}],
-      6 => [{:mday => 17, :year_ranges => { :limited => [2024] },:name => "Hari Raya Haji", :regions => [:sg]}],
+            {:mday => 12, :year_ranges => { :limited => [2025] },:name => "Vesak Day", :regions => [:sg]}],
+      6 => [{:mday => 7, :year_ranges => { :limited => [2025] },:name => "Hari Raya Haji", :regions => [:sg]}],
       8 => [{:mday => 9, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "National Day", :regions => [:sg]}],
-      10 => [{:mday => 31, :year_ranges => { :limited => [2024] },:name => "Deepavali (Observed)", :regions => [:sg]}],
+      10 => [{:mday => 20, :year_ranges => { :limited => [2025] },:name => "Deepavali (Observed)", :regions => [:sg]}],
       12 => [{:mday => 25, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:sg]}]
       }
     end


### PR DESCRIPTION
Dates are referenced from https://www.mom.gov.sg/newsroom/press-releases/2024/0805-public-holidays-for-2025
