### PR TITLE
WIP: Filter calendar by groups

### DIFF
--- a/assets/javascripts/discourse/lib/discourse-markdown/discourse-calendar.js
+++ b/assets/javascripts/discourse/lib/discourse-markdown/discourse-calendar.js
@@ -19,6 +19,10 @@ const calendarRule = {
     }
     state.push("span_close", "span", -1);
 
+    if (info.attrs.showGroupSelector) {
+      _renderGroupSelector(state);
+    }
+
     state.push("div_calendar_header", "div", -1);
 
     let mainCalendarDivToken = state.push("div_calendar", "div", 1);
@@ -43,6 +47,13 @@ const calendarRule = {
       mainCalendarDivToken.attrs.push([
         "data-calendar-show-add-to-calendar",
         info.attrs.showAddToCalendar === "true",
+      ]);
+    }
+
+    if (info.attrs.showGroupSelector) {
+      mainCalendarDivToken.attrs.push([
+        "data-calendar-show-group-selector",
+        info.attrs.showGroupSelector,
       ]);
     }
 
@@ -91,17 +102,26 @@ function _renderTimezonePicker(state) {
   state.push("select_close", "select", -1);
 }
 
+function _renderGroupSelector(state) {
+  const groupSelectToken = state.push("select_open", "select", 1);
+  groupSelectToken.attrs = [["class", "discourse-calendar-group-picker"]];
+
+  state.push("select_close", "select", -1);
+}
+
 export function setup(helper) {
   helper.allowList([
     "div.calendar",
     "div.discourse-calendar-header",
     "div.discourse-calendar-wrap",
     "select.discourse-calendar-timezone-picker",
+    "select.discourse-calendar-group-picker",
     "span.discourse-calendar-timezone-wrap",
     "h2.discourse-calendar-title",
     "div[data-calendar-type]",
     "div[data-calendar-default-view]",
     "div[data-calendar-default-timezone]",
+    "div[data-calendar-show-group-selector",
     "div[data-weekends]",
     "div[data-hidden-days]",
     "div.group-timezones",

--- a/assets/stylesheets/common/discourse-calendar.scss
+++ b/assets/stylesheets/common/discourse-calendar.scss
@@ -177,7 +177,8 @@ a.holiday {
   background: var(--primary-very-low);
   min-height: 60px;
 
-  .discourse-calendar-timezone-picker {
+  .discourse-calendar-timezone-picker,
+  .discourse-calendar-group-picker {
     font-size: 16px;
     margin-bottom: 0;
     max-width: 50vw;

--- a/assets/stylesheets/mobile/discourse-calendar.scss
+++ b/assets/stylesheets/mobile/discourse-calendar.scss
@@ -14,7 +14,8 @@
       overflow: hidden;
     }
 
-    .discourse-calendar-timezone-picker {
+    .discourse-calendar-timezone-picker,
+    .discourse-calendar-group-picker {
       max-width: 40vw;
     }
   }


### PR DESCRIPTION
This will allow filtering a calendar's users by the
selected group. This dropdown will only show when
`showGroupSelector` is added to the calendar BBCode

![image](https://github.com/user-attachments/assets/05c3d93f-b172-4965-ba16-cc13676ae485)

