### PR TITLE
FEATURE: Upcoming events calendar filter

### DIFF
--- a/assets/javascripts/discourse/components/calendar-categories-selector.gjs
+++ b/assets/javascripts/discourse/components/calendar-categories-selector.gjs
@@ -1,0 +1,33 @@
+
+
+import { computed } from "@ember/object";
+import { classNames } from "@ember-decorators/component";
+import Category from "discourse/models/category";
+import MultiSelectComponent from "select-kit/components/multi-select";
+import { tracked } from '@glimmer/tracking'
+import {
+  pluginApiIdentifiers,
+} from "select-kit/components/select-kit";
+
+@classNames("event-categories-selector")
+@pluginApiIdentifiers(["event-categories-selector"])
+export default class CalendarCategoriesSelector extends MultiSelectComponent {
+    @tracked events = null;
+
+    @computed("events.[]")
+    get content() {
+        return Category.findByIds(this.events.map((e) => e.categoryId))
+            .map((c) => {
+                let name = c.name
+                if (c.parent_category_id) {
+                const parentCategory = Category.findById(c.parent_category_id)
+                name = `${parentCategory.name} / ${name}`
+                }
+                return {
+                id: c.id,
+                name: name
+                }
+            })
+            .sort((a, b) => a.name.localeCompare(b.name))
+    }
+}

--- a/assets/javascripts/discourse/components/calendar-categories-selector.gjs
+++ b/assets/javascripts/discourse/components/calendar-categories-selector.gjs
@@ -1,33 +1,29 @@
-
-
+import { tracked } from "@glimmer/tracking";
 import { computed } from "@ember/object";
 import { classNames } from "@ember-decorators/component";
 import Category from "discourse/models/category";
 import MultiSelectComponent from "select-kit/components/multi-select";
