### PR TITLE
FIX: add line break before and after event block on event insertion

### DIFF
--- a/assets/javascripts/discourse/components/modal/post-event-builder.js
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.js
@@ -224,9 +224,18 @@ export default class PostEventBuilder extends Component {
       markdownParams.push(`${key}="${value}"`);
     });
 
-    this.args.model.toolbarEvent.addText(
-      `[event ${markdownParams.join(" ")}]\n[/event]`
-    );
+    let eventText = `[event ${markdownParams.join(" ")}]\n[/event]`;
+    const selectedText = this.args.model.toolbarEvent.selected;
+    if (selectedText.pre && selectedText.pre.slice(-1) !== "\n") {
+      eventText = `\n${eventText}`;
+    }
+    if (
+      (selectedText.post && selectedText.post.slice(1) !== "\n") ||
+      !selectedText.post
+    ) {
+      eventText = `${eventText}\n`;
+    }
+    this.args.model.toolbarEvent.addText(eventText);
     this.args.closeModal();
   }
 

--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -63,7 +63,7 @@ acceptance("Post event - composer", function (needs) {
     assert
       .dom(".d-editor-input")
       .hasValue(
-        `[event start="2022-07-01 12:00" status="public" timezone="Europe/Paris" end="2022-07-01 13:00" allowedGroups="trust_level_0"]\n[/event]`,
+        `[event start="2022-07-01 12:00" status="public" timezone="Europe/Paris" end="2022-07-01 13:00" allowedGroups="trust_level_0"]\n[/event]\n`,
         "bbcode is correct"
       );
   });


### PR DESCRIPTION
If user doesn't well select or put his cursor in composer textarea, the composer text may be malformed after event insertion and it will not create an event after save.

This check composer text selected text and add some line breaks if necessary to avoid malformed text.

**Before fix:**

![image](https://github.com/user-attachments/assets/0ae89757-6151-49db-85a1-dafe0d96924d)
will not create event:
![image](https://github.com/user-attachments/assets/c9a7b950-e57f-4083-81c2-abcbb2490c6e)


**After fix:**
![image](https://github.com/user-attachments/assets/0ae89757-6151-49db-85a1-dafe0d96924d)
will create event
![image](https://github.com/user-attachments/assets/7293af20-8b13-4061-b982-312cef7e2e48)
