### PR TITLE
UX: ensure that the calendar displays the month

### DIFF
--- a/assets/stylesheets/common/upcoming-events-calendar.scss
+++ b/assets/stylesheets/common/upcoming-events-calendar.scss
@@ -39,10 +39,6 @@
       padding: 3px 3px 3px 0.5em;
     }
 
-    .fc-center {
-      display: none;
-    }
-
     .fc-button {
       border-radius: 0;
       box-shadow: none;


### PR DESCRIPTION
Before:

<img width="1102" height="427" alt="SCR-20250711-lwyq" src="https://github.com/user-attachments/assets/9e1412a2-98aa-4be5-9f29-a779da06c2fc" />

After:

<img width="1112" height="437" alt="Screenshot 2025-07-11 at 12 20 41" src="https://github.com/user-attachments/assets/cbd4908b-ff6b-4cf1-bb25-0844935f8b91" />
