### PR TITLE
Fix for inconsistent first-day-of-the-week display.

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -46,6 +46,7 @@ export default class UpcomingEventsCalendar extends Component {
     this._loadCalendar().then(() => {
       const fullCalendar = new window.FullCalendar.Calendar(calendarNode, {
         ...fullCalendarDefaultOptions(),
+        firstDay: 1,
         height: "auto",
         eventPositioned: (info) => {
           if (siteSettings.events_max_rows === 0) {

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -133,6 +133,7 @@ function initializeDiscourseCalendar(api) {
         await loadFullCalendar();
         let fullCalendar = new window.FullCalendar.Calendar(categoryEventNode, {
           ...fullCalendarDefaultOptions(),
+          firstDay: 1,
           eventPositioned: (info) => {
             if (siteSettings.events_max_rows === 0) {
               return;

--- a/test/javascripts/acceptance/category-events-calendar-test.js
+++ b/test/javascripts/acceptance/category-events-calendar-test.js
@@ -157,7 +157,7 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
 
     assert.deepEqual(
       [...queryAll(".fc-day-header span")].map((el) => el.innerText),
-      ["dom.", "seg.", "ter.", "qua.", "qui.", "sex.", "sáb."],
+      ["seg.", "ter.", "qua.", "qui.", "sex.", "sáb.", "dom."],
       "Week days are translated in the calendar header"
     );
 


### PR DESCRIPTION
There are three places in this plugin where FullCalendar is set up.

In one of these three the parameter firstDay: 1 is passed, in the other two it's not. This leads to an inconsistency where the Upcoming Events calendar begins on Sunday, whereas the topic calendars start on Monday. (See https://meta.discourse.org/t/choose-first-day-of-the-week-on-upcoming-events-calendar/307785/5)

Ideally this would be taken from the users (browser) preferences, but since [all other places in core](https://github.com/search?q=repo%3Adiscourse%2Fdiscourse%20firstDay&type=code) hard code it to firstDay: 1 as well, this small patch at least adds some consistency.