### PR TITLE
DEV: update more deprecated icon names

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/invitee.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/invitee.gjs
@@ -14,11 +14,11 @@ export default class DiscoursePostEventInvitee extends Component {
   get statusIcon() {
     switch (this.args.invitee.status) {
       case "going":
-        return "fa-check";
+        return "check";
       case "interested":
-        return "fa-star";
+        return "star";
       case "not_going":
-        return "fa-times";
+        return "xmark";
     }
   }
 

--- a/assets/javascripts/discourse/widgets/discourse-group-timezones-reset.js
+++ b/assets/javascripts/discourse/widgets/discourse-group-timezones-reset.js
@@ -28,7 +28,7 @@ export default createWidget("discourse-group-timezones-reset", {
       attrs=(hash
         disabled=this.transformed.isDisabled
         action="onResetOffset"
-        icon="undo"
+        icon="arrow-rotate-left"
       )
     }}
   `,


### PR DESCRIPTION
This PR updates the deprecated `times` and `undo` icon names, and removes some `fa-` prefixes which we remove in core anyway. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.