### PR TITLE
FEATURE: Add who can see invitees setting

### DIFF
--- a/app/models/who_can_see_invitees_site_setting.rb
+++ b/app/models/who_can_see_invitees_site_setting.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "enum_site_setting"
+
+class WhoCanSeeInviteesSiteSetting < EnumSiteSetting
+  def self.valid_value?(val)
+    values.any? { |v| v[:value].to_s == val.to_s }
+  end
+
+  def self.values
+    @values ||= [
+      {
+        name: "discourse_calendar.who_can_see_invitees.only_who_can_act",
+        value: "only_who_can_act",
+      },
+      {
+        name: "discourse_calendar.who_can_see_invitees.all_logged_in_users",
+        value: "all_logged_in_users",
+      },
+      {
+        name: "discourse_calendar.who_can_see_invitees.event_creator_and_who_can_act",
+        value: "event_creator_and_who_can_act",
+      },
+    ]
+  end
+
+  def self.translate_names?
+    true
+  end
+end

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import EmberObject, { action } from "@ember/object";
 import { service } from "@ember/service";
+import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -35,7 +36,24 @@ export default class DiscoursePostEventMoreMenu extends Component {
   }
 
   get shouldShowParticipants() {
-    return this.canActOnEvent && !this.args.isStandaloneEvent;
+    const shouldShowBasedOnSettings = () => {
+      switch (this.siteSettings.who_can_see_invitees) {
+        case "only_who_can_act": // default
+          return false;
+        case "all_logged_in_users":
+          return !!this.currentUser;
+        case "event_creator_and_who_can_act":
+          return (
+            this.currentUser &&
+            this.currentUser.id === this.args.event.creator.id
+          );
+      }
+    };
+
+    return (
+      (this.canActOnEvent && !this.args.isStandaloneEvent) ||
+      shouldShowBasedOnSettings()
+    );
   }
 
   get canInvite() {

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import EmberObject, { action } from "@ember/object";
 import { service } from "@ember/service";
-import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
 import { popupAjaxError } from "discourse/lib/ajax-error";

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -33,6 +33,10 @@ en:
       date: "Date"
       add_to_calendar: "Add to Google Calendar"
       toggle_timezone_offset_title: "Toggle timezone offset"
+      who_can_see_invitees:
+        only_who_can_act: "Only users who can edit the event"
+        all_logged_in_users: "All logged in users"
+        event_creator_and_who_can_act: "Event creator and users who can edit the event"
       region:
         title: "Region"
         none: "None"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -59,6 +59,7 @@ en:
     event_participation_buttons: "List of event participation buttons users can use."
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'."
     include_expired_events_on_calendar: "Include past/expired events on Category Calendar and Upcoming Events views."
+    who_can_see_invitees: "Who can see the invitees of an event."
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -127,3 +127,7 @@ discourse_calendar:
   include_expired_events_on_calendar:
     default: false
     client: true
+  who_can_see_invitees:
+    client: true
+    default: "only_who_can_act"
+    enum: "WhoCanSeeInviteesSiteSetting"


### PR DESCRIPTION
For some forums, it might be useful to restrict who can see the list of invitees for an event without having to give `acting`/editing powers to a user.

This commit adds a new site setting, `who_can_see_invitees,` that allows admins to restrict who can see the list of invitees for an event.

The setting can be set to one of the following values:
- `only_who_can_act`: (default/current) only users who can act on the event can see the list of invitees.
- `all_logged_in_users` : all logged in users can see the list of invitees.
- `event_creator_and_who_can_act`: only the event creator and users who can act on the event can see the list of invitees.

- [ ] Add tests