### PR TITLE
FIX: row height on the upcoming events calendar

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -46,7 +46,7 @@ export default class UpcomingEventsCalendar extends Component {
     this._loadCalendar().then(() => {
       const fullCalendar = new window.FullCalendar.Calendar(calendarNode, {
         ...fullCalendarDefaultOptions(),
-        height: "parent",
+        height: "auto",
         eventPositioned: (info) => {
           if (siteSettings.events_max_rows === 0) {
             return;


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/003ed3be-3856-40a4-b6bd-f680a4862fc0)


After
![image](https://github.com/user-attachments/assets/2925b6f0-1571-484b-bdce-85988b947746)
