### PR TITLE
FIX: Revert colors.scss changes

### DIFF
--- a/assets/stylesheets/colors.scss
+++ b/assets/stylesheets/colors.scss
@@ -1,16 +1,15 @@
-@use "sass:color";
-
+/* stylelint-disable scss/no-global-function-names */
 :root {
   --calendar-normal: #{dark-light-choose(
-      color.adjust($tertiary, $lightness: 55%),
-      color.adjust($tertiary, $lightness: -25%)
+      lighten($tertiary, 55%),
+      darken($tertiary, 25%)
     )};
   --calendar-close-to-working-hours: #{dark-light-choose(
-      color.adjust(color.adjust($tertiary, $lightness: 45%), $saturation: -15%),
-      color.adjust($tertiary, $lightness: -15%)
+      desaturate(lighten($tertiary, 45%), 15%),
+      darken($tertiary, 15%)
     )};
   --calendar-in-working-hours: #{dark-light-choose(
-      color.adjust(color.adjust($tertiary, $lightness: 40%), $saturation: -20%),
-      color.adjust($tertiary, $lightness: -10%)
+      desaturate(lighten($tertiary, 40%), 20%),
+      darken($tertiary, 10%)
     )};
 }


### PR DESCRIPTION
Fails with `"Error: @use rules must be written before any other rules"` because color stylesheets are concatenated

Followup to fc3f4071ff8bbe25eb05cd9440cc39f1442a5072