### PR TITLE
DEV: ensures we are on correct page

### DIFF
--- a/spec/system/category_calendar_spec.rb
+++ b/spec/system/category_calendar_spec.rb
@@ -20,10 +20,12 @@ describe "Category calendar", type: :system do
 
     find(".nav-item_hot").click
 
+    expect(page).to have_current_path("#{category.relative_url}/l/hot")
     expect(category_page).to have_selector("#category-events-calendar.fc")
 
     find(".nav-item_latest").click
 
+    expect(page).to have_current_path("#{category.relative_url}/l/latest")
     expect(category_page).to have_selector("#category-events-calendar.fc")
   end
 end


### PR DESCRIPTION
Playwright will not accept this kind of specs as it's not reliable. You would potentially get this error:

```
     Playwright::Error:
       Element is not attached to the DOM
       Call log:
         - attempting click action
         -     - waiting for element to be visible, enabled and stable
```

What happens is that the ".nav-item_latest" would be present before navigation, and playwright would find it just before the page has loaded, the click though might happen right after page transition and the initial element wouldn't be attached to the dom anymore.