### PR TITLE
FIX: nbsp handling in group-timezones

### DIFF
--- a/assets/javascripts/discourse/components/group-timezones/index.gjs
+++ b/assets/javascripts/discourse/components/group-timezones/index.gjs
@@ -11,6 +11,8 @@ import NewDay from "./new-day";
 import TimeTraveller from "./time-traveller";
 import Timezone from "./timezone";
 
+const nbsp = "\xa0";
+
 export default class GroupTimezones extends Component {
   @service siteSettings;
 
@@ -132,7 +134,7 @@ export default class GroupTimezones extends Component {
     return `${sign}${hours.replace(/^0(\d)/, "$1")}${minutes.replace(
       /:00$/,
       ""
-    )}`.replace(/-0/, "&nbsp;");
+    )}`.replace(/-0/, nbsp);
   }
 
   #workingDays() {


### PR DESCRIPTION
Since it was converted to Glimmer, the nbsp html entity is being escaped by ember before rendering. We can use a unicode literal instead.

Followup to d471bbdf9aab7579e99ddf73c9f0d4343764fc2e