### PR TITLE
UX: smart format dates

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -30,11 +30,15 @@ export default class DiscoursePostEventDates extends Component {
   }
 
   get format() {
-    return guessDateFormat(this.startsAt, this.endsAt);
+    return "llll";
   }
 
   get isSameDay() {
     return moment(this.startsAt).isSame(this.endsAt, "day");
+  }
+
+  get isSameYear() {
+    return moment(this.startsAt).isSame(this.endsAt, "year") && !this.isSameDay;
   }
 
   get datesBBCode() {
@@ -55,6 +59,10 @@ export default class DiscoursePostEventDates extends Component {
 
       if (this.isSameDay) {
         endsAtFormat = "LT";
+      } else if (this.isSameYear) {
+        endsAtFormat = "'ddd, MMM D, LT'";
+      } else {
+        endsAtFormat = "'llll'";
       }
 
       if (this.args.event.recurrence) {
@@ -116,6 +124,7 @@ export default class DiscoursePostEventDates extends Component {
       if (this.endsAt) {
         dates += ` → ${moment(this.endsAt).format(this.format)}`;
       }
+      debugger;
       this.htmlDates = htmlSafe(dates);
     }
   }

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -29,33 +29,38 @@ export default class DiscoursePostEventDates extends Component {
   }
 
   get startsAtFormat() {
-    let startsAtFormat = "'ddd, MMM D'";
+    const formatParts = ["ddd, MMM D"];
+
     if (!this.isSameYear(this.startsAt)) {
-      startsAtFormat = startsAtFormat.replace(/'$/, ", YYYY'");
+      formatParts.push("YYYY");
     }
-    if (this.hasTime(this.startsAt) || this.isSingleDayEvent) {
-      startsAtFormat = startsAtFormat.replace(/'$/, " LT'");
-    }
-    return startsAtFormat;
+
+    const dateString = formatParts.join(", ");
+    const timeString =
+      this.hasTime(this.startsAt) || this.isSingleDayEvent ? " LT" : "";
+
+    return `'${dateString}${timeString}'`;
   }
 
   get endsAtFormat() {
-    let endsAtFormat = "'ddd, MMM D'";
     if (this.isSingleDayEvent) {
       return "LT";
     }
-    if (
-      !(
-        this.isSameYear(this.endsAt) &&
-        this.isSameYear(this.endsAt, this.startsAt)
-      )
-    ) {
-      endsAtFormat = endsAtFormat.replace(/'$/, ", YYYY'");
+
+    const formatParts = ["ddd, MMM D"];
+
+    const showYear =
+      !this.isSameYear(this.endsAt) ||
+      !this.isSameYear(this.endsAt, this.startsAt);
+
+    if (showYear) {
+      formatParts.push("YYYY");
     }
-    if (this.hasTime(this.endsAt)) {
-      endsAtFormat = endsAtFormat.replace(/'$/, " LT'");
-    }
-    return endsAtFormat;
+
+    const dateString = formatParts.join(", ");
+    const timeString = this.hasTime(this.endsAt) ? " LT" : "";
+
+    return `'${dateString}${timeString}'`;
   }
 
   get isSingleDayEvent() {

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -65,10 +65,22 @@ export default class DiscoursePostEventDates extends Component {
   get datesBBCode() {
     const dates = [];
 
-    dates.push(this.buildDateBBCode(this.startsAt, this.startsAtFormat));
+    dates.push(
+      this.buildDateBBCode({
+        date: this.startsAt,
+        format: this.startsAtFormat,
+        range: !!this.endsAt && "from",
+      })
+    );
 
     if (this.endsAt) {
-      dates.push(this.buildDateBBCode(this.endsAt, this.endsAtFormat));
+      dates.push(
+        this.buildDateBBCode({
+          date: this.endsAt,
+          format: this.endsAtFormat,
+          range: "to",
+        })
+      );
     }
 
     return dates;
@@ -82,7 +94,7 @@ export default class DiscoursePostEventDates extends Component {
     return date.hour() || date.minute();
   }
 
-  buildDateBBCode(date, format) {
+  buildDateBBCode({ date, format, range }) {
     const bbcode = {
       date: date.format("YYYY-MM-DD"),
       time: date.format("HH:mm"),
@@ -93,6 +105,10 @@ export default class DiscoursePostEventDates extends Component {
 
     if (this.args.event.showLocalTime) {
       bbcode.displayedTimezone = this.args.event.timezone;
+    }
+
+    if (range) {
+      bbcode.range = range;
     }
 
     const content = Object.entries(bbcode)

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -36,21 +36,41 @@ export default class DiscoursePostEventDates extends Component {
   get datesBBCode() {
     const dates = [];
 
-    dates.push(this.buildDateBBCode(this.startsAt));
+    let startsAtFormat = this.format;
+    if (this.args.event.recurrence) {
+      startsAtFormat = "'ddd, MMM DD";
+      if (this.startsAt.year() !== moment().year()) {
+        startsAtFormat += ", YYYY";
+      }
+      startsAtFormat += ", h:mmA'";
+    }
+    dates.push(this.buildDateBBCode(this.startsAt, startsAtFormat));
 
     if (this.endsAt) {
-      dates.push(this.buildDateBBCode(this.endsAt));
+      let endsAtFormat = this.format;
+      if (this.args.event.recurrence) {
+        endsAtFormat = "'";
+        if (this.startsAt.dayOfYear() !== this.endsAt.dayOfYear()) {
+          endsAtFormat += "ddd, MMM DD, ";
+        }
+        if (this.endsAt.year() !== moment().year()) {
+          endsAtFormat += "YYYY, ";
+        }
+        endsAtFormat += "h:mmA'";
+      }
+      dates.push(this.buildDateBBCode(this.endsAt, endsAtFormat));
     }
 
     return dates;
   }
 
-  buildDateBBCode(date) {
+  buildDateBBCode(date, format) {
     const bbcode = {
       date: date.format("YYYY-MM-DD"),
       time: date.format("HH:mm"),
-      format: this.format,
+      format,
       timezone: this.timezone,
+      hideTimezone: this.args.event.showLocalTime,
     };
 
     if (this.args.event.showLocalTime) {

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -29,53 +29,66 @@ export default class DiscoursePostEventDates extends Component {
     return this.args.event.timezone || "UTC";
   }
 
-  get format() {
+  get startsAtFormat() {
+    let startsAtFormat = "llll";
+    if (this.isSameYear(this.startsAt)) {
+      startsAtFormat = "'ddd, MMM D";
+      if (this.startsAt.hour() || this.startsAt.minute()) {
+        startsAtFormat += ", LT'";
+      }
+    }
+    return startsAtFormat;
+  }
+
+  get endsAtFormat() {
+    if (this.isSingleDayEvent) {
+      return "LT";
+    }
+    if (this.isSameYear(this.endsAt) && this.isSameYear(this.endsAt, this.startsAt)) {
+      let endsAtFormat = "'ddd, MMM D";
+      if (this.endsAt.hour() || this.endsAt.minute()) {
+        endsAtFormat += ", LT'";
+      }
+      return endsAtFormat;
+    }
     return "llll";
   }
 
-  get isSameDay() {
-    return moment(this.startsAt).isSame(this.endsAt, "day");
+  get isSingleDayEvent() {
+    return this.startsAt.isSame(this.endsAt, "day");
   }
 
-  get isSameYear() {
-    return moment(this.startsAt).isSame(this.endsAt, "year") && !this.isSameDay;
+  isSameYear(date1, date2) {
+    if (!date2) {
+      console.log(moment().toString());
+    }
+    return date1.isSame(date2 || moment(), "year");
   }
 
   get datesBBCode() {
     const dates = [];
 
-    let startsAtFormat = this.format;
     if (this.args.event.recurrence) {
-      startsAtFormat = "'ddd, MMM DD";
-      if (this.startsAt.year() !== moment().year()) {
-        startsAtFormat += ", YYYY";
-      }
-      startsAtFormat += ", h:mmA'";
+      // startsAtFormat = "'ddd, MMM DD";
+      // if (this.startsAt.year() !== moment().year()) {
+      //   startsAtFormat += ", YYYY";
+      // }
+      // startsAtFormat += ", h:mmA'";
     }
-    dates.push(this.buildDateBBCode(this.startsAt, startsAtFormat));
+    dates.push(this.buildDateBBCode(this.startsAt, this.startsAtFormat));
 
     if (this.endsAt) {
-      let endsAtFormat = this.format;
-
-      if (this.isSameDay) {
-        endsAtFormat = "LT";
-      } else if (this.isSameYear) {
-        endsAtFormat = "'ddd, MMM D, LT'";
-      } else {
-        endsAtFormat = "'llll'";
-      }
-
       if (this.args.event.recurrence) {
-        endsAtFormat = "'";
-        if (this.startsAt.dayOfYear() !== this.endsAt.dayOfYear()) {
-          endsAtFormat += "ddd, MMM DD, ";
-        }
-        if (this.endsAt.year() !== moment().year()) {
-          endsAtFormat += "YYYY, ";
-        }
-        endsAtFormat += "h:mmA'";
+        // endsAtFormat = "'";
+        // if (this.startsAt.dayOfYear() !== this.endsAt.dayOfYear()) {
+        //   endsAtFormat += "ddd, MMM DD, ";
+        // }
+        // if (this.endsAt.year() !== moment().year()) {
+        //   endsAtFormat += "YYYY, ";
+        // }
+        // endsAtFormat += "h:mmA'";
       }
-      dates.push(this.buildDateBBCode(this.endsAt, endsAtFormat));
+      dates.push(this.buildDateBBCode(this.endsAt, this.endsAtFormat));
     }
 
     return dates;
@@ -120,11 +133,10 @@ export default class DiscoursePostEventDates extends Component {
         );
       });
     } else {
-      let dates = `${this.startsAt.format(this.format)}`;
+      let dates = `${this.startsAt.format(this.startsAtFormat)}`;
       if (this.endsAt) {
-        dates += ` → ${moment(this.endsAt).format(this.format)}`;
+        dates += ` → ${moment(this.endsAt).format(this.endsAtFormat)}`;
       }
-      debugger;
       this.htmlDates = htmlSafe(dates);
     }
   }

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -33,7 +33,7 @@ export default class DiscoursePostEventDates extends Component {
     if (!this.isSameYear(this.startsAt)) {
       startsAtFormat = startsAtFormat.replace(/'$/, ", YYYY'");
     }
-    if (this.hasTime(this.startsAt)) {
+    if (this.hasTime(this.startsAt) || this.isSingleDayEvent) {
       startsAtFormat = startsAtFormat.replace(/'$/, " LT'");
     }
     return startsAtFormat;
@@ -62,14 +62,6 @@ export default class DiscoursePostEventDates extends Component {
     return this.startsAt.isSame(this.endsAt, "day");
   }
 
-  isSameYear(date1, date2) {
-    return date1.isSame(date2 || moment(), "year");
-  }
-
-  hasTime(date) {
-    return date.hour() || date.minute();
-  }
-
   get datesBBCode() {
     const dates = [];
 
@@ -80,6 +72,14 @@ export default class DiscoursePostEventDates extends Component {
     }
 
     return dates;
+  }
+
+  isSameYear(date1, date2) {
+    return date1.isSame(date2 || moment(), "year");
+  }
+
+  hasTime(date) {
+    return date.hour() || date.minute();
   }
 
   buildDateBBCode(date, format) {

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -33,6 +33,10 @@ export default class DiscoursePostEventDates extends Component {
     return guessDateFormat(this.startsAt, this.endsAt);
   }
 
+  get isSameDay() {
+    return moment(this.startsAt).isSame(this.endsAt, "day");
+  }
+
   get datesBBCode() {
     const dates = [];
 
@@ -48,6 +52,11 @@ export default class DiscoursePostEventDates extends Component {
 
     if (this.endsAt) {
       let endsAtFormat = this.format;
+
+      if (this.isSameDay) {
+        endsAtFormat = "LT";
+      }
+
       if (this.args.event.recurrence) {
         endsAtFormat = "'";
         if (this.startsAt.dayOfYear() !== this.endsAt.dayOfYear()) {

--- a/test/javascripts/integration/components/dates-test.gjs
+++ b/test/javascripts/integration/components/dates-test.gjs
@@ -1,6 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import { getOwner } from "@ember/owner";
-import { render } from "@ember/test-helpers";
+import { render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
@@ -10,19 +9,6 @@ module("Integration | Component | Dates", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    const store = getOwner(this).lookup("service:store");
-
-    this.user = store.createRecord("user", {
-      username: "j.jaffeux",
-      name: "joffrey",
-      id: 321,
-    });
-
-    getOwner(this).unregister("service:current-user");
-    getOwner(this).register("service:current-user", this.user, {
-      instantiate: false,
-    });
-
     this.basicEvent = class {
       @tracked endsAt;
       @tracked startsAt = new Date("2025-10-01T10:00:00Z");
@@ -34,31 +20,73 @@ module("Integration | Component | Dates", function (hooks) {
       isExpired = false;
     };
 
-    // this.clock = fakeTime("2025-10-01T00:00:00Z", this.currentUser.user_option.timezone, false);
+    this.clock = fakeTime("2025-11-01T00:00:00Z", "UTC", true);
   });
 
   hooks.afterEach(function () {
     this.clock?.restore();
   });
 
-  test("formats same day range dates and times", async function (assert) {
-    const eventWithinDayRange = new (class extends this.basicEvent {
-      @tracked endsAt = new Date("2025-10-01T11:00:00Z");
-    })();
+  const starts = {
+    startsAt: "2025-10-06T00:00:00Z",
+  };
+  const events = {
+    currentYear: {
+      starts,
+      endsSameDay: {
+        ...starts,
+        endsAt: "2025-10-06T01:00:00Z",
+      },
+      endsSameWeek: {
+        ...starts,
+        endsAt: "2025-10-10",
+      },
+      endsSameMonth: {
+        ...starts,
+        endsAt: "2025-10-20",
+      },
+      endsDiffMonth: {
+        ...starts,
+        endsAt: "2025-11-06",
+      },
+      endsDiffYear: {
+        ...starts,
+        endsAt: "2026-01-06",
+      },
+    },
+  };
 
-    await render(<template><Dates @event={{eventWithinDayRange}} /></template>);
+  module("dates without time", function () {
+    test("formats same day range dates and times", async function (assert) {
+      const testState = new (class {
+        // @tracked endsAt = new Date("2025-10-01T11:00:00Z");
+        @tracked event = events.currentYear.starts;
+      })();
 
-    assert
-      .dom(".event-dates")
-      .hasText(
-        "Wed, Oct 1, 10:00 AM → 11:00 AM",
-        "`endAt` should be formatted with localized time only"
-      );
+      await render(<template><Dates @event={{testState.event}} /></template>);
+
+      assert
+        .dom(".event-dates")
+        .hasText(
+          "Mon, Oct 6",
+          "`startAt` should not render the current year, and not show any time"
+        );
+
+      testState.event = events.currentYear.endsSameWeek;
+      await settled();
+      assert
+        .dom(".event-dates")
+        .hasText(
+          "Mon, Oct 6 → Fri, Oct 10",
+          "`startAt`, `endAt` should not render the current year, and not show any time"
+        );
+    });
   });
 
   test("formats same week range dates and times", async function (assert) {
     const eventWithinWeekRange = new (class extends this.basicEvent {
-      @tracked endsAt = new Date("2025-10-03T00:00:00Z");
+      @tracked endsAt = "2025-10-03T00:00:00Z";
+      // @tracked endsAt = new Date("2025-10-03T00:00:00Z");
     })();
 
     await render(
@@ -68,7 +96,7 @@ module("Integration | Component | Dates", function (hooks) {
     assert
       .dom(".event-dates")
       .hasText(
-        "Wed, Oct 1, 10:00 AM → Fri, Oct 3, 12:00 AM",
+        "Wed, Oct 1 10:00 AM → Fri, Oct 3",
         "`endAt` should be formatted with localized weekday, date and time"
       );
   });
@@ -85,7 +113,7 @@ module("Integration | Component | Dates", function (hooks) {
     assert
       .dom(".event-dates")
       .hasText(
-        "Wed, Oct 1, 10:00 AM → Sat, Nov 1, 10:00 AM",
+        "Wed, Oct 1 10:00 AM → Sat, Nov 1 10:00 AM",
         "`endAt` should be formatted with localized weekday, date and time"
       );
   });
@@ -102,7 +130,7 @@ module("Integration | Component | Dates", function (hooks) {
     assert
       .dom(".event-dates")
       .hasText(
-        "Wed, Oct 1, 10:00 AM → Thu, Oct 1, 2026 10:00 AM",
+        "Wed, Oct 1 10:00 AM → Thu, Oct 1, 2026 10:00 AM",
         "`endAt` should be formatted with localized weekday, date and time"
       );
   });

--- a/test/javascripts/integration/components/dates-test.gjs
+++ b/test/javascripts/integration/components/dates-test.gjs
@@ -29,6 +29,7 @@ module("Integration | Component | Dates", function (hooks) {
 
   const starts = {
     startsAt: "2025-10-06T00:00:00Z",
+    timezone: "UTC",
   };
   const events = {
     currentYear: {
@@ -39,66 +40,88 @@ module("Integration | Component | Dates", function (hooks) {
       },
       endsSameWeek: {
         ...starts,
-        endsAt: "2025-10-10",
+        endsAt: "2025-10-10T00:00:00Z",
       },
       endsSameMonth: {
         ...starts,
-        endsAt: "2025-10-20",
+        endsAt: "2025-10-20T00:00:00Z",
       },
       endsDiffMonth: {
         ...starts,
-        endsAt: "2025-11-06",
+        endsAt: "2025-11-06T00:00:00Z",
       },
       endsDiffYear: {
         ...starts,
-        endsAt: "2026-01-06",
+        endsAt: "2026-01-06T00:00:00Z",
       },
     },
   };
 
   module("dates without time", function () {
-    test("formats same day range dates and times", async function (assert) {
-      const testState = new (class {
-        // @tracked endsAt = new Date("2025-10-01T11:00:00Z");
-        @tracked event = events.currentYear.starts;
-      })();
-
-      await render(<template><Dates @event={{testState.event}} /></template>);
+    test("formats start date", async function (assert) {
+      await render(
+        <template><Dates @event={{events.currentYear.starts}} /></template>
+      );
 
       assert
         .dom(".event-dates")
         .hasText(
           "Mon, Oct 6",
-          "`startAt` should not render the current year, and not show any time"
+          "`startsAt` should not show current year and time"
         );
+    });
 
-      testState.event = events.currentYear.endsSameWeek;
-      await settled();
+    test("formats same day range", async function (assert) {
+      await render(
+        <template><Dates @event={{events.currentYear.endsSameDay}} /></template>
+      );
+
+      assert
+        .dom(".event-dates")
+        .hasText(
+          "Mon, Oct 6 12:00 AM → 1:00 AM",
+          "`endsAt` should show time only"
+        );
+    });
+
+    test("formats same week range", async function (assert) {
+      await render(
+        <template><Dates @event={{events.currentYear.endsSameWeek}} /></template>
+      );
+
       assert
         .dom(".event-dates")
         .hasText(
           "Mon, Oct 6 → Fri, Oct 10",
-          "`startAt`, `endAt` should not render the current year, and not show any time"
+          "`endAt` should be formatted with weekday, month and date"
         );
     });
-  });
 
-  test("formats same week range dates and times", async function (assert) {
-    const eventWithinWeekRange = new (class extends this.basicEvent {
-      @tracked endsAt = "2025-10-03T00:00:00Z";
-      // @tracked endsAt = new Date("2025-10-03T00:00:00Z");
-    })();
-
-    await render(
-      <template><Dates @event={{eventWithinWeekRange}} /></template>
-    );
-
-    assert
-      .dom(".event-dates")
-      .hasText(
-        "Wed, Oct 1 10:00 AM → Fri, Oct 3",
-        "`endAt` should be formatted with localized weekday, date and time"
+    test("formats same month range", async function (assert) {
+      await render(
+        <template><Dates @event={{events.currentYear.endsSameMonth}} /></template>
       );
+
+      assert
+        .dom(".event-dates")
+        .hasText(
+          "Mon, Oct 6 → Mon, Oct 20",
+          "`endAt` should be formatted with weekday, month and date"
+        );
+    });
+
+    test("formats different months range", async function (assert) {
+      await render(
+        <template><Dates @event={{events.currentYear.endsDiffMonth}} /></template>
+      );
+
+      assert
+        .dom(".event-dates")
+        .hasText(
+          "Mon, Oct 6 → Thu, Nov 6",
+          "`endAt` should be formatted with weekday, month and date"
+        );
+    });
   });
 
   test("formats different month range dates and times", async function (assert) {

--- a/test/javascripts/integration/components/dates-test.gjs
+++ b/test/javascripts/integration/components/dates-test.gjs
@@ -1,0 +1,65 @@
+import { hash } from "@ember/helper";
+import { getOwner } from "@ember/owner";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+// import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import Dates from "../../discourse/components/discourse-post-event/dates";
+
+module("Integration | Component | Dates", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const store = getOwner(this).lookup("service:store");
+
+    this.user = store.createRecord("user", {
+      username: "j.jaffeux",
+      name: "joffrey",
+      id: 321,
+    });
+
+    getOwner(this).unregister("service:current-user");
+    getOwner(this).register("service:current-user", this.user, {
+      instantiate: false,
+    });
+  });
+
+  test("formats dates", async function (assert) {
+    // withPluginApi("1.34.0", (api) => {
+    //   api.registerValueTransformer(
+    //     "discourse-calendar-event-more-menu-should-show-participants",
+    //     () => {
+    //       return true; // by default it should show to canActOnDiscoursePostEvent users
+    //     }
+    //   );
+    // });
+
+    // const store = getOwner(this).lookup("service:store");
+    // const creator = store.createRecord("user", {
+    //   username: "gabriel",
+    //   name: "gabriel",
+    //   id: 322,
+    // });
+
+    const startsAt = new Date("2023-10-01T10:00:00Z");
+    const endsAt = new Date("2023-10-01T11:00:00Z");
+
+    await render(
+      <template>
+        <Dates
+          @event={{hash
+            id="123"
+            recurrence=false
+            showLocalTime=false
+            timezone="Asia/Singapore"
+            isExpired=false
+            endsAt=endsAt
+            startsAt=startsAt
+          }}
+        />
+      </template>
+    );
+
+    assert.dom(".event-dates").hasText("October 1, 2023 10:00 AM → 11:00 AM");
+  });
+});

--- a/test/javascripts/integration/components/dates-test.gjs
+++ b/test/javascripts/integration/components/dates-test.gjs
@@ -181,7 +181,7 @@ module("Integration | Component | Dates", function (hooks) {
       assert
         .dom(".event-dates")
         .hasText(
-          "Today 2:00 PM → 4:00 PM",
+          "Today 2:00 PM → 4:00 PM (UTC)",
           "`endsAt` should show from today time to time only"
         );
     });

--- a/test/javascripts/integration/components/dates-test.gjs
+++ b/test/javascripts/integration/components/dates-test.gjs
@@ -3,6 +3,7 @@ import { getOwner } from "@ember/owner";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import Dates from "../../discourse/components/discourse-post-event/dates";
 
 module("Integration | Component | Dates", function (hooks) {
@@ -24,7 +25,7 @@ module("Integration | Component | Dates", function (hooks) {
 
     this.basicEvent = class {
       @tracked endsAt;
-      @tracked startsAt = new Date("2023-10-01T10:00:00Z");
+      @tracked startsAt = new Date("2025-10-01T10:00:00Z");
 
       id = "123";
       recurrence = false;
@@ -32,11 +33,17 @@ module("Integration | Component | Dates", function (hooks) {
       timezone = "Asia/Singapore";
       isExpired = false;
     };
+
+    // this.clock = fakeTime("2025-10-01T00:00:00Z", this.currentUser.user_option.timezone, false);
+  });
+
+  hooks.afterEach(function () {
+    this.clock?.restore();
   });
 
   test("formats same day range dates and times", async function (assert) {
     const eventWithinDayRange = new (class extends this.basicEvent {
-      @tracked endsAt = new Date("2023-10-01T11:00:00Z");
+      @tracked endsAt = new Date("2025-10-01T11:00:00Z");
     })();
 
     await render(<template><Dates @event={{eventWithinDayRange}} /></template>);
@@ -44,14 +51,14 @@ module("Integration | Component | Dates", function (hooks) {
     assert
       .dom(".event-dates")
       .hasText(
-        "Sun, Oct 1, 2023 10:00 AM → 11:00 AM",
+        "Wed, Oct 1, 10:00 AM → 11:00 AM",
         "`endAt` should be formatted with localized time only"
       );
   });
 
   test("formats same week range dates and times", async function (assert) {
     const eventWithinWeekRange = new (class extends this.basicEvent {
-      @tracked endsAt = new Date("2023-10-03T00:00:00Z");
+      @tracked endsAt = new Date("2025-10-03T00:00:00Z");
     })();
 
     await render(
@@ -61,14 +68,14 @@ module("Integration | Component | Dates", function (hooks) {
     assert
       .dom(".event-dates")
       .hasText(
-        "Sun, Oct 1, 2023 10:00 AM → Tue, Oct 3, 12:00 AM",
+        "Wed, Oct 1, 10:00 AM → Fri, Oct 3, 12:00 AM",
         "`endAt` should be formatted with localized weekday, date and time"
       );
   });
 
   test("formats different month range dates and times", async function (assert) {
     const eventWithinWeekRange = new (class extends this.basicEvent {
-      @tracked endsAt = new Date("2024-11-01T10:00:00Z");
+      @tracked endsAt = new Date("2025-11-01T10:00:00Z");
     })();
 
     await render(
@@ -78,14 +85,14 @@ module("Integration | Component | Dates", function (hooks) {
     assert
       .dom(".event-dates")
       .hasText(
-        "Sun, Oct 1, 2023 10:00 AM → Fri, Nov 1, 2024 10:00 AM",
+        "Wed, Oct 1, 10:00 AM → Sat, Nov 1, 10:00 AM",
         "`endAt` should be formatted with localized weekday, date and time"
       );
   });
 
   test("formats different year range dates and times", async function (assert) {
     const eventWithinWeekRange = new (class extends this.basicEvent {
-      @tracked endsAt = new Date("2024-10-01T10:00:00Z");
+      @tracked endsAt = new Date("2026-10-01T10:00:00Z");
     })();
 
     await render(
@@ -95,7 +102,7 @@ module("Integration | Component | Dates", function (hooks) {
     assert
       .dom(".event-dates")
       .hasText(
-        "Sun, Oct 1, 2023 10:00 AM → Tue, Oct 1, 2024 10:00 AM",
+        "Wed, Oct 1, 10:00 AM → Thu, Oct 1, 2026 10:00 AM",
         "`endAt` should be formatted with localized weekday, date and time"
       );
   });


### PR DESCRIPTION
This PR overhauls the way event dates are rendered by applying context-aware formatting rules:
* Single-day events only show times when appropriate, hiding “12:00 AM” for events without `endDate`.
* Multi-day ranges omit redundant parts (e.g. for the current year) and include weekday/month/day when needed.

### Tests added
* Weekday-only ranges (e.g. “Friday → Monday”)
* Same-week and same-month spans (omitting year)
* Cross-month and cross-year spans (including year where needed)
* `Today/Yesterday/Tomorrow` labels with time ranges
* Same-day events showing only time  ￼

### Impact
* Improves readability of event dates across the app
* Reduces visual noise by hiding redundant date/time fragments
* Ensures consistency with user expectations around relative dates

### Things to clarify

* Relative labels (`Yesterday, Today, Tomorrow`) replace literal dates for nearby days.
* Timezones are only shown when `showLocalTime` is toggled.

### Discussion

https://meta.discourse.org/t/new-calendar-feature-show-local-time/368608/