### PR TITLE
FIX: do not show 'send pm' button to the user who created the event

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -52,6 +52,13 @@ export default class DiscoursePostEventMoreMenu extends Component {
     return !this.expiredOrClosed && !this.args.event.isStandalone;
   }
 
+  get canSendPmToCreator() {
+    return (
+      this.currentUser &&
+      this.currentUser.username !== this.args.event.creator.username
+    );
+  }
+
   @action
   addToCalendar() {
     this.menuApi.close();
@@ -241,7 +248,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
             </dropdown.item>
           {{/unless}}
 
-          {{#if this.currentUser}}
+          {{#if this.canSendPmToCreator}}
             <dropdown.item class="send-pm-to-creator">
               <DButton
                 @icon="envelope"

--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -87,6 +87,19 @@ describe "Post event", type: :system do
     expect(page).to have_no_css(".show-all-participants")
   end
 
+  it "does not show 'send pm' button to the user who created the event" do
+    post =
+      PostCreator.create(
+        admin,
+        title: "My test meetup event",
+        raw: "[event name='cool-event' status='public' start='2222-02-22 00:00' ]\n[/event]",
+      )
+
+    visit(post.topic.url)
+    page.find(".discourse-post-event-more-menu-trigger").click
+    expect(page).to have_no_css(".send-pm-to-creator")
+  end
+
   it "persists changes" do
     visit "/new-topic"
     composer.fill_title("Test event with updates")


### PR DESCRIPTION
<img width="735" alt="Screenshot 2025-02-12 at 18 22 39" src="https://github.com/user-attachments/assets/09b27f66-c40e-4be5-960e-0e9325d36217" />