-import { tracked } from '@glimmer/tracking'
-import {
-  pluginApiIdentifiers,
-} from "select-kit/components/select-kit";
+import { pluginApiIdentifiers } from "select-kit/components/select-kit";
 
 @classNames("event-categories-selector")
 @pluginApiIdentifiers(["event-categories-selector"])
 export default class CalendarCategoriesSelector extends MultiSelectComponent {
-    @tracked events = null;
+  @tracked events = null;
 
-    @computed("events.[]")
-    get content() {
-        return Category.findByIds(this.events.map((e) => e.categoryId))
-            .map((c) => {
-                let name = c.name
-                if (c.parent_category_id) {
-                const parentCategory = Category.findById(c.parent_category_id)
-                name = `${parentCategory.name} / ${name}`
-                }
-                return {
-                id: c.id,
-                name: name
-                }
-            })
-            .sort((a, b) => a.name.localeCompare(b.name))
-    }
+  @computed("events.[]")
+  get content() {
+    return Category.findByIds(this.events.map((e) => e.categoryId))
+      .map((c) => {
+        let name = c.name;
+        if (c.parent_category_id) {
+          const parentCategory = Category.findById(c.parent_category_id);
+          name = `${parentCategory.name} / ${name}`;
+        }
+        return {
+          id: c.id,
+          name,
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
 }

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
@@ -1,5 +1,6 @@
 
 <div>
+    <h3>{{ i18n "js.discourse_calendar.upcoming_events_categories_selector" }}</h3>
     <CalendarCategoriesSelector
         @events={{ this.events }}
         @value={{ this.selectedCategories }}

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
@@ -1,1 +1,9 @@
+
+<div>
+    <CalendarCategoriesSelector
+        @events={{ this.events }}
+        @value={{ this.selectedCategories }}
+        @onChange={{ this.changeSelectedCategories}}
+    />
+</div>
 <div id="upcoming-events-calendar"></div>

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
@@ -1,12 +1,13 @@
-
 <div>
-    {{#if this.siteSettings.display_upcoming_events_calendar_categories_selector}}
-        <h3>{{ i18n "js.discourse_calendar.upcoming_events_categories_selector" }}</h3>
-        <CalendarCategoriesSelector
-            @events={{ this.events }}
-            @value={{ this.selectedCategories }}
-            @onChange={{ this.changeSelectedCategories}}
-        />
-    {{/if}}
+  {{#if this.siteSettings.display_upcoming_events_calendar_categories_selector}}
+    <h3>{{i18n
+        "js.discourse_calendar.upcoming_events_categories_selector"
+      }}</h3>
+    <CalendarCategoriesSelector
+      @events={{this.events}}
+      @value={{this.selectedCategories}}
+      @onChange={{this.changeSelectedCategories}}
+    />
+  {{/if}}
 </div>
 <div id="upcoming-events-calendar"></div>

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
@@ -1,8 +1,11 @@
 <div>
   {{#if this.siteSettings.display_upcoming_events_calendar_categories_selector}}
     <h3>{{i18n
-        "js.discourse_calendar.upcoming_events_categories_selector"
+        "js.discourse_calendar.upcoming_events_categories_selector_title"
       }}</h3>
+    <p>{{i18n
+        "js.discourse_calendar.upcoming_events_categories_selector_help"
+      }}</p>
     <CalendarCategoriesSelector
       @events={{this.events}}
       @value={{this.selectedCategories}}

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.hbs
@@ -1,10 +1,12 @@
 
 <div>
-    <h3>{{ i18n "js.discourse_calendar.upcoming_events_categories_selector" }}</h3>
-    <CalendarCategoriesSelector
-        @events={{ this.events }}
-        @value={{ this.selectedCategories }}
-        @onChange={{ this.changeSelectedCategories}}
-    />
+    {{#if this.siteSettings.display_upcoming_events_calendar_categories_selector}}
+        <h3>{{ i18n "js.discourse_calendar.upcoming_events_categories_selector" }}</h3>
+        <CalendarCategoriesSelector
+            @events={{ this.events }}
+            @value={{ this.selectedCategories }}
+            @onChange={{ this.changeSelectedCategories}}
+        />
+    {{/if}}
 </div>
 <div id="upcoming-events-calendar"></div>

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -1,6 +1,7 @@
 import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import { schedule } from "@ember/runloop";
+import { service } from "@ember/service";
 import { tagName } from "@ember-decorators/component";
 import { Promise } from "rsvp";
 import getURL from "discourse/lib/get-url";
@@ -10,20 +11,29 @@ import { formatEventName } from "../helpers/format-event-name";
 import addRecurrentEvents from "../lib/add-recurrent-events";
 import fullCalendarDefaultOptions from "../lib/full-calendar-default-options";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
-import { service } from "@ember/service";
 
 @tagName("")
 export default class UpcomingEventsCalendar extends Component {
   @service siteSettings;
 
-  events = null;
   @tracked selectedCategories = [];
+  events = null;
+
+  changeSelectedCategories = (value) => {
+    this.selectedCategories = value;
+    this._calendar.rerenderEvents();
+  };
 
   init() {
     super.init(...arguments);
     this._calendar = null;
-    if (this.siteSettings.display_upcoming_events_calendar_categories_selector) {
-      this.selectedCategories = this.siteSettings.default_upcoming_events_calendar_categories.split("|").map((c) => parseInt(c));
+    if (
+      this.siteSettings.display_upcoming_events_calendar_categories_selector
+    ) {
+      this.selectedCategories =
+        this.siteSettings.default_upcoming_events_calendar_categories
+          .split("|")
+          .map((c) => parseInt(c, 10));
     }
   }
 
@@ -82,14 +92,18 @@ export default class UpcomingEventsCalendar extends Component {
         fullCalendar.updateSize();
       },
       eventRender: (info) => {
-        if (!siteSettings.display_upcoming_events_calendar_categories_selector) {
-          return true
+        if (
+          !siteSettings.display_upcoming_events_calendar_categories_selector
+        ) {
+          return true;
         }
         if (!this.selectedCategories.length) {
-          return true
+          return true;
         }
-        return this.selectedCategories.includes(info.event.extendedProps.categoryId)
-      }
+        return this.selectedCategories.includes(
+          info.event.extendedProps.categoryId
+        );
+      },
     });
     this._calendar = fullCalendar;
 
@@ -138,17 +152,12 @@ export default class UpcomingEventsCalendar extends Component {
         backgroundColor,
         classNames,
         extendedProps: {
-          categoryId: categoryId
-        }
+          categoryId,
+        },
       });
     });
 
     this._calendar.render();
-  }
-
-  changeSelectedCategories = (value) => {
-    this.selectedCategories = value;
-    this._calendar.rerenderEvents()
   }
 
   _loadCalendar() {

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -22,7 +22,9 @@ export default class UpcomingEventsCalendar extends Component {
   init() {
     super.init(...arguments);
     this._calendar = null;
-    this.selectedCategories = this.siteSettings.default_upcoming_events_calendar_categories.split("|").map((c) => parseInt(c));
+    if (this.siteSettings.display_upcoming_events_calendar_categories_selector) {
+      this.selectedCategories = this.siteSettings.default_upcoming_events_calendar_categories.split("|").map((c) => parseInt(c));
+    }
   }
 
   willDestroyElement() {
@@ -80,6 +82,9 @@ export default class UpcomingEventsCalendar extends Component {
         fullCalendar.updateSize();
       },
       eventRender: (info) => {
+        if (!siteSettings.display_upcoming_events_calendar_categories_selector) {
+          return true
+        }
         if (!this.selectedCategories.length) {
           return true
         }

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -120,6 +120,9 @@ export default class UpcomingEventsCalendar extends Component {
         url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
         backgroundColor,
         classNames,
+        extendedProps: {
+          categoryId: categoryId
+        }
       });
     });
 

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import { schedule } from "@ember/runloop";
 import { tagName } from "@ember-decorators/component";
@@ -13,10 +14,12 @@ import { isNotFullDayEvent } from "../lib/guess-best-date-format";
 @tagName("")
 export default class UpcomingEventsCalendar extends Component {
   events = null;
+  @tracked selectedCategories = [];
 
   init() {
     super.init(...arguments);
     this._calendar = null;
+    this.selectedCategories = [7];
   }
 
   willDestroyElement() {
@@ -73,6 +76,12 @@ export default class UpcomingEventsCalendar extends Component {
         }
         fullCalendar.updateSize();
       },
+      eventRender: (info) => {
+        if (!this.selectedCategories.length) {
+          return true
+        }
+        return this.selectedCategories.includes(info.event.extendedProps.categoryId)
+      }
     });
     this._calendar = fullCalendar;
 
@@ -127,6 +136,11 @@ export default class UpcomingEventsCalendar extends Component {
     });
 
     this._calendar.render();
+  }
+
+  changeSelectedCategories = (value) => {
+    this.selectedCategories = value;
+    this._calendar.rerenderEvents()
   }
 
   _loadCalendar() {

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.js
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.js
@@ -10,16 +10,19 @@ import { formatEventName } from "../helpers/format-event-name";
 import addRecurrentEvents from "../lib/add-recurrent-events";
 import fullCalendarDefaultOptions from "../lib/full-calendar-default-options";
 import { isNotFullDayEvent } from "../lib/guess-best-date-format";
+import { service } from "@ember/service";
 
 @tagName("")
 export default class UpcomingEventsCalendar extends Component {
+  @service siteSettings;
+
   events = null;
   @tracked selectedCategories = [];
 
   init() {
     super.init(...arguments);
     this._calendar = null;
-    this.selectedCategories = [7];
+    this.selectedCategories = this.siteSettings.default_upcoming_events_calendar_categories.split("|").map((c) => parseInt(c));
   }
 
   willDestroyElement() {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -307,6 +307,7 @@ en:
         week: "Week"
         day: "Day"
         list: "List"
+      upcoming_events_categories_selector: "Displayed categories"
     group_timezones:
       search: "Search..."
       group_availability: "%{group} availability"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -307,7 +307,8 @@ en:
         week: "Week"
         day: "Day"
         list: "List"
-      upcoming_events_categories_selector: "Displayed categories"
+      upcoming_events_categories_selector_title: "Displayed categories"
+      upcoming_events_categories_selector_help: "Select the categories you want affiliated events to display in."
     group_timezones:
       search: "Search..."
       group_availability: "%{group} availability"

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -313,6 +313,7 @@ fr:
         week: "Semaine"
         day: "Jour"
         list: "Liste"
+      upcoming_events_categories_selector: "Catégories affichées"
     group_timezones:
       search: "Recherche…"
       group_availability: "disponibilité de %{group}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -127,3 +127,7 @@ discourse_calendar:
   include_expired_events_on_calendar:
     default: false
     client: true
+  default_upcoming_events_calendar_categories:
+    type: category_list
+    client: true
+    default: ""

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -127,6 +127,9 @@ discourse_calendar:
   include_expired_events_on_calendar:
     default: false
     client: true
+  display_upcoming_events_calendar_categories_selector:
+    default: false
+    client: true
   default_upcoming_events_calendar_categories:
     type: category_list
     client: true


### PR DESCRIPTION
This adds a **category selector on top upcoming events**  page.

This category selector is **prefilled with some categories** selected in discourse-calendar admin settings.

This adds an **admin setting to display the category selector** on the upcoming events page.