### PR TITLE
FIX: use correct property for sidebar icon

### DIFF
--- a/assets/javascripts/discourse/initializers/add-upcoming-events-to-sidebar.js
+++ b/assets/javascripts/discourse/initializers/add-upcoming-events-to-sidebar.js
@@ -17,7 +17,7 @@ export default {
             route = "discourse-post-event-upcoming-events";
             text = i18n("discourse_post_event.upcoming_events.title");
             title = i18n("discourse_post_event.upcoming_events.title");
-            icon = "calendar-days";
+            defaultPrefixValue = "calendar-day";
           };
         });
       });


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/c0298ee8-326e-4aad-964d-df420dcc12a9)



After:

![image](https://github.com/user-attachments/assets/8605cad6-abc7-4e2c-821a-6834c44f47ae)