### PR TITLE
UX: displays event local time in calendar

### DIFF
--- a/app/serializers/discourse_post_event/event_summary_serializer.rb
+++ b/app/serializers/discourse_post_event/event_summary_serializer.rb
@@ -5,6 +5,7 @@ module DiscoursePostEvent
     attributes :id
     attributes :starts_at
     attributes :ends_at
+    attributes :show_local_time
     attributes :timezone
     attributes :post
     attributes :name

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
@@ -51,6 +51,7 @@ export default class UpcomingEventsCalendar extends Component {
 
     const fullCalendar = new window.FullCalendar.Calendar(calendarNode, {
       ...fullCalendarDefaultOptions(),
+      timeZone: this.currentUser?.user_option?.timezone || "local",
       firstDay: 1,
       height: "auto",
       defaultView: view,

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
@@ -151,7 +151,7 @@ export default class UpcomingEventsCalendar extends Component {
       }
 
       this._calendar.addEvent({
-        title: formatEventName(event, this.currentUser?.timezone),
+        title: formatEventName(event, this.currentUser?.user_option?.timezone),
         start: startsAt,
         end: endsAt || startsAt,
         allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),

--- a/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
@@ -151,7 +151,7 @@ export default class UpcomingEventsCalendar extends Component {
       }
 
       this._calendar.addEvent({
-        title: formatEventName(event),
+        title: formatEventName(event, this.currentUser?.timezone),
         start: startsAt,
         end: endsAt || startsAt,
         allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),

--- a/assets/javascripts/discourse/helpers/format-event-name.js
+++ b/assets/javascripts/discourse/helpers/format-event-name.js
@@ -1,9 +1,23 @@
 import { i18n } from "discourse-i18n";
 
-export function formatEventName(event) {
+function sameTimezoneOffset(timezone1, timezone2) {
+  if (!timezone1 || !timezone2) {
+    return false;
+  }
+
+  const offset1 = moment.tz(timezone1).utcOffset();
+  const offset2 = moment.tz(timezone2).utcOffset();
+  return offset1 === offset2;
+}
+
+export function formatEventName(event, userTimezone) {
   let output = event.name || event.post.topic.title;
 
-  if (event.showLocalTime && event.timezone) {
+  if (
+    event.showLocalTime &&
+    event.timezone &&
+    !sameTimezoneOffset(event.timezone, userTimezone)
+  ) {
     output +=
       ` (${i18n("discourse_calendar.local_time")}: ` +
       moment(event.startsAt).tz(event.timezone).format("H:mma") +

--- a/assets/javascripts/discourse/helpers/format-event-name.js
+++ b/assets/javascripts/discourse/helpers/format-event-name.js
@@ -1,3 +1,14 @@
+import { i18n } from "discourse-i18n";
+
 export function formatEventName(event) {
-  return event.name || event.post.topic.title;
+  let output = event.name || event.post.topic.title;
+
+  if (event.showLocalTime && event.timezone) {
+    output +=
+      ` (${i18n("discourse_calendar.local_time")}: ` +
+      moment(event.startsAt).tz(event.timezone).format("H:mma") +
+      ")";
+  }
+
+  return output;
 }

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -27,8 +27,8 @@ function loadFullCalendar() {
 
 function initializeDiscourseCalendar(api) {
   const siteSettings = api.container.lookup("service:site-settings");
-  const currentUser = api.getCurrentUser();
-  if (siteSettings.login_required && !currentUser) {
+
+  if (siteSettings.login_required && !api.getCurrentUser()) {
     return;
   }
 
@@ -206,7 +206,7 @@ function initializeDiscourseCalendar(api) {
           }
 
           fullCalendar.addEvent({
-            title: formatEventName(event, currentUser.timezone),
+            title: formatEventName(event, api.getCurrentUser()?.timezone),
             start: startsAt,
             end: endsAt || startsAt,
             allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -27,8 +27,8 @@ function loadFullCalendar() {
 
 function initializeDiscourseCalendar(api) {
   const siteSettings = api.container.lookup("service:site-settings");
-
-  if (siteSettings.login_required && !api.getCurrentUser()) {
+  const currentUser = api.getCurrentUser();
+  if (siteSettings.login_required && !currentUser) {
     return;
   }
 
@@ -206,7 +206,7 @@ function initializeDiscourseCalendar(api) {
           }
 
           fullCalendar.addEvent({
-            title: formatEventName(event),
+            title: formatEventName(event, currentUser.timezone),
             start: startsAt,
             end: endsAt || startsAt,
             allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),

--- a/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -206,7 +206,10 @@ function initializeDiscourseCalendar(api) {
           }
 
           fullCalendar.addEvent({
-            title: formatEventName(event, api.getCurrentUser()?.timezone),
+            title: formatEventName(
+              event,
+              api.getCurrentUser()?.user_option?.timezone
+            ),
             start: startsAt,
             end: endsAt || startsAt,
             allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -33,6 +33,7 @@ en:
       date: "Date"
       add_to_calendar: "Add to Google Calendar"
       toggle_timezone_offset_title: "Toggle timezone offset"
+      local_time: "Local time"
       region:
         title: "Region"
         none: "None"

--- a/spec/system/page_objects/discourse_calendar/upcoming_events.rb
+++ b/spec/system/page_objects/discourse_calendar/upcoming_events.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    module DiscourseCalendar
+      class UpcomingEvents < PageObjects::Pages::Base
+        def visit
+          super("/upcoming-events")
+        end
+
+        def open_year_list
+          find(".fc-listNextYear-button").click
+        end
+      end
+    end
+  end
+end

--- a/spec/system/upcoming_events_spec.rb
+++ b/spec/system/upcoming_events_spec.rb
@@ -40,13 +40,6 @@ describe "Upcoming Events", type: :system do
 
       PostCreator.create!(
         admin,
-        title: "Event with local time and same timezone than user",
-        raw:
-          "[event showLocalTime=true timezone=\"America/New_York\" start=\"2025-09-12 08:05\"]\n[/event]",
-      )
-
-      PostCreator.create!(
-        admin,
         title: "Event with local time",
         raw: "[event showLocalTime=true timezone=CET start=\"2025-09-11 08:05\"]\n[/event]",
       )
@@ -56,6 +49,13 @@ describe "Upcoming Events", type: :system do
         title: "Event without local time",
         raw: "[event timezone=CET start=\"2025-09-11 19:00\"]\n[/event]",
       )
+
+      PostCreator.create!(
+        admin,
+        title: "Event with local time and same timezone than user",
+        raw:
+          "[event showLocalTime=true timezone=\"America/New_York\" start=\"2025-09-12 08:05\"]\n[/event]",
+      )
     end
 
     it "shows the local time in the title", timezone: "Australia/Brisbane" do
@@ -64,17 +64,17 @@ describe "Upcoming Events", type: :system do
       upcoming_events.open_year_list
 
       first_item = find(".fc-list-item:nth-child(2)")
-      expect(first_item.find(".fc-list-item-time")).to have_text("4:05pm")
+      expect(first_item.find(".fc-list-item-time")).to have_text("2:05am")
       expect(first_item.find(".fc-list-item-title")).to have_text(
         "Event with local time (Local time: 8:05am)",
       )
 
-      second_item = find(".fc-list-item:nth-child(4)")
-      expect(second_item.find(".fc-list-item-time")).to have_text("3:00am")
+      second_item = find(".fc-list-item:nth-child(3)")
+      expect(second_item.find(".fc-list-item-time")).to have_text("1:00pm")
       expect(second_item.find(".fc-list-item-title")).to have_text("Event without local time")
 
       third_item = find(".fc-list-item:nth-child(5)")
-      expect(third_item.find(".fc-list-item-time")).to have_text("10:05pm")
+      expect(third_item.find(".fc-list-item-time")).to have_text("8:05am")
       expect(third_item.find(".fc-list-item-title")).to have_text(
         "Event with local time and same timezone than user",
       )

--- a/spec/system/upcoming_events_spec.rb
+++ b/spec/system/upcoming_events_spec.rb
@@ -36,6 +36,15 @@ describe "Upcoming Events", type: :system do
     before do
       freeze_time(fixed_time)
 
+      admin.user_option.update!(timezone: "America/New_York")
+
+      PostCreator.create!(
+        admin,
+        title: "Event with local time and same timezone than user",
+        raw:
+          "[event showLocalTime=true timezone=\"America/New_York\" start=\"2025-09-12 08:05\"]\n[/event]",
+      )
+
       PostCreator.create!(
         admin,
         title: "Event with local time",
@@ -59,9 +68,16 @@ describe "Upcoming Events", type: :system do
       expect(first_item.find(".fc-list-item-title")).to have_text(
         "Event with local time (Local time: 8:05am)",
       )
+
       second_item = find(".fc-list-item:nth-child(4)")
       expect(second_item.find(".fc-list-item-time")).to have_text("3:00am")
       expect(second_item.find(".fc-list-item-title")).to have_text("Event without local time")
+
+      third_item = find(".fc-list-item:nth-child(5)")
+      expect(third_item.find(".fc-list-item-time")).to have_text("10:05pm")
+      expect(third_item.find(".fc-list-item-title")).to have_text(
+        "Event with local time and same timezone than user",
+      )
     end
   end
 

--- a/spec/system/upcoming_events_spec.rb
+++ b/spec/system/upcoming_events_spec.rb
@@ -4,9 +4,10 @@ describe "Upcoming Events", type: :system do
   fab!(:admin)
   fab!(:user)
   fab!(:category)
-  fab!(:event)
+
   let(:composer) { PageObjects::Components::Composer.new }
   let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:upcoming_events) { PageObjects::Pages::DiscourseCalendar::UpcomingEvents.new }
 
   before do
     SiteSetting.calendar_enabled = true
@@ -15,10 +16,12 @@ describe "Upcoming Events", type: :system do
   end
 
   context "when user is signed in" do
+    fab!(:event)
+
     before { sign_in(admin) }
 
     it "shows the upcoming events" do
-      visit("/upcoming-events")
+      upcoming_events.visit
 
       expect(page).to have_css(
         "#upcoming-events-calendar .fc-event-container",
@@ -27,7 +30,44 @@ describe "Upcoming Events", type: :system do
     end
   end
 
+  context "when display events with showLocalTime" do
+    let(:fixed_time) { Time.utc(2025, 6, 2, 19, 00) }
+
+    before do
+      freeze_time(fixed_time)
+
+      PostCreator.create!(
+        admin,
+        title: "Event with local time",
+        raw: "[event showLocalTime=true timezone=CET start=\"2025-09-11 08:05\"]\n[/event]",
+      )
+
+      PostCreator.create!(
+        admin,
+        title: "Event without local time",
+        raw: "[event timezone=CET start=\"2025-09-11 19:00\"]\n[/event]",
+      )
+    end
+
+    it "shows the local time in the title", timezone: "Australia/Brisbane" do
+      page.driver.with_playwright_page { |pw_page| pw_page.clock.set_fixed_time(fixed_time) }
+      upcoming_events.visit
+      upcoming_events.open_year_list
+
+      first_item = find(".fc-list-item:nth-child(2)")
+      expect(first_item.find(".fc-list-item-time")).to have_text("4:05pm")
+      expect(first_item.find(".fc-list-item-title")).to have_text(
+        "Event with local time (Local time: 8:05am)",
+      )
+      second_item = find(".fc-list-item:nth-child(4)")
+      expect(second_item.find(".fc-list-item-time")).to have_text("3:00am")
+      expect(second_item.find(".fc-list-item-title")).to have_text("Event without local time")
+    end
+  end
+
   context "when event is recurring" do
+    fab!(:event)
+
     let(:fixed_time) { Time.utc(2025, 6, 2, 19, 00) }
 
     before do
@@ -43,7 +83,7 @@ describe "Upcoming Events", type: :system do
 
     it "respects the until date" do
       page.driver.with_playwright_page { |pw_page| pw_page.clock.set_fixed_time(fixed_time) }
-      visit("/upcoming-events")
+      upcoming_events.visit
 
       expect(page).to have_css(".fc-day-grid-event", count: 3)
       expect(page).to have_css(


### PR DESCRIPTION
When an event is set with `show_local_time=true` we will display the local time of the event in the calendar.

Eg: My Event (Local time: 8:10am)

![Screenshot 2025-07-02 at 11 47 30](https://github.com/user-attachments/assets/0d1ebfc4-d9e0-4d25-bb32-38bd352e7987)

![Screenshot 2025-07-02 at 11 47 40](https://github.com/user-attachments/assets/3359fe97-06f7-497c-9897-924ed7af4654)

Note that if a user is in the same timezone than the event, we won't show the local time text.