### PR TITLE
FIX: allow create events for everyone group

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -158,7 +158,11 @@ after_initialize do
       begin
         return true if staff?
         allowed_groups = SiteSetting.discourse_post_event_allowed_on_groups.to_s.split("|").compact
-        allowed_groups.present? && groups.where(id: allowed_groups).exists?
+        allowed_groups.present? &&
+          (
+            allowed_groups.include?(Group::AUTO_GROUPS[:everyone].to_s) ||
+              groups.where(id: allowed_groups).exists?
+          )
       rescue StandardError
         false
       end

--- a/spec/models/discourse_post_event/user_spec.rb
+++ b/spec/models/discourse_post_event/user_spec.rb
@@ -46,6 +46,17 @@ describe User do
           end
         end
 
+        context "when allowed group is 'everyone'" do
+          let(:topic_1) { Fabricate(:topic, user: user_1) }
+          let(:post_1) { Fabricate(:post, topic: topic_1, user: user_1) }
+          let(:post_event_1) { Fabricate(:event, post: post_1) }
+
+          it "can act on the event" do
+            SiteSetting.discourse_post_event_allowed_on_groups = Group::AUTO_GROUPS[:everyone]
+            expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(true)
+          end
+        end
+
         context "when user didn’t create the event" do
           let(:user_2) { Fabricate(:user) }
           let(:topic_1) { Fabricate(:topic, user: user_2) }


### PR DESCRIPTION
When `discourse_post_event_allowed_on_groups` is set to `everyone`, everyone should be able to create post events.

https://meta.discourse.org/t/selecting-the-everyone-group-in-the-allowed-on-groups-setting-does-not-enable-event-creation/279434