### PR TITLE
FEATURE: Add value transformer for showing participants in the event more menu

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -37,7 +37,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
 
   get shouldShowParticipants() {
     return applyValueTransformer(
-      "discourse-calendar-should-show-participants",
+      "discourse-calendar-event-more-menu-should-show-participants",
       this.canActOnEvent && !this.args.isStandaloneEvent,
       {
         event: this.args.event,

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -9,6 +9,7 @@ import { downloadCalendar } from "discourse/lib/download-calendar";
 import { exportEntity } from "discourse/lib/export-csv";
 import { getAbsoluteURL } from "discourse/lib/get-url";
 import { cook } from "discourse/lib/text";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
 import { buildParams, replaceRaw } from "../../lib/raw-event-helper";
@@ -35,7 +36,13 @@ export default class DiscoursePostEventMoreMenu extends Component {
   }
 
   get shouldShowParticipants() {
-    return this.canActOnEvent && !this.args.isStandaloneEvent;
+    return applyValueTransformer(
+      "discourse-calendar-should-show-participants",
+       (this.canActOnEvent && !this.args.isStandaloneEvent),
+      {
+        event: this.args.event,
+      }
+    );
   }
 
   get canInvite() {

--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -38,7 +38,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
   get shouldShowParticipants() {
     return applyValueTransformer(
       "discourse-calendar-should-show-participants",
-       (this.canActOnEvent && !this.args.isStandaloneEvent),
+      this.canActOnEvent && !this.args.isStandaloneEvent,
       {
         event: this.args.event,
       }

--- a/assets/javascripts/discourse/pre-initializers/transformers.js
+++ b/assets/javascripts/discourse/pre-initializers/transformers.js
@@ -5,7 +5,7 @@ export default {
   initialize() {
     withPluginApi("1.33.0", (api) => {
       api.addValueTransformerName(
-        "discourse-calendar-should-show-participants"
+        "discourse-calendar-event-more-menu-should-show-participants"
       );
     });
   },

--- a/assets/javascripts/discourse/pre-initializers/transformers.js
+++ b/assets/javascripts/discourse/pre-initializers/transformers.js
@@ -1,0 +1,12 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  before: "freeze-valid-transformers",
+  initialize() {
+    withPluginApi("1.33.0", (api) => {
+      api.addValueTransformerName(
+        "discourse-calendar-should-show-participants"
+      );
+    });
+  },
+};

--- a/test/javascripts/integration/components/more-menu-test.gjs
+++ b/test/javascripts/integration/components/more-menu-test.gjs
@@ -2,7 +2,7 @@ import { hash } from "@ember/helper";
 import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
-import { apiInitializer } from "discourse/lib/api";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import MoreMenu from "../../discourse/components/discourse-post-event/more-menu";
 
@@ -25,7 +25,7 @@ module("Integration | Component | MoreMenu", function (hooks) {
   });
 
   test("value transformer works", async function (assert) {
-    apiInitializer("1.34.0", (api) => {
+    withPluginApi("1.34.0", (api) => {
       api.registerValueTransformer(
         "discourse-calendar-should-show-participants",
         () => {

--- a/test/javascripts/integration/components/more-menu-test.gjs
+++ b/test/javascripts/integration/components/more-menu-test.gjs
@@ -11,7 +11,7 @@ module("Integration | Component | MoreMenu", function (hooks) {
   test("value transformer works", async function (assert) {
     withPluginApi("1.34.0", (api) => {
       api.registerValueTransformer(
-        "discourse-calendar-should-show-participants",
+        "discourse-calendar-event-more-menu-should-show-participants",
         () => {
           return true; // by default it should not show to unauthenticated users
         }

--- a/test/javascripts/integration/components/more-menu-test.gjs
+++ b/test/javascripts/integration/components/more-menu-test.gjs
@@ -9,7 +9,6 @@ module("Integration | Component | MoreMenu", function (hooks) {
   setupRenderingTest(hooks);
 
   test("value transformer works", async function (assert) {
-
     withPluginApi("1.34.0", (api) => {
       api.registerValueTransformer(
         "discourse-calendar-should-show-participants",

--- a/test/javascripts/integration/components/more-menu-test.gjs
+++ b/test/javascripts/integration/components/more-menu-test.gjs
@@ -1,6 +1,6 @@
 import { hash } from "@ember/helper";
 import { getOwner } from "@ember/owner";
-import { click,render } from "@ember/test-helpers";
+import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { apiInitializer } from "discourse/lib/api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -37,8 +37,6 @@ module("Integration | Component | MoreMenu", function (hooks) {
       <MoreMenu @event={{hash isExpired=false creator=this.user}} />
     </template>);
     await click(".discourse-post-event-more-menu-trigger");
-    assert
-      .dom(".show-all-participants")
-      .exists();
+    assert.dom(".show-all-participants").exists();
   });
 });

--- a/test/javascripts/integration/components/more-menu-test.gjs
+++ b/test/javascripts/integration/components/more-menu-test.gjs
@@ -1,5 +1,4 @@
 import { hash } from "@ember/helper";
-import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -9,22 +8,8 @@ import MoreMenu from "../../discourse/components/discourse-post-event/more-menu"
 module("Integration | Component | MoreMenu", function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    const store = getOwner(this).lookup("service:store");
-
-    this.user = store.createRecord("user", {
-      username: "j.jaffeux",
-      name: "joffrey",
-      id: 321,
-    });
-
-    getOwner(this).unregister("service:current-user");
-    getOwner(this).register("service:current-user", this.user, {
-      instantiate: false,
-    });
-  });
-
   test("value transformer works", async function (assert) {
+
     withPluginApi("1.34.0", (api) => {
       api.registerValueTransformer(
         "discourse-calendar-should-show-participants",
@@ -33,9 +18,11 @@ module("Integration | Component | MoreMenu", function (hooks) {
         }
       );
     });
+
     await render(<template>
-      <MoreMenu @event={{hash isExpired=false creator=this.user}} />
+      <MoreMenu @event={{hash isExpired=false}} />
     </template>);
+
     await click(".discourse-post-event-more-menu-trigger");
     assert.dom(".show-all-participants").exists();
   });

--- a/test/javascripts/integration/components/more-menu-test.gjs
+++ b/test/javascripts/integration/components/more-menu-test.gjs
@@ -1,4 +1,5 @@
 import { hash } from "@ember/helper";
+import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -8,18 +9,46 @@ import MoreMenu from "../../discourse/components/discourse-post-event/more-menu"
 module("Integration | Component | MoreMenu", function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    const store = getOwner(this).lookup("service:store");
+
+    this.user = store.createRecord("user", {
+      username: "j.jaffeux",
+      name: "joffrey",
+      id: 321,
+    });
+
+    getOwner(this).unregister("service:current-user");
+    getOwner(this).register("service:current-user", this.user, {
+      instantiate: false,
+    });
+  });
+
   test("value transformer works", async function (assert) {
     withPluginApi("1.34.0", (api) => {
       api.registerValueTransformer(
         "discourse-calendar-event-more-menu-should-show-participants",
         () => {
-          return true; // by default it should not show to unauthenticated users
+          return true; // by default it should show to canActOnDiscoursePostEvent users
         }
       );
     });
 
+    const store = getOwner(this).lookup("service:store");
+    const creator = store.createRecord("user", {
+      username: "gabriel",
+      name: "gabriel",
+      id: 322,
+    });
+
     await render(<template>
-      <MoreMenu @event={{hash isExpired=false}} />
+      <MoreMenu
+        @event={{hash
+          isExpired=false
+          creator=creator
+          canActOnDiscoursePostEvent=false
+        }}
+      />
     </template>);
 
     await click(".discourse-post-event-more-menu-trigger");

--- a/test/javascripts/integration/components/more-menu-test.gjs
+++ b/test/javascripts/integration/components/more-menu-test.gjs
@@ -1,0 +1,44 @@
+import { hash } from "@ember/helper";
+import { getOwner } from "@ember/owner";
+import { click,render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { apiInitializer } from "discourse/lib/api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import MoreMenu from "../../discourse/components/discourse-post-event/more-menu";
+
+module("Integration | Component | MoreMenu", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const store = getOwner(this).lookup("service:store");
+
+    this.user = store.createRecord("user", {
+      username: "j.jaffeux",
+      name: "joffrey",
+      id: 321,
+    });
+
+    getOwner(this).unregister("service:current-user");
+    getOwner(this).register("service:current-user", this.user, {
+      instantiate: false,
+    });
+  });
+
+  test("value transformer works", async function (assert) {
+    apiInitializer("1.34.0", (api) => {
+      api.registerValueTransformer(
+        "discourse-calendar-should-show-participants",
+        () => {
+          return true; // by default it should not show to unauthenticated users
+        }
+      );
+    });
+    await render(<template>
+      <MoreMenu @event={{hash isExpired=false creator=this.user}} />
+    </template>);
+    await click(".discourse-post-event-more-menu-trigger");
+    assert
+      .dom(".show-all-participants")
+      .exists();
+  });
+});


### PR DESCRIPTION
Plugins can add a value transformer to show participants in the event more menu. This is useful for plugins that want to show participants in the event more menu, but the user currently does not have the authority to see the participants, this gives more flexibility to do so.