### PR TITLE
FIX: uses Unicode escape sequence for a standard double quote

### DIFF
--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -39,7 +39,7 @@ export default class DiscoursePostEventDates extends Component {
     const timeString =
       this.hasTime(this.startsAt) || this.isSingleDayEvent ? " LT" : "";
 
-    return `\u0027${dateString}${timeString}\u0027`;
+    return `\u0022${dateString}${timeString}\u0022`;
   }
 
   get endsAtFormat() {

--- a/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -39,7 +39,7 @@ export default class DiscoursePostEventDates extends Component {
     const timeString =
       this.hasTime(this.startsAt) || this.isSingleDayEvent ? " LT" : "";
 
-    return `'${dateString}${timeString}'`;
+    return `\u0027${dateString}${timeString}\u0027`;
   }
 
   get endsAtFormat() {


### PR DESCRIPTION
This will produce a string wrapped in standard ASCII double quotes (") and prevent the browser from substituting them with language-specific typographic quotes, such as the German „ (low-9) and “ (left double).