### PR TITLE
UX: Do not show participants in admin drop down menu for standalone events

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -108,6 +108,7 @@ export default class DiscoursePostEvent extends Component {
 
             <MoreMenu
               @event={{@event}}
+              @isStandaloneEvent={{this.isStandaloneEvent}}
               @composePrivateMessage={{routeAction "composePrivateMessage"}}
             />
           </header>

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -34,6 +34,10 @@ export default class DiscoursePostEventMoreMenu extends Component {
     return this.currentUser && this.args.event.canActOnDiscoursePostEvent;
   }
 
+  get shouldShowParticipants() {
+    return this.canActOnEvent && !this.args.isStandaloneEvent;
+  }
+
   get canInvite() {
     return (
       !this.expiredOrClosed && this.canActOnEvent && this.args.event.isPublic
@@ -275,7 +279,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
             </dropdown.item>
           {{/if}}
 
-          {{#if this.canActOnEvent}}
+          {{#if this.shouldShowParticipants}}
             <dropdown.item class="show-all-participants">
               <DButton
                 @icon="user-group"
@@ -286,7 +290,8 @@ export default class DiscoursePostEventMoreMenu extends Component {
             </dropdown.item>
 
             <dropdown.divider />
-
+          {{/if}}
+          {{#if this.canActOnEvent}}
             <dropdown.item class="export-event">
               <DButton
                 @icon="file-csv"

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -74,6 +74,19 @@ describe "Post event", type: :system do
     expect(event.invitees.count).to eq(2)
   end
 
+  it "does not show participants button when event is standalone" do
+    post =
+      PostCreator.create(
+        admin,
+        title: "My test meetup event",
+        raw: "[event name='cool-event' status='standalone' start='2222-02-22 00:00' ]\n[/event]",
+      )
+
+    visit(post.topic.url)
+    page.find(".discourse-post-event-more-menu-trigger").click
+    expect(page.find(".show-all-participants")).to eq(false)
+  end
+
   it "persists changes" do
     visit "/new-topic"
     composer.fill_title("Test event with updates")

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -84,7 +84,7 @@ describe "Post event", type: :system do
 
     visit(post.topic.url)
     page.find(".discourse-post-event-more-menu-trigger").click
-    expect(page.find(".show-all-participants")).to eq(false)
+    expect(page).to have_no_css(".show-all-participants")
   end
 
   it "persists changes" do


### PR DESCRIPTION
This PR adds logic in order to *not* show the "show participants" button in the `more` dropdown on standalone events.

**After**
![CleanShot 2025-01-14 at 15 03 06@2x](https://github.com/user-attachments/assets/557f57c3-eb14-48d6-85f2-e2a51fd91671)

**Before**
![CleanShot 2025-01-14 at 15 03 52@2x](https://github.com/user-attachments/assets/7cd21788-a54f-49a7-baa5-8dc1008294e1)
