### PR TITLE
FEATURE: optional attached chat channel for event

### DIFF
--- a/app/serializers/discourse_post_event/event_serializer.rb
+++ b/app/serializers/discourse_post_event/event_serializer.rb
@@ -30,6 +30,8 @@ module DiscoursePostEvent
     attributes :timezone
     attributes :url
     attributes :watching_invitee
+    attributes :chat_enabled
+    attributes :chat_channel_id
 
     def can_act_on_discourse_post_event
       scope.can_act_on_discourse_post_event?(object)

--- a/app/services/discourse_post_event/chat_channel_sync.rb
+++ b/app/services/discourse_post_event/chat_channel_sync.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+#
+module DiscoursePostEvent
+  class ChatChannelSync
+    def self.sync(event)
+      return if !event.chat_enabled?
+
+      ensure_chat_channel!(event) if !event.chat_channel_id
+      sync_chat_channel_members!(event)
+    end
+
+    def self.sync_chat_channel_members!(event)
+      missing_members_sql = <<~SQL
+        SELECT user_id
+        FROM discourse_post_event_invitees
+        WHERE post_id = :post_id
+        AND status in (:statuses)
+        AND user_id NOT IN (
+          SELECT user_id
+          FROM user_chat_channel_memberships
+          WHERE chat_channel_id = :chat_channel_id
+        )
+      SQL
+
+      missing_user_ids =
+        DB.query_single(
+          missing_members_sql,
+          post_id: event.post.id,
+          statuses: [DiscoursePostEvent::Invitee.statuses[:going]],
+          chat_channel_id: event.chat_channel_id,
+        )
+
+      if missing_user_ids.present?
+        ActiveRecord::Base.transaction do
+          missing_user_ids.each do |user_id|
+            event.chat_channel.user_chat_channel_memberships.create!(
+              user_id:,
+              chat_channel_id: event.chat_channel_id,
+              following: true,
+            )
+          end
+        end
+      end
+    end
+
+    def self.ensure_chat_channel!(event)
+      name = event.name
+
+      guardian = Guardian.new(Discourse.system_user)
+      channel = nil
+      Chat::CreateCategoryChannel.call(
+        guardian:,
+        params: {
+          name:,
+          category_id: event.post.topic.category_id,
+        },
+      ) do |result|
+        on_success { channel = result.channel }
+        on_failure { raise StandardError, result.inspect_steps }
+      end
+
+      # system user does not belong in the channel - this is awkward, we should be allowed to avoid
+      channel.user_chat_channel_memberships.where(user_id: Discourse.system_user.id).destroy_all
+
+      event.chat_channel_id = channel.id
+    end
+  end
+end

--- a/assets/javascripts/discourse/components/modal/post-event-builder.hbs
+++ b/assets/javascripts/discourse/components/modal/post-event-builder.hbs
@@ -223,6 +223,25 @@
             </label>
           </EventField>
 
+          {{#if siteSettings.chat_enabled}}
+            <EventField
+              class="allow-chat"
+              @label="discourse_post_event.builder_modal.allow_chat.label"
+            >
+              <label class="checkbox-label">
+                <Input
+                  @type="checkbox"
+                  @checked={{@model.event.chat_enabled}}
+                />
+                <span class="message">
+                  {{i18n
+                    "discourse_post_event.builder_modal.allow_chat.checkbox_label"
+                  }}
+                </span>
+              </label>
+            </EventField>
+          {{/if}}
+
           {{#if this.allowedCustomFields.length}}
             <EventField
               @label="discourse_post_event.builder_modal.custom_fields.label"

--- a/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -33,6 +33,10 @@ export function buildParams(startsAt, endsAt, event, siteSettings) {
     params.minimal = "true";
   }
 
+  if (event.chat_enabled) {
+    params.chat = "true";
+  }
+
   if (endsAt) {
     params.end = moment(endsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -460,6 +460,9 @@ en:
         minimal:
           label: "Minimal event"
           checkbox_label: "Hide Going/Not going buttons and invitees status"
+        allow_chat:
+          label: "Chat integration"
+          checkbox_label: "Create and manage event specific chat channel"
         url:
           label: "URL"
           placeholder: "Optional"

--- a/db/migrate/20250520042223_add_chat_fields_to_events.rb
+++ b/db/migrate/20250520042223_add_chat_fields_to_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddChatFieldsToEvents < ActiveRecord::Migration[7.2]
+  def change
+    add_column :discourse_post_event_events, :chat_enabled, :boolean, default: false, null: false
+    add_column :discourse_post_event_events, :chat_channel_id, :bigint
+  end
+end

--- a/lib/discourse_post_event/event_parser.rb
+++ b/lib/discourse_post_event/event_parser.rb
@@ -14,6 +14,7 @@ module DiscoursePostEvent
       :timezone,
       :minimal,
       :closed,
+      :chat,
     ]
 
     def self.extract_events(post)

--- a/spec/services/discourse_post_event/chat_channel_sync_spec.rb
+++ b/spec/services/discourse_post_event/chat_channel_sync_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+return if !defined?(Chat)
+
+describe DiscoursePostEvent::ChatChannelSync do
+  fab!(:user)
+
+  it "is able to create a chat channel and sync members" do
+    event = Fabricate(:event, chat_enabled: true)
+
+    expect(event.chat_channel_id).not_to be_nil
+    expect(event.chat_channel.name).to eq(event.name)
+
+    # not expecting system user or anyone else here
+    expect(event.chat_channel.user_chat_channel_memberships.count).to eq(0)
+
+    event.create_invitees([user_id: user.id, status: DiscoursePostEvent::Invitee.statuses[:going]])
+    event.save!
+
+    expect(event.chat_channel.user_chat_channel_memberships.count).to eq(1)
+  end
+end


### PR DESCRIPTION
This defines a feature where event creators can opt for an associated chat channel
creation.

TODO:

- think through permissions - at the moment system is creating the channel which is can be a security hole.
- is a DM channel better here?

