### PR TITLE
UX: Remove max-width and allow event container to fill width of post

### DIFF
--- a/assets/stylesheets/common/discourse-post-event.scss
+++ b/assets/stylesheets/common/discourse-post-event.scss
@@ -3,7 +3,6 @@ $show-interested: inherit;
 
 .discourse-post-event {
   display: flex;
-  max-width: 35rem;
   justify-content: center;
 
   .event__section {


### PR DESCRIPTION
# After
![CleanShot 2025-03-10 at 11 03 57@2x](https://github.com/user-attachments/assets/f2758a11-c91a-47d2-bcbb-8d5c8260e1a8)

# Before
![CleanShot 2025-03-10 at 11 04 16@2x](https://github.com/user-attachments/assets/ad78d3e4-44f0-4e1e-8bca-b8257ce1eff7)
