### PR TITLE
FIX: remove double quotes `"` character when building the event's mar…

### DIFF
--- a/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -83,10 +83,11 @@ export function replaceRaw(params, raw) {
 
   if (eventMatches && eventMatches[1]) {
     const markdownParams = [];
+
     Object.keys(params).forEach((param) => {
       const value = params[param];
       if (value && value.length) {
-        markdownParams.push(`${param}="${params[param]}"`);
+        markdownParams.push(`${param}="${value.replace(/"/g, "")}"`);
       }
     });
 

--- a/test/javascripts/lib/raw-event-helper-test.js
+++ b/test/javascripts/lib/raw-event-helper-test.js
@@ -12,7 +12,7 @@ module("Unit | Lib | raw-event-helper", function () {
     assert.strictEqual(
       replaceRaw(params, raw),
       'Some text [event param1="newValue1" param2="value2"] more text',
-      "it updates existing parameters and adds new ones"
+      "updates existing parameters and adds new ones"
     );
 
     assert.false(
@@ -23,13 +23,13 @@ module("Unit | Lib | raw-event-helper", function () {
     assert.strictEqual(
       replaceRaw({ foo: 'bar"quoted' }, '[event original="value"]'),
       '[event foo="barquoted"]',
-      "it properly escapes quotes in parameter values"
+      "escapes double quotes in parameter values"
     );
 
     assert.strictEqual(
       replaceRaw({}, '[event param1="value1"]'),
       "[event ]",
-      "it handles empty params object"
+      "handles empty params object"
     );
   });
 });

--- a/test/javascripts/lib/raw-event-helper-test.js
+++ b/test/javascripts/lib/raw-event-helper-test.js
@@ -3,28 +3,31 @@ import { replaceRaw } from "discourse/plugins/discourse-calendar/discourse/lib/r
 
 module("Unit | Lib | raw-event-helper", function () {
   test("replaceRaw", function (assert) {
-    const raw = "Some text [event param1=\"value1\"] more text";
+    const raw = 'Some text [event param1="value1"] more text';
     const params = {
       param1: "newValue1",
-      param2: "value2"
+      param2: "value2",
     };
 
     assert.strictEqual(
       replaceRaw(params, raw),
-      "Some text [event param1=\"newValue1\" param2=\"value2\"] more text",
+      'Some text [event param1="newValue1" param2="value2"] more text',
       "it updates existing parameters and adds new ones"
     );
 
-    assert.false(replaceRaw(params, "No event tag here"), "returns false when no event tag is found");
+    assert.false(
+      replaceRaw(params, "No event tag here"),
+      "returns false when no event tag is found"
+    );
 
     assert.strictEqual(
-      replaceRaw({ foo: "bar\"quoted" }, "[event original=\"value\"]"),
-      "[event foo=\"barquoted\"]",
+      replaceRaw({ foo: 'bar"quoted' }, '[event original="value"]'),
+      '[event foo="barquoted"]',
       "it properly escapes quotes in parameter values"
     );
 
     assert.strictEqual(
-      replaceRaw({}, "[event param1=\"value1\"]"),
+      replaceRaw({}, '[event param1="value1"]'),
       "[event ]",
       "it handles empty params object"
     );

--- a/test/javascripts/lib/raw-event-helper-test.js
+++ b/test/javascripts/lib/raw-event-helper-test.js
@@ -4,7 +4,7 @@ import { replaceRaw } from "discourse/plugins/discourse-calendar/discourse/lib/r
 module("Unit | Lib | raw-event-helper", function () {
   test("replaceRaw", function (assert) {
     const raw = "Some text [event param1=\"value1\"] more text";
-    const params = { 
+    const params = {
       param1: "newValue1",
       param2: "value2"
     };
@@ -15,11 +15,7 @@ module("Unit | Lib | raw-event-helper", function () {
       "it updates existing parameters and adds new ones"
     );
 
-    assert.strictEqual(
-      replaceRaw(params, "No event tag here"),
-      false,
-      "returns false when no event tag is found"
-    );
+    assert.false(replaceRaw(params, "No event tag here"), "returns false when no event tag is found");
 
     assert.strictEqual(
       replaceRaw({ foo: "bar\"quoted" }, "[event original=\"value\"]"),

--- a/test/javascripts/lib/raw-event-helper-test.js
+++ b/test/javascripts/lib/raw-event-helper-test.js
@@ -1,0 +1,36 @@
+import { module, test } from "qunit";
+import { replaceRaw } from "discourse/plugins/discourse-calendar/discourse/lib/raw-event-helper";
+
+module("Unit | Lib | raw-event-helper", function () {
+  test("replaceRaw", function (assert) {
+    const raw = "Some text [event param1=\"value1\"] more text";
+    const params = { 
+      param1: "newValue1",
+      param2: "value2"
+    };
+
+    assert.strictEqual(
+      replaceRaw(params, raw),
+      "Some text [event param1=\"newValue1\" param2=\"value2\"] more text",
+      "it updates existing parameters and adds new ones"
+    );
+
+    assert.strictEqual(
+      replaceRaw(params, "No event tag here"),
+      false,
+      "returns false when no event tag is found"
+    );
+
+    assert.strictEqual(
+      replaceRaw({ foo: "bar\"quoted" }, "[event original=\"value\"]"),
+      "[event foo=\"barquoted\"]",
+      "it properly escapes quotes in parameter values"
+    );
+
+    assert.strictEqual(
+      replaceRaw({}, "[event param1=\"value1\"]"),
+      "[event ]",
+      "it handles empty params object"
+    );
+  });
+});


### PR DESCRIPTION
…kdown

This is not the best UX as user might enter an event name with double quotes and they'll be deleted once they click save. But at least it won't break their event because the double quote breaks the BBCode/Markdown.

A proper fix would be to manipulate an AST instead of using regular expressions on a a string.

Meta - https://meta.discourse.org/t/-/360010