### PR TITLE
FIX: Decrease height of the calendar scroller.

### DIFF
--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -12,7 +12,7 @@
 }
 
 .calendar.fc {
-  height: 645px; // Must be fixed to prevent height change on load
+  height: 660px; // Must be fixed to prevent height change on load
   border: 0;
 
   &.fc-unthemed {

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -12,7 +12,7 @@
 }
 
 .calendar.fc {
-  height: 660px; // Must be fixed to prevent height change on load
+  height: 645px; // Must be fixed to prevent height change on load
   border: 0;
 
   &.fc-unthemed {
@@ -33,7 +33,7 @@
     overflow: hidden;
 
     .fc-scroller {
-      height: 575px !important;
+      height: 560px !important;
       padding-bottom: 5px;
     }
 


### PR DESCRIPTION
## ✨ What's This?

When a calendar has enough entries that it needs to scroll within its container, it can't quite scroll far enough, causing the last row to be slightly cut off.

This fix tweaks the size of the scroll container to ensure the last row is fully visible.

## 📺 Screenshots

### Before
![](https://github.com/user-attachments/assets/a388e779-d50d-409a-b187-ea138d28d70b)

### After
![](https://github.com/user-attachments/assets/cfef7d4d-5c93-454a-84dd-f6cfc3abc7f4)

## 👑 Testing

Test that the calendar scrolls fully on different browsers and devices.

Note that there is still some cut-off on particularly small resolutions (<500px wide) due to the way the Month/Week/List buttons are shifted around.