### PR TITLE
DEV Add Ghana Eid-Ul-Adha holiday for 2025

### DIFF
--- a/vendor/holidays/definitions/gh.yaml
+++ b/vendor/holidays/definitions/gh.yaml
@@ -105,8 +105,9 @@ methods:
     arguments: year
     ruby: |
       eid_ul_adha_dates = {
-        '2023' => Date.civil(2024, 6, 28),
-        '2024' => Date.civil(2024, 6, 16)
+        '2023' => Date.civil(2023, 6, 28),
+        '2024' => Date.civil(2024, 6, 16),
+        '2025' => Date.civil(2025, 6, 6)
       }
       eid_ul_adha_dates[year.to_s]
 
@@ -168,7 +169,7 @@ tests:
     expect:
       name: "African Union Day"
   - given:
-      date: ["2023-06-28","2024-06-17" ]
+      date: ["2023-06-28","2024-06-17", "2025-06-06"]
       regions: ["gh"]
       options: ["observed"]
     expect:

--- a/vendor/holidays/lib/generated_definitions/gh.rb
+++ b/vendor/holidays/lib/generated_definitions/gh.rb
@@ -44,8 +44,9 @@ eid_ul_fitr_dates[year.to_s]
 
 "eid_ul_adha(year)" => Proc.new { |year|
 eid_ul_adha_dates = {
-  '2023' => Date.civil(2024, 6, 28),
-  '2024' => Date.civil(2024, 6, 16)
+  '2023' => Date.civil(2023, 6, 28),
+  '2024' => Date.civil(2024, 6, 16),
+  '2025' => Date.civil(2025, 6, 6)
 }
 eid_ul_adha_dates[year.to_s]
 },

--- a/vendor/holidays/test/defs/test_defs_gh.rb
+++ b/vendor/holidays/test/defs/test_defs_gh.rb
@@ -30,6 +30,7 @@ assert_equal "Eid-ul-Fitr", (Holidays.on(Date.civil(2024, 4, 11), [:gh], [:obser
 
     assert_equal "Eid-ul-Adha", (Holidays.on(Date.civil(2023, 6, 28), [:gh], [:observed])[0] || {})[:name]
 assert_equal "Eid-ul-Adha", (Holidays.on(Date.civil(2024, 6, 17), [:gh], [:observed])[0] || {})[:name]
+assert_equal "Eid-ul-Adha", (Holidays.on(Date.civil(2025, 6, 6), [:gh], [:observed])[0] || {})[:name]
 
     assert_equal "Republic Day", (Holidays.on(Date.civil(2022, 7, 1), [:gh], [:informal])[0] || {})[:name]
 


### PR DESCRIPTION
See https://www.mint.gov.gh/declaration-of-friday-6th-june-2025-as-a-public-holiday/