### PR TITLE
DEV: adjust tests to use d-menu toolbar options menu

### DIFF
--- a/spec/system/post_event_spec.rb
+++ b/spec/system/post_event_spec.rb
@@ -139,9 +139,8 @@ describe "Post event", type: :system do
   it "persists changes" do
     visit "/new-topic"
     composer.fill_title("Test event with updates")
-    dropdown = PageObjects::Components::SelectKit.new(".toolbar-popup-menu-options")
-    dropdown.expand
-    dropdown.select_row_by_name(I18n.t("js.discourse_post_event.builder_modal.attach"))
+    find(".toolbar-menu__options-trigger").click
+    find("button[title='#{I18n.t("js.discourse_post_event.builder_modal.attach")}']").click
     find(".d-modal input[name=status][value=private]").click
     find(".d-modal input.group-selector").send_keys("test_")
     find(".autocomplete.ac-group").click

--- a/test/javascripts/acceptance/post-event-builder-test.js
+++ b/test/javascripts/acceptance/post-event-builder-test.js
@@ -21,11 +21,9 @@ acceptance("Post event - composer", function (needs) {
     const categoryChooser = selectKit(".category-chooser");
     await categoryChooser.expand();
     await categoryChooser.selectRowByValue(2);
-    await click(".toolbar-popup-menu-options .dropdown-select-box-header");
+    await click(".toolbar-menu__options-trigger");
     await click(
-      `.toolbar-popup-menu-options *[data-name='${i18n(
-        "discourse_post_event.builder_modal.attach"
-      )}']`
+      `button[title='${i18n("discourse_post_event.builder_modal.attach")}']`
     );
 
     const modal = ".post-event-builder-modal";
@@ -91,11 +89,9 @@ acceptance("Post event - composer", function (needs) {
       await categoryChooser.expand();
       await categoryChooser.selectRowByValue(2);
 
-      await click(".toolbar-popup-menu-options .dropdown-select-box-header");
+      await click(".toolbar-menu__options-trigger");
       await click(
-        `.toolbar-popup-menu-options *[data-name='${i18n(
-          "discourse_post_event.builder_modal.attach"
-        )}']`
+        `button[title='${i18n("discourse_post_event.builder_modal.attach")}']`
       );
 
       const modal = ".post-event-builder-modal";


### PR DESCRIPTION
Following changes made on  https://github.com/discourse/discourse/pull/33247