### PR TITLE
FIX: Allow events belonging to deleted users to be destroyed

### DIFF
--- a/lib/holiday_status.rb
+++ b/lib/holiday_status.rb
@@ -15,7 +15,7 @@ module DiscourseCalendar
     end
 
     def self.clear!(user)
-      user.clear_status! if user.user_status && is_holiday_status?(user.user_status)
+      user.clear_status! if user&.user_status && is_holiday_status?(user.user_status)
     end
 
     private


### PR DESCRIPTION
`DiscourseCalendar::CreateHolidayEvents` periodically deletes holiday events to recreate updated ones. If one of the events belonged to a user that has been destroyed and if `enable_user_status` was enabled, the `after_destroy` hook would raise an exception.