### PR TITLE
FIX: prevents double event and uses correct starts_at

### DIFF
--- a/app/serializers/discourse_post_event/event_summary_serializer.rb
+++ b/app/serializers/discourse_post_event/event_summary_serializer.rb
@@ -46,9 +46,10 @@ module DiscoursePostEvent
 
     def upcoming_dates
       difference = object.original_ends_at ? object.original_ends_at - object.original_starts_at : 0
+
       RRuleGenerator
         .generate(
-          starts_at: object.original_starts_at,
+          starts_at: object.original_starts_at.in_time_zone(object.timezone),
           timezone: object.timezone,
           max_years: 1,
           recurrence: object.recurrence,

--- a/assets/javascripts/discourse/lib/add-recurrent-events.js
+++ b/assets/javascripts/discourse/lib/add-recurrent-events.js
@@ -4,6 +4,10 @@ import DiscoursePostEventEvent from "../models/discourse-post-event-event";
 export default function addRecurrentEvents(events) {
   try {
     return events.flatMap((event) => {
+      if (!event.upcomingDates?.length) {
+        return [event];
+      }
+
       const upcomingEvents =
         event.upcomingDates?.map((upcomingDate) =>
           DiscoursePostEventEvent.create({
@@ -15,7 +19,7 @@ export default function addRecurrentEvents(events) {
           })
         ) || [];
 
-      return [event, ...upcomingEvents];
+      return upcomingEvents;
     });
   } catch (error) {
     console.error("Failed to retrieve events:", error);

--- a/lib/discourse_post_event/rrule_generator.rb
+++ b/lib/discourse_post_event/rrule_generator.rb
@@ -14,7 +14,7 @@ class RRuleGenerator
     rrule = set_mandatory_options(rrule, starts_at)
 
     ::RRule::Rule
-      .new(stringify(rrule), dtstart: starts_at + 1.minute, tzid: timezone)
+      .new(stringify(rrule), dtstart: starts_at, tzid: timezone)
       .between(Time.current, Time.current + 14.months)
       .first(RRuleConfigurator.how_many_recurring_events(recurrence:, max_years:))
   end

--- a/spec/integration/recurrence_spec.rb
+++ b/spec/integration/recurrence_spec.rb
@@ -15,7 +15,7 @@ describe "discourse_post_event_recurrence" do
   end
 
   before do
-    freeze_time(starts_at)
+    freeze_time(starts_at + 1.minute)
 
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
@@ -98,7 +98,7 @@ describe "discourse_post_event_recurrence" do
     end
 
     it "sets the next day" do
-      freeze_time(post_event_1.original_starts_at)
+      freeze_time(post_event_1.original_starts_at + 1.minute)
       post_event_1.set_next_date
 
       expect(post_event_1.starts_at).to eq_time(Time.zone.parse("2020-09-14 19:00"))

--- a/spec/lib/discourse_post_event/rrule_generator_spec.rb
+++ b/spec/lib/discourse_post_event/rrule_generator_spec.rb
@@ -36,7 +36,7 @@ describe RRuleGenerator do
   describe "every day" do
     context "when a rule and time are given" do
       it "generates the rule" do
-        rrule = RRuleGenerator.generate(starts_at: time, recurrence: "every_day").first
+        rrule = RRuleGenerator.generate(starts_at: time, recurrence: "every_day", max_years: 1)[1]
         expect(rrule.to_s).to eq("2020-08-13 16:32:00 UTC")
       end
 

--- a/spec/serializers/discourse_post_event/event_summary_serializer_spec.rb
+++ b/spec/serializers/discourse_post_event/event_summary_serializer_spec.rb
@@ -87,8 +87,8 @@ describe DiscoursePostEvent::EventSummarySerializer do
       expect(json[:event_summary][:upcoming_dates].length).to eq(365)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2024-01-01 15:00:00.000000000 +0000",
-          ends_at: "2024-01-01 16:00:00.000000000 +0000",
+          starts_at: "2023-12-31 15:00:00.000000000 +0000",
+          ends_at: "2023-12-31 16:00:00.000000000 +0000",
         },
       )
     end
@@ -98,8 +98,8 @@ describe DiscoursePostEvent::EventSummarySerializer do
       expect(json[:event_summary][:upcoming_dates].length).to eq(52)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2023-12-31 15:00:00.000000000 +0000", # Sunday
-          ends_at: "2023-12-31 16:00:00.000000000 +0000",
+          starts_at: "2023-12-24 15:00:00.000000000 +0000", # Sunday
+          ends_at: "2023-12-24 16:00:00.000000000 +0000",
         },
       )
     end
@@ -109,8 +109,8 @@ describe DiscoursePostEvent::EventSummarySerializer do
       expect(json[:event_summary][:upcoming_dates].length).to eq(26)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2023-12-31 15:00:00.000000000 +0000", # Sunday
-          ends_at: "2023-12-31 16:00:00.000000000 +0000",
+          starts_at: "2023-12-17 15:00:00.000000000 +0000", # Sunday
+          ends_at: "2023-12-17 16:00:00.000000000 +0000",
         },
       )
     end
@@ -120,8 +120,8 @@ describe DiscoursePostEvent::EventSummarySerializer do
       expect(json[:event_summary][:upcoming_dates].length).to eq(13)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2023-12-31 15:00:00.000000000 +0000", # Sunday
-          ends_at: "2023-12-31 16:00:00.000000000 +0000",
+          starts_at: "2023-12-03 15:00:00.000000000 +0000", # Sunday
+          ends_at: "2023-12-03 16:00:00.000000000 +0000",
         },
       )
     end
@@ -142,8 +142,8 @@ describe DiscoursePostEvent::EventSummarySerializer do
       expect(json[:event_summary][:upcoming_dates].length).to eq(12)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2024-01-07 15:00:00.000000000 +0000", # Sunday
-          ends_at: "2024-01-07 16:00:00.000000000 +0000",
+          starts_at: "2023-12-03 15:00:00.000000000 +0000", # Sunday
+          ends_at: "2023-12-03 16:00:00.000000000 +0000",
         },
       )
     end

--- a/spec/system/upcoming_events_spec.rb
+++ b/spec/system/upcoming_events_spec.rb
@@ -19,23 +19,25 @@ describe "Upcoming Events", type: :system do
 
     it "shows the upcoming events" do
       visit("/upcoming-events")
-      expect(page).to have_css("#upcoming-events-calendar")
 
-      calendar = find("#upcoming-events-calendar")
-      expect(calendar).to have_css(".fc-event-container")
+      expect(page).to have_css(
+        "#upcoming-events-calendar .fc-event-container",
+        text: event.post.topic.title,
+      )
     end
   end
 
   context "when event is recurring" do
-    let(:fixed_time) { Time.utc(2018, 6, 5, 9, 30) }
+    let(:fixed_time) { Time.utc(2025, 6, 2, 19, 00) }
 
     before do
       freeze_time(fixed_time)
 
       event.update!(
-        original_starts_at: fixed_time + 1.hour,
-        recurrence: "every_day",
-        recurrence_until: 3.days.from_now,
+        original_starts_at: Time.utc(2025, 3, 18, 13, 00),
+        timezone: "Australia/Brisbane",
+        recurrence: "every_week",
+        recurrence_until: 21.days.from_now,
       )
     end
 
@@ -44,6 +46,18 @@ describe "Upcoming Events", type: :system do
       visit("/upcoming-events")
 
       expect(page).to have_css(".fc-day-grid-event", count: 3)
+      expect(page).to have_css(
+        ".fc-week:nth-child(2) .fc-content-skeleton:nth-child(2)",
+        text: event.post.topic.title,
+      )
+      expect(page).to have_css(
+        ".fc-week:nth-child(3) .fc-content-skeleton:nth-child(2)",
+        text: event.post.topic.title,
+      )
+      expect(page).to have_css(
+        ".fc-week:nth-child(4) .fc-content-skeleton:nth-child(2)",
+        text: event.post.topic.title,
+      )
     end
   end
 end

--- a/test/javascripts/acceptance/category-events-calendar-test.js
+++ b/test/javascripts/acceptance/category-events-calendar-test.js
@@ -54,6 +54,16 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
               {
                 starts_at: moment()
                   .tz("Asia/Calcutta")
+                  .add(1, "days")
+                  .format("YYYY-MM-DDT15:14:00.000Z"),
+                ends_at: moment()
+                  .tz("Asia/Calcutta")
+                  .add(1, "days")
+                  .format("YYYY-MM-DDT16:14:00.000Z"),
+              },
+              {
+                starts_at: moment()
+                  .tz("Asia/Calcutta")
                   .add(2, "days")
                   .format("YYYY-MM-DDT15:14:00.000Z"),
                 ends_at: moment()

--- a/test/javascripts/acceptance/upcoming-events-calendar-test.js
+++ b/test/javascripts/acceptance/upcoming-events-calendar-test.js
@@ -54,6 +54,10 @@ acceptance("Discourse Calendar - Upcoming Events Calendar", function (needs) {
             name: "Awesome Event",
             upcoming_dates: [
               {
+                starts_at: tomorrow().format("YYYY-MM-DDT15:14:00.000Z"),
+                ends_at: tomorrow().format("YYYY-MM-DDT16:14:00.000Z"),
+              },
+              {
                 starts_at: twoDays().format("YYYY-MM-DDT15:14:00.000Z"),
                 ends_at: twoDays().format("YYYY-MM-DDT16:14:00.000Z"),
               },


### PR DESCRIPTION
- we were not applying the timezone for the list of upcoming events
- we would return the first event + the upcoming events, we now get all the events generate by RRule if this is a recurring event, and if it's not a recurring event we just return the event, instead of doing a dance where we would remove the first event from RRule but prepend the initial event on the frontend