### PR TITLE
FIX: correctly display single digit event in safari

### DIFF
--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -16,7 +16,7 @@ const DEFAULT_UPCOMING_DAYS = 180;
 const DEFAULT_COUNT = 8;
 
 function addToResult(date, item, result) {
-  const day = date.date();
+  const day = date.format("DD");
   const monthKey = date.format("YYYY-MM");
 
   result[monthKey] = result[monthKey] ?? {};


### PR DESCRIPTION
We were building the list of events by using the non padded day as key, eg:

```
{ 3: { ... }, 16: { ... } }
```

Which we would then use to construct a date and would end up doing something like:

```
moment("2025-07-3").format()
```

It was working in most browsers, but safari was not accepting it and would display an `invalid date` error.

The fix is using a padded day as key that will ensure consistent behavior:

```
{ "03": { ... }, "16": { ... } }
```

No test as it's browser specific behavior.