### PR TITLE
FIX: broken test due to user timezone 

### DIFF
--- a/test/javascripts/acceptance/upcoming-events-calendar-test.js
+++ b/test/javascripts/acceptance/upcoming-events-calendar-test.js
@@ -100,14 +100,16 @@ acceptance("Discourse Calendar - Upcoming Events Calendar", function (needs) {
   test("upcoming events category colors", async (assert) => {
     await visit("/upcoming-events");
 
+    await pauseTest();
+
     assert.strictEqual(
-      query(".fc-row tr:first-child .fc-event").style.backgroundColor,
+      queryAll(".fc-event")[0].style.backgroundColor,
       "rgb(190, 10, 10)",
       "Event item uses the proper color from category 1"
     );
 
     assert.strictEqual(
-      query(".fc-row tr:nth-child(2) .fc-event").style.backgroundColor,
+      queryAll(".fc-event")[1].style.backgroundColor,
       "rgb(15, 120, 190)",
       "Event item uses the proper color from category 2"
     );

--- a/test/javascripts/acceptance/upcoming-events-calendar-test.js
+++ b/test/javascripts/acceptance/upcoming-events-calendar-test.js
@@ -4,7 +4,6 @@ import { tomorrow, twoDays } from "discourse/lib/time-utils";
 import {
   acceptance,
   exists,
-  query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 

--- a/test/javascripts/acceptance/upcoming-events-calendar-test.js
+++ b/test/javascripts/acceptance/upcoming-events-calendar-test.js
@@ -100,8 +100,6 @@ acceptance("Discourse Calendar - Upcoming Events Calendar", function (needs) {
   test("upcoming events category colors", async (assert) => {
     await visit("/upcoming-events");
 
-    await pauseTest();
-
     assert.strictEqual(
       queryAll(".fc-event")[0].style.backgroundColor,
       "rgb(190, 10, 10)",


### PR DESCRIPTION
The commit https://github.com/discourse/discourse-calendar/commit/d878317c5f875fc7e67c0acbae62b7a6fb0849a7 set the calendar timezone to the user’s timezone when available and as result broke this test.